### PR TITLE
Update package exports and dependency specifications

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,14 +14,11 @@
   "files": [
     "dist"
   ],
-  "module": "dist/elmethis.js",
-  "main": "dist/elmethis.umd.cjs",
-  "types": "dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/elmethis.js",
-      "require": "./dist/elmethis.umd.cjs",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/elmethis.umd.cjs"
     }
   },
   "scripts": {

--- a/packages/notion-node/package.json
+++ b/packages/notion-node/package.json
@@ -30,7 +30,7 @@
     "open-graph-scraper": "^6.8.2"
   },
   "devDependencies": {
-    "@elmethis/core": "^",
+    "@elmethis/core": "workspace:*",
     "dotenv": "^16.4.5",
     "tsx": "^4.19.2",
     "vitest": "^2.1.4"

--- a/packages/notion-node/tests/lib.test.ts
+++ b/packages/notion-node/tests/lib.test.ts
@@ -1,6 +1,0 @@
-import { divide } from '../src/lib.js'
-import { expect, test } from 'vitest'
-
-test('divide', () => {
-  expect(divide(4, 2)).toBe(2)
-})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,8 +121,8 @@ importers:
         version: 6.8.2
     devDependencies:
       '@elmethis/core':
-        specifier: ^
-        version: 1.0.0-alpha.5
+        specifier: workspace:*
+        version: link:../core
       dotenv:
         specifier: ^16.4.5
         version: 16.4.5
@@ -504,9 +504,6 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       postcss: ^8.4
-
-  '@elmethis/core@1.0.0-alpha.5':
-    resolution: {integrity: sha512-t9WFGb2mopgQtMylLFfYewPi5KtgROK/8KUqGNqNGuR/yLITH+l57RnLmVf0dzYo3E/qnv5AqcUqPpcicg7liw==}
 
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
@@ -3346,8 +3343,6 @@ snapshots:
   '@csstools/utilities@2.0.0(postcss@8.4.47)':
     dependencies:
       postcss: 8.4.47
-
-  '@elmethis/core@1.0.0-alpha.5': {}
 
   '@esbuild/aix-ppc64@0.21.5':
     optional: true


### PR DESCRIPTION
Streamline module and type definitions in `package.json` and update the `@elmethis/core` dependency to use the workspace protocol. Remove an obsolete test file for the divide function.