### PR TITLE
Refactor list handling and color type in client

### DIFF
--- a/crates/elmethis-notion/src/block.rs
+++ b/crates/elmethis-notion/src/block.rs
@@ -256,5 +256,5 @@ pub struct ElmInlineTextProps {
     pub underline: bool,
     pub strikethrough: bool,
     pub code: bool,
-    pub color: String,
+    pub color: Option<String>,
 }

--- a/crates/elmethis-notion/src/block.rs
+++ b/crates/elmethis-notion/src/block.rs
@@ -256,5 +256,5 @@ pub struct ElmInlineTextProps {
     pub underline: bool,
     pub strikethrough: bool,
     pub code: bool,
-    pub color: notionrs::Color,
+    pub color: String,
 }

--- a/crates/elmethis-notion/src/client.rs
+++ b/crates/elmethis-notion/src/client.rs
@@ -399,16 +399,6 @@ impl Client {
                             ));
                         }
                     };
-
-                    // match &mut ol {
-                    //     Some(ol) => {
-                    //         ol.children.push(list_item_block);
-                    //     }
-                    //     None => {
-                    //         let new_ol = vec![list_item_block];
-                    //         ol = Some(crate::block::ElmNumberedList { children: new_ol })
-                    //     }
-                    // };
                 }
                 notionrs::block::Block::Paragraph { paragraph } => {
                     let block = crate::block::Block::ElmParagraph(crate::block::ElmParagraph {

--- a/crates/elmethis-notion/src/client.rs
+++ b/crates/elmethis-notion/src/client.rs
@@ -581,7 +581,7 @@ impl Client {
                 underline: annotations.underline,
                 strikethrough: annotations.italic,
                 code: annotations.code,
-                color: annotations.color,
+                color: annotations.color.to_string(),
             };
 
             blocks.push(crate::block::Block::ElmInlineText(

--- a/crates/elmethis-notion/src/client.rs
+++ b/crates/elmethis-notion/src/client.rs
@@ -581,7 +581,19 @@ impl Client {
                 underline: annotations.underline,
                 strikethrough: annotations.italic,
                 code: annotations.code,
-                color: annotations.color.to_string(),
+                color: match annotations.color {
+                    notionrs::Color::Default => None,
+                    notionrs::Color::Blue => Some(String::from("#6987b8")),
+                    notionrs::Color::Brown => Some(String::from("#8b4c3f")),
+                    notionrs::Color::Gray => Some(String::from("#868e9c")),
+                    notionrs::Color::Green => Some(String::from("#59b57c")),
+                    notionrs::Color::Orange => Some(String::from("#bf7e71")),
+                    notionrs::Color::Pink => Some(String::from("#c9699e")),
+                    notionrs::Color::Purple => Some(String::from("#9771bd")),
+                    notionrs::Color::Red => Some(String::from("#b36472")),
+                    notionrs::Color::Yellow => Some(String::from("#b8a36e")),
+                    _ => None,
+                },
             };
 
             blocks.push(crate::block::Block::ElmInlineText(


### PR DESCRIPTION
Simplify the handling of bulleted and numbered lists while removing unnecessary commented-out code. Update the color type in `ElmInlineTextProps` to use `Option<String>` for better flexibility in color handling.