### PR TITLE
Update workflow to link @elmethis/core package in build process

### DIFF
--- a/.github/workflows/notion-node-build.yml
+++ b/.github/workflows/notion-node-build.yml
@@ -34,9 +34,10 @@ jobs:
       - name: Install dependencies
         run: pnpm install 
 
-      - name: Link local packages
-        run: pnpm link --global
-        
+      - name: Link @elmethis/core
+        run: pnpm link ../core
+        working-directory: packages/notion-node
+
       - name: Run Build Test
         run: pnpm run build
         working-directory: packages/notion-node


### PR DESCRIPTION
Modify the workflow to link the @elmethis/core package during the build process, ensuring proper dependency management.