### PR TITLE
Add ElmBadge component with customizable color and slot support

### DIFF
--- a/packages/core/src/components/badge/ElmBadge.stories.tsx
+++ b/packages/core/src/components/badge/ElmBadge.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from '@storybook/vue3'
+import ElmBadge from './ElmBadge.vue'
+import ElmInlineText from '../inline/ElmInlineText.vue'
+
+const meta: Meta<typeof ElmBadge> = {
+  title: 'Components/Badge/ElmBadge',
+  component: ElmBadge,
+  tags: ['autodocs'],
+  args: {}
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Primary: Story = {
+  args: {
+    color: '#c56565'
+  },
+  render: (args) => ({
+    setup() {
+      return { args }
+    },
+    components: { ElmBadge, ElmInlineText },
+    template: `<ElmBadge v-bind="args">
+      <template #left>
+        <span>Left</span>
+      </template>
+
+      <template #right>
+        <ElmInlineText text="Right" />
+      </template>
+    </ElmBadge>`
+  })
+}

--- a/packages/core/src/components/badge/ElmBadge.vue
+++ b/packages/core/src/components/badge/ElmBadge.vue
@@ -1,0 +1,45 @@
+<template>
+  <span :class="$style.badge" :style="{ '--bg-color': color }">
+    <span
+      :class="$style.left"
+      :style="{
+        color:
+          getLuminance(color) > 0.5
+            ? 'rgba(0,0,0,0.7)'
+            : 'rgba(255,255,255,0.7)'
+      }"
+    >
+      <slot name="left" />
+    </span>
+
+    <span :class="$style.right">
+      <slot name="right" />
+    </span>
+  </span>
+</template>
+
+<script setup lang="ts">
+import { getLuminance } from 'polished'
+
+export interface ElmBadgeProps {
+  color: string
+}
+
+withDefaults(defineProps<ElmBadgeProps>(), {})
+</script>
+
+<style module lang="scss">
+.badge {
+  border: 1px solid var(--bg-color);
+  border-radius: 0.25rem;
+
+  .left {
+    background-color: var(--bg-color);
+    padding-inline: 0.5rem;
+  }
+
+  .right {
+    padding-inline: 0.5rem;
+  }
+}
+</style>

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 // badge
+import ElmBadge, { ElmBadgeProps } from './components/badge/ElmBadge.vue'
 import ElmTag, { ElmTagProps } from './components/badge/ElmTag.vue'
 
 // code
@@ -207,6 +208,7 @@ import ElmListItem, {
 import { useElmethisTheme } from './hooks/useElmethisTheme'
 
 export {
+  ElmBadge,
   ElmTag,
   ElmCodeBlock,
   ElmPrismHighlighter,
@@ -273,6 +275,7 @@ export {
 }
 
 export type {
+  ElmBadgeProps,
   ElmTagProps,
   ElmCodeBlockProps,
   ElmPrismHighlighterProps,


### PR DESCRIPTION
Introduce the ElmBadge component, allowing for customizable colors and slot usage. Export ElmBadge and its props from the core index for easier access.