### PR TITLE
Reduce underline height in ElmHeading components and bump version

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elmethis/core",
-  "version": "1.0.0-alpha.7",
+  "version": "1.0.0-alpha.8",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/components/headings/ElmHeading1.vue
+++ b/packages/core/src/components/headings/ElmHeading1.vue
@@ -74,7 +74,7 @@ useIntersectionObserver(target, ([{ isIntersecting }], _) => {
     bottom: -2px;
     left: 0;
     width: 100%;
-    height: 1px;
+    height: 0.25px;
     background-color: rgba(0, 0, 0, 0.5);
 
     transition: transform 800ms;

--- a/packages/core/src/components/headings/ElmHeading2.vue
+++ b/packages/core/src/components/headings/ElmHeading2.vue
@@ -106,12 +106,13 @@ useIntersectionObserver(target, ([{ isIntersecting }], _) => {
 }
 
 .underline {
+  overflow: hidden;
   position: absolute;
   content: '';
   bottom: -6px;
   left: 0;
   width: 100%;
-  height: 1px;
+  height: 0.25px;
   background-color: rgba(0, 0, 0, 0.5);
 
   transition: transform 800ms;


### PR DESCRIPTION
Adjust the underline height in the ElmHeading1 and ElmHeading2 components for improved aesthetics and update the package version to 1.0.0-alpha.8.