### PR TITLE
Add ElmFragmentIdentifier for improved heading navigation

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elmethis/core",
-  "version": "1.0.0-alpha.76",
+  "version": "1.0.0-alpha.77",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/components/headings/ElmFragmentIdentifier.stories.tsx
+++ b/packages/core/src/components/headings/ElmFragmentIdentifier.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from '@storybook/vue3'
+import ElmFragmentIdentifier from './ElmFragmentIdentifier.vue'
+
+const meta: Meta<typeof ElmFragmentIdentifier> = {
+  title: 'Components/Headings/ElmFragmentIdentifier',
+  component: ElmFragmentIdentifier,
+  tags: ['autodocs'],
+  args: {}
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Primary: Story = {}

--- a/packages/core/src/components/headings/ElmFragmentIdentifier.vue
+++ b/packages/core/src/components/headings/ElmFragmentIdentifier.vue
@@ -17,6 +17,10 @@ export interface ElmFragmentIdentifierProps {
 withDefaults(defineProps<ElmFragmentIdentifierProps>(), {})
 
 const handleLinkClick = (id: string) => {
+  const url = new URL(window.location.href)
+  url.hash = id
+  window.history.replaceState(null, '', url.toString())
+
   const target = document.getElementById(id)
   if (target != null) {
     target.scrollIntoView({ behavior: 'smooth' })

--- a/packages/core/src/components/headings/ElmFragmentIdentifier.vue
+++ b/packages/core/src/components/headings/ElmFragmentIdentifier.vue
@@ -6,6 +6,7 @@
 
 <script setup lang="ts">
 import { LinkIcon } from '@heroicons/vue/24/outline'
+import { nextTick, onMounted } from 'vue'
 
 export interface ElmFragmentIdentifierProps {
   /**
@@ -26,6 +27,15 @@ const handleLinkClick = (id: string) => {
     target.scrollIntoView({ behavior: 'smooth' })
   }
 }
+
+onMounted(() => {
+  nextTick(() => {
+    const element = document.querySelector(window.location.hash)
+    if (element) {
+      element.scrollIntoView({ behavior: 'smooth' })
+    }
+  })
+})
 </script>
 
 <style module lang="scss">

--- a/packages/core/src/components/headings/ElmFragmentIdentifier.vue
+++ b/packages/core/src/components/headings/ElmFragmentIdentifier.vue
@@ -1,0 +1,50 @@
+<template>
+  <div :class="$style.fragment">
+    <LinkIcon :class="$style.icon" @click="handleLinkClick(id)" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { LinkIcon } from '@heroicons/vue/24/outline'
+
+export interface ElmFragmentIdentifierProps {
+  /**
+   * ID of the heading element.
+   */
+  id: string
+}
+
+withDefaults(defineProps<ElmFragmentIdentifierProps>(), {})
+
+const handleLinkClick = (id: string) => {
+  const target = document.getElementById(id)
+  if (target != null) {
+    target.scrollIntoView({ behavior: 'smooth' })
+  }
+}
+</script>
+
+<style module lang="scss">
+.fragment {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+}
+
+.icon {
+  padding: 0.25rem;
+  border-radius: 0.25rem;
+  width: 20px;
+  height: 20px;
+  color: #6987b8;
+  transition: background-color 200ms;
+  cursor: pointer;
+
+  &:hover {
+    background-color: rgba(black, 0.1);
+    [data-theme='dark'] & {
+      background-color: rgba(white, 0.1);
+    }
+  }
+}
+</style>

--- a/packages/core/src/components/headings/ElmHeading1.vue
+++ b/packages/core/src/components/headings/ElmHeading1.vue
@@ -11,7 +11,6 @@
   >
     {{ text }}
   </h1>
-  <ElmFragmentIdentifier :id="id ?? kebabCase(text)" />
 </template>
 
 <script setup lang="ts">
@@ -19,7 +18,6 @@ import type { Property } from 'csstype'
 import { ref } from 'vue'
 import { useIntersectionObserver } from '@vueuse/core'
 import { kebabCase } from 'lodash-es'
-import ElmFragmentIdentifier from './ElmFragmentIdentifier.vue'
 
 export interface ElmHeading1Props {
   /**

--- a/packages/core/src/components/headings/ElmHeading1.vue
+++ b/packages/core/src/components/headings/ElmHeading1.vue
@@ -11,6 +11,7 @@
   >
     {{ text }}
   </h1>
+  <ElmFragmentIdentifier :id="id ?? kebabCase(text)" />
 </template>
 
 <script setup lang="ts">
@@ -18,6 +19,7 @@ import type { Property } from 'csstype'
 import { ref } from 'vue'
 import { useIntersectionObserver } from '@vueuse/core'
 import { kebabCase } from 'lodash-es'
+import ElmFragmentIdentifier from './ElmFragmentIdentifier.vue'
 
 export interface ElmHeading1Props {
   /**
@@ -51,7 +53,6 @@ useIntersectionObserver(target, ([{ isIntersecting }], _) => {
 
 <style module lang="scss">
 .h1 {
-  margin-block: 3rem;
   position: relative;
   font-size: var(--font-size);
   line-height: var(cacl(--font-size + 0.25rem));

--- a/packages/core/src/components/headings/ElmHeading2.vue
+++ b/packages/core/src/components/headings/ElmHeading2.vue
@@ -11,6 +11,7 @@
   >
     {{ text }}<span :class="$style.underline" aria-hidden></span>
   </h2>
+  <ElmFragmentIdentifier :id="id ?? kebabCase(text)" />
 </template>
 
 <script setup lang="ts">
@@ -18,6 +19,7 @@ import { useIntersectionObserver } from '@vueuse/core'
 import type { Property } from 'csstype'
 import { kebabCase } from 'lodash-es'
 import { ref } from 'vue'
+import ElmFragmentIdentifier from './ElmFragmentIdentifier.vue'
 
 export interface ElmHeading2Props {
   /**
@@ -51,7 +53,7 @@ useIntersectionObserver(target, ([{ isIntersecting }], _) => {
 
 <style module lang="scss">
 .h2 {
-  margin-block: 3rem;
+  margin-block: 1rem;
   position: relative;
   font-size: var(--font-size);
   line-height: var(--font-size);

--- a/packages/core/src/components/headings/ElmHeading3.vue
+++ b/packages/core/src/components/headings/ElmHeading3.vue
@@ -7,6 +7,7 @@
   >
     {{ text }}
   </h3>
+  <ElmFragmentIdentifier :id="id ?? kebabCase(text)" />
 </template>
 
 <script setup lang="ts">
@@ -14,6 +15,7 @@ import { useIntersectionObserver } from '@vueuse/core'
 import type { Property } from 'csstype'
 import { kebabCase } from 'lodash-es'
 import { ref } from 'vue'
+import ElmFragmentIdentifier from './ElmFragmentIdentifier.vue'
 
 export interface ElmHeading3Props {
   /**
@@ -47,7 +49,7 @@ useIntersectionObserver(target, ([{ isIntersecting }], _) => {
 
 <style module lang="scss">
 .h3 {
-  margin-block: 3rem;
+  margin-block: 1rem;
   position: relative;
   box-sizing: border-box;
   padding-left: 0.75rem;

--- a/packages/core/src/components/headings/ElmHeading4.vue
+++ b/packages/core/src/components/headings/ElmHeading4.vue
@@ -6,11 +6,13 @@
   >
     {{ text }}
   </h4>
+  <ElmFragmentIdentifier :id="id ?? kebabCase(text)" />
 </template>
 
 <script setup lang="ts">
 import type { Property } from 'csstype'
 import { kebabCase } from 'lodash-es'
+import ElmFragmentIdentifier from './ElmFragmentIdentifier.vue'
 
 export interface ElmHeading4Props {
   /**
@@ -37,7 +39,7 @@ withDefaults(defineProps<ElmHeading4Props>(), {
 
 <style module lang="scss">
 .h4 {
-  margin-block: 3rem;
+  margin-block: 0.5rem;
   font-size: var(--font-size);
 
   transition: color 400ms;

--- a/packages/core/src/components/headings/ElmHeading5.vue
+++ b/packages/core/src/components/headings/ElmHeading5.vue
@@ -6,11 +6,13 @@
   >
     {{ text }}
   </h5>
+  <ElmFragmentIdentifier :id="id ?? kebabCase(text)" />
 </template>
 
 <script setup lang="ts">
 import type { Property } from 'csstype'
 import { kebabCase } from 'lodash-es'
+import ElmFragmentIdentifier from './ElmFragmentIdentifier.vue'
 
 export interface ElmHeading5Props {
   /**
@@ -37,7 +39,7 @@ withDefaults(defineProps<ElmHeading5Props>(), {
 
 <style module lang="scss">
 .h5 {
-  margin-block: 3rem;
+  margin-block: 0.5rem;
   font-size: var(--font-size);
 
   transition: color 400ms;

--- a/packages/core/src/components/headings/ElmHeading6.vue
+++ b/packages/core/src/components/headings/ElmHeading6.vue
@@ -6,11 +6,13 @@
   >
     {{ text }}
   </h6>
+  <ElmFragmentIdentifier :id="id ?? kebabCase(text)" />
 </template>
 
 <script setup lang="ts">
 import type { Property } from 'csstype'
 import { kebabCase } from 'lodash-es'
+import ElmFragmentIdentifier from './ElmFragmentIdentifier.vue'
 
 export interface ElmHeading6Props {
   /**
@@ -37,7 +39,7 @@ withDefaults(defineProps<ElmHeading6Props>(), {
 
 <style module lang="scss">
 .h6 {
-  margin-block: 3rem;
+  margin-block: 0.5rem;
   font-size: var(--font-size);
 
   transition: color 400ms;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -72,6 +72,9 @@ import ElmHeading5, {
 import ElmHeading6, {
   ElmHeading6Props
 } from './components/headings/ElmHeading6.vue'
+import ElmFragmentIdentifier, {
+  ElmFragmentIdentifierProps
+} from './components/headings/ElmFragmentIdentifier.vue'
 
 // icon
 import ElmArrowIcon, {
@@ -217,6 +220,7 @@ export {
   ElmHeading4,
   ElmHeading5,
   ElmHeading6,
+  ElmFragmentIdentifier,
   ElmArrowIcon,
   ElmBookmarkIcon,
   ElmCubeIcon,
@@ -278,6 +282,7 @@ export type {
   ElmHeading4Props,
   ElmHeading5Props,
   ElmHeading6Props,
+  ElmFragmentIdentifierProps,
   ElmArrowIconProps,
   ElmBookmarkIconProps,
   ElmCubeIconProps,


### PR DESCRIPTION
Introduce the ElmFragmentIdentifier component to enable smooth scrolling to headings and enhance navigation. Update link handling to modify the URL hash without page reloads and ensure scrolling to elements on mount if a hash is present. Bump version to 1.0.0-alpha.77.