### PR TITLE
Add margin support to multiple components and update version

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elmethis/core",
-  "version": "1.0.0-alpha.40",
+  "version": "1.0.0-alpha.41",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/components/code/ElmCodeBlock.vue
+++ b/packages/core/src/components/code/ElmCodeBlock.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="$style.wrapper">
+  <div :class="$style.wrapper" :style="{ '--margin-block': margin }">
     <div :class="$style.header">
       <div :class="$style.header__left">
         <ElmLanguageIcon :language="language" :size="20" />
@@ -43,6 +43,7 @@ import ElmInlineText from '../inline/ElmInlineText.vue'
 import ElmPrismHighlighter from './ElmPrismHighlighter.vue'
 import { useClipboard } from '@vueuse/core'
 import ElmTooltip from '../containments/ElmTooltip.vue'
+import type { Property } from 'csstype'
 
 export interface ElmCodeBlockProps {
   /**
@@ -60,6 +61,11 @@ export interface ElmCodeBlockProps {
    * If not provided, the language will be used.
    */
   caption?: string
+
+  /**
+   * The margin of the code block.
+   */
+  margin: Property.MarginBlock
 }
 
 const props = withDefaults(defineProps<ElmCodeBlockProps>(), {
@@ -71,6 +77,7 @@ const { copy, copied } = useClipboard({ source: props.code })
 
 <style module lang="scss">
 .wrapper {
+  margin-block: var(--margin-block);
   display: flex;
   flex-direction: column;
   border-radius: 0.25rem;

--- a/packages/core/src/components/code/ElmCodeBlock.vue
+++ b/packages/core/src/components/code/ElmCodeBlock.vue
@@ -65,7 +65,7 @@ export interface ElmCodeBlockProps {
   /**
    * The margin of the code block.
    */
-  margin: Property.MarginBlock
+  margin?: Property.MarginBlock
 }
 
 const props = withDefaults(defineProps<ElmCodeBlockProps>(), {

--- a/packages/core/src/components/containments/ElmToggle.stories.tsx
+++ b/packages/core/src/components/containments/ElmToggle.stories.tsx
@@ -14,18 +14,20 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Primary: Story = {
-  render: () => ({
+  render: (args) => ({
+    setup: () => ({ args }),
     components: { ElmToggle, ElmInlineText },
     template:
-      '<ElmToggle summary="Toggle Blocks"><p><ElmInlineText text="Block Content" /></p></ElmToggle>',
+      '<ElmToggle summary="Toggle Blocks" v-bind="args"><p><ElmInlineText text="Block Content" /></p></ElmToggle>',
     data: () => ({ value: false })
   })
 }
 
 export const InlineSummary: Story = {
-  render: () => ({
+  render: (args) => ({
+    setup: () => ({ args }),
     components: { ElmToggle, ElmInlineText, ElmInlineCode },
-    template: `<ElmToggle>
+    template: `<ElmToggle v-bind="args">
       <template #summary>
         <ElmInlineText text="How to use " />
         <ElmInlineCode code="console.table()" />

--- a/packages/core/src/components/containments/ElmToggle.vue
+++ b/packages/core/src/components/containments/ElmToggle.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="$style.toggle">
+  <div :class="$style.toggle" :style="{ '--margin-block': margin }">
     <div :class="$style.summary" @click="handleClick">
       <div :style="{ display: 'flex', gap: '0.5rem' }">
         <ChevronRightIcon
@@ -31,12 +31,18 @@
 <script setup lang="ts">
 import ElmInlineText from '../inline/ElmInlineText.vue'
 import { ChevronRightIcon, PlusIcon } from '@heroicons/vue/24/outline'
+import type { Property } from 'csstype'
 
 export interface ElmToggleProps {
   /**
    * The summary of the toggle.
    */
   summary: string
+
+  /**
+   * The margin of the toggle.
+   */
+  margin: Property.MarginBlock
 }
 
 withDefaults(defineProps<ElmToggleProps>(), {})
@@ -53,6 +59,7 @@ const handleClick = (event: Event): void => {
 
 <style module lang="scss">
 .toggle {
+  margin-block: var(--margin-block);
   box-shadow: 0 0 0.25rem rgba(black, 0.05);
 }
 .summary {

--- a/packages/core/src/components/containments/ElmToggle.vue
+++ b/packages/core/src/components/containments/ElmToggle.vue
@@ -42,7 +42,7 @@ export interface ElmToggleProps {
   /**
    * The margin of the toggle.
    */
-  margin: Property.MarginBlock
+  margin?: Property.MarginBlock
 }
 
 withDefaults(defineProps<ElmToggleProps>(), {})

--- a/packages/core/src/components/media/ElmImage.vue
+++ b/packages/core/src/components/media/ElmImage.vue
@@ -73,7 +73,10 @@ export interface ElmImageProps {
    */
   enableModal?: boolean
 
-  margin: Property.MarginBlock
+  /**
+   * The margin of the image.
+   */
+  margin?: Property.MarginBlock
 }
 
 withDefaults(defineProps<ElmImageProps>(), {

--- a/packages/core/src/components/media/ElmImage.vue
+++ b/packages/core/src/components/media/ElmImage.vue
@@ -1,5 +1,9 @@
 <template>
-  <div :class="$style.fallback" v-if="isLoading">
+  <div
+    :class="$style.fallback"
+    v-if="isLoading"
+    :style="{ '--margin-block': margin }"
+  >
     <elm-rectangle-wave />
     <div>
       <elm-dot-loading-icon />
@@ -25,7 +29,8 @@
     :style="{
       '--height': isLoading ? '0' : 'auto',
       '--opacity': isLoading ? 0 : 1,
-      '--cursor': enableModal ? 'zoom-in' : 'inherit'
+      '--cursor': enableModal ? 'zoom-in' : 'inherit',
+      '--margin-block': margin
     }"
   />
 
@@ -50,6 +55,7 @@ import { ref } from 'vue'
 import ElmRectangleWave from '../fallback/ElmRectangleWave.vue'
 import ElmDotLoadingIcon from '../icon/ElmDotLoadingIcon.vue'
 import { onKeyStroke } from '@vueuse/core'
+import type { Property } from 'csstype'
 
 export interface ElmImageProps {
   /**
@@ -66,6 +72,8 @@ export interface ElmImageProps {
    * Enable modal on image click. Default: `false`
    */
   enableModal?: boolean
+
+  margin: Property.MarginBlock
 }
 
 withDefaults(defineProps<ElmImageProps>(), {
@@ -83,6 +91,7 @@ onKeyStroke('Escape', (e) => {
 
 <style module lang="scss">
 .image {
+  margin-block: var(--margin-block);
   display: block;
   width: 100%;
   height: var(--height);
@@ -92,6 +101,7 @@ onKeyStroke('Escape', (e) => {
 }
 
 .fallback {
+  margin-block: var(--margin-block);
   margin: 0;
   padding: 0;
   position: relative;

--- a/packages/core/src/components/table/ElmTable.vue
+++ b/packages/core/src/components/table/ElmTable.vue
@@ -1,17 +1,30 @@
 <template>
-  <table class="table">
+  <table
+    class="table"
+    :style="{
+      '--margin-block': margin
+    }"
+  >
     <slot />
   </table>
 </template>
 
 <script setup lang="ts">
-export interface ElmTableProps {}
+import type { Property } from 'csstype'
+
+export interface ElmTableProps {
+  /**
+   * The margin of the table.
+   */
+  margin?: Property.MarginBlock
+}
 
 withDefaults(defineProps<ElmTableProps>(), {})
 </script>
 
 <style scoped lang="scss">
 .table {
+  margin-block: var(--margin-block);
   border-collapse: collapse;
   border-spacing: 0;
   box-shadow: 0 0 0.125rem rgba(black, 0.1);

--- a/packages/core/src/components/typography/ElmDivider.vue
+++ b/packages/core/src/components/typography/ElmDivider.vue
@@ -16,7 +16,7 @@ import { ref } from 'vue'
 
 export interface ElmDividerProps {
   /**
-   * The margin of the toggle.
+   * The margin of the divider.
    */
   margin?: Property.MarginBlock
 }

--- a/packages/core/src/components/typography/ElmDivider.vue
+++ b/packages/core/src/components/typography/ElmDivider.vue
@@ -3,16 +3,23 @@
     ref="target"
     :class="$style.divider"
     :style="{
-      '--scale': targetIsVisible ? 1 : 0
+      '--scale': targetIsVisible ? 1 : 0,
+      '--margin-block': margin
     }"
   />
 </template>
 
 <script setup lang="ts">
 import { useIntersectionObserver } from '@vueuse/core'
+import type { Property } from 'csstype'
 import { ref } from 'vue'
 
-export interface ElmDividerProps {}
+export interface ElmDividerProps {
+  /**
+   * The margin of the toggle.
+   */
+  margin?: Property.MarginBlock
+}
 
 withDefaults(defineProps<ElmDividerProps>(), {})
 
@@ -40,6 +47,7 @@ useIntersectionObserver(target, ([{ isIntersecting }], _) => {
 }
 
 .divider {
+  margin-block: var(--margin-block);
   position: relative;
   display: block;
   width: 100%;


### PR DESCRIPTION
Introduce margin support for ElmCodeBlock, ElmToggle, ElmImage, ElmTable, and ElmDivider components, making the margin prop optional where applicable. Update the version to 1.0.0-alpha.41. Correct the margin prop description in ElmDivider.