### PR TITLE
Enhance ElmInlineText component with styling options

### DIFF
--- a/src/components/inline/ElmInlineText.vue
+++ b/src/components/inline/ElmInlineText.vue
@@ -1,7 +1,22 @@
 <template>
-  <span class="text" :style="{ '--color': color, '--font-size': size }">{{
-    text
-  }}</span>
+  <span
+    class="text"
+    :style="{
+      '--color': color,
+      '--font-size': size,
+      '--font-weight': bold ? 'bold' : undefined,
+      '--font-style': italic ? 'italic' : undefined,
+      '--text-decoration':
+        underline && strikethrough
+          ? 'underline line-through'
+          : underline
+            ? 'underline'
+            : strikethrough
+              ? 'line-through'
+              : undefined
+    }"
+    >{{ text }}</span
+  >
 </template>
 
 <script setup lang="ts">
@@ -25,8 +40,33 @@ withDefaults(
      * Specifies the font size of the text.
      */
     size?: Property.FontSize
+
+    /**
+     * Specifies whether the text should be bold.
+     */
+    bold?: boolean
+
+    /**
+     * Specifies whether the text should be italic.
+     */
+    italic?: boolean
+
+    /**
+     * Specifies whether the text should be underlined.
+     */
+    underline?: boolean
+
+    /**
+     * Specifies whether the text should be strikethrough.
+     */
+    strikethrough?: boolean
   }>(),
-  {}
+  {
+    bold: false,
+    italic: false,
+    underline: false,
+    strikethrough: false
+  }
 )
 </script>
 
@@ -34,6 +74,9 @@ withDefaults(
 .text {
   color: var(--color, rgba(0, 0, 0, 0.7));
   font-size: var(--font-size);
+  font-weight: var(--font-weight);
+  font-style: var(--font-style);
+  text-decoration: var(--text-decoration);
 
   &::selection {
     color: rgba(255, 255, 255, 0.7);


### PR DESCRIPTION
Introduce additional styling options for the ElmInlineText component, allowing text to be bold, italic, underlined, or strikethrough. Default values for these options are set to false.