### PR TITLE
Add ElmBlockFallback component and update Storybook titles

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elmethis/core",
-  "version": "1.0.0-alpha.26",
+  "version": "1.0.0-alpha.27",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/components/badge/ElmTag.stories.tsx
+++ b/packages/core/src/components/badge/ElmTag.stories.tsx
@@ -3,7 +3,7 @@ import ElmTag from './ElmTag.vue'
 import { lighten } from 'polished'
 
 const meta: Meta<typeof ElmTag> = {
-  title: 'Components/badge/ElmTag',
+  title: 'Components/Badge/ElmTag',
   component: ElmTag,
   tags: ['autodocs'],
   args: {}

--- a/packages/core/src/components/fallback/ElmBlockFallback.stories.tsx
+++ b/packages/core/src/components/fallback/ElmBlockFallback.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from '@storybook/vue3'
+import ElmBlockFallback from './ElmBlockFallback.vue'
+
+const meta: Meta<typeof ElmBlockFallback> = {
+  title: 'Components/Fallback/ElmBlockFallback',
+  component: ElmBlockFallback,
+  tags: ['autodocs'],
+  args: {}
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Primary: Story = {}

--- a/packages/core/src/components/fallback/ElmBlockFallback.vue
+++ b/packages/core/src/components/fallback/ElmBlockFallback.vue
@@ -1,0 +1,23 @@
+<template>
+  <div class="elmethis-block-fallback">
+    <ElmDotLoadingIcon />
+  </div>
+</template>
+
+<script setup lang="ts">
+import ElmDotLoadingIcon from '../icon/ElmDotLoadingIcon.vue'
+
+export interface ElmBlockFallbackProps {}
+
+withDefaults(defineProps<ElmBlockFallbackProps>(), {})
+</script>
+
+<style scoped lang="scss">
+.elmethis-block-fallback {
+  width: 100%;
+  height: 8rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+</style>

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -40,6 +40,9 @@ import ElmProgress, {
 import ElmRectangleWave, {
   ElmRectangleWaveProps
 } from './components/fallback/ElmRectangleWave.vue'
+import ElmBlockFallback, {
+  ElmBlockFallbackProps
+} from './components/fallback/ElmBlockFallback.vue'
 
 // Headings
 import ElmHeading1, {
@@ -183,6 +186,7 @@ export {
   ElmTooltip,
   ElmProgress,
   ElmRectangleWave,
+  ElmBlockFallback,
   ElmHeading1,
   ElmHeading2,
   ElmHeading3,
@@ -236,6 +240,7 @@ export type {
   ElmTooltipProps,
   ElmProgressProps,
   ElmRectangleWaveProps,
+  ElmBlockFallbackProps,
   ElmHeading1Props,
   ElmHeading2Props,
   ElmHeading3Props,


### PR DESCRIPTION
Introduce the ElmBlockFallback component with a loading icon and integrate it into Storybook. Update the title casing for the ElmTag component in Storybook and bump the package version to 1.0.0-alpha.27.