### PR TITLE
Add Multiple story for ElmTag component and update version to 1.0.0-alpha.26

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elmethis/core",
-  "version": "1.0.0-alpha.25",
+  "version": "1.0.0-alpha.26",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/components/badge/ElmTag.stories.tsx
+++ b/packages/core/src/components/badge/ElmTag.stories.tsx
@@ -18,3 +18,19 @@ export const Primary: Story = {
     color: lighten(0.3, '#6987b8')
   }
 }
+
+export const Multiple: Story = {
+  render: () => ({
+    components: { ElmTag },
+    template: `
+      <div style="display: flex; gap: 0.25rem;">
+        <ElmTag text="Primary Tag" color="${lighten(0.2, '#6987b8')}" />
+        <ElmTag text="Secondary Tag" color="${lighten(0.2, '#bf7e71')}" />
+        <ElmTag text="Success Tag" color="${lighten(0.2, '#59b57c')}" />
+        <ElmTag text="Danger Tag" color="${lighten(0.2, '#b36472')}" />
+        <ElmTag text="Warning Tag" color="${lighten(0.2, '#b8a36e')}" />
+        <ElmTag text="Info Tag" color="${lighten(0.2, '#9771bd')}" />
+      </div>
+    `
+  })
+}

--- a/packages/core/src/components/badge/ElmTag.vue
+++ b/packages/core/src/components/badge/ElmTag.vue
@@ -1,15 +1,12 @@
 <template>
   <div class="container" :style="{ backgroundColor: color }">
     <div class="icon" v-html="icon"></div>
-    <div>
-      <ElmInlineText :text="text" />
-    </div>
+    <div class="text">{{ text }}</div>
   </div>
 </template>
 
 <script setup lang="ts">
 import { icons } from 'feather-icons'
-import ElmInlineText from '../inline/ElmInlineText.vue'
 
 export interface ElmTagProps {
   /**
@@ -44,6 +41,11 @@ const icon = icons['tag'].toSvg({
   border-radius: 0.25rem;
   gap: 0.25rem;
   padding: 0.125rem 0.25rem;
+
+  color: rgba(black, 0.7);
+  [data-theme='dark'] & {
+    color: rgba(white, 0.7);
+  }
 }
 
 .icon {
@@ -51,9 +53,9 @@ const icon = icons['tag'].toSvg({
   line-height: 1;
   margin: 0;
   padding: 0;
-  color: rgba(black, 0.7);
-  [data-theme='dark'] & {
-    color: rgba(white, 0.7);
-  }
+}
+
+.text {
+  white-space: nowrap;
 }
 </style>


### PR DESCRIPTION
Introduce a new Multiple story for the ElmTag component to showcase various tag styles and update the package version to 1.0.0-alpha.26.