### PR TITLE
Update package dependencies to use devDependencies for @elmethis/core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,8 +6,7 @@
   "packages": {
     "": {
       "workspaces": [
-        "./packages/core",
-        "./packages/notion-node"
+        "packages/*"
       ],
       "dependencies": {
         "@notionhq/client": "^2.2.15",
@@ -8953,7 +8952,7 @@
       "name": "@elmethis/notion-node",
       "version": "1.0.0-alpha.3",
       "license": "MIT",
-      "dependencies": {
+      "devDependencies": {
         "@elmethis/core": "^1.0.0-alpha.5"
       }
     }

--- a/packages/notion-node/package.json
+++ b/packages/notion-node/package.json
@@ -25,7 +25,7 @@
       "types": "./dist/index.d.ts"
     }
   },
-  "dependencies": {
+  "devDependencies": {
     "@elmethis/core": "^1.0.0-alpha.5"
   }
 }


### PR DESCRIPTION
Refactor the package configuration to move @elmethis/core from dependencies to devDependencies in both package-lock.json and notion-node package.json.