### PR TITLE
Migrate from Heroicons to Iconify components across various components

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,7 +29,6 @@
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^3.2.4",
-    "@heroicons/vue": "^2.2.0",
     "@iconify/vue": "^4.3.0",
     "@notionhq/client": "^2.2.15",
     "@storybook/addon-essentials": "^8.5.0",

--- a/packages/core/src/components/code/ElmCodeBlock.vue
+++ b/packages/core/src/components/code/ElmCodeBlock.vue
@@ -15,14 +15,20 @@
 
       <ElmTooltip>
         <template #original>
-          <component
+          <Icon
+            width="24"
+            height="24"
+            :icon="
+              copied
+                ? 'mdi:clipboard-check-multiple-outline'
+                : 'mdi:clipboard-multiple-outline'
+            "
             :class="$style['copy-icon']"
             @click="
               () => {
                 copy(code)
               }
             "
-            :is="copied ? ClipboardDocumentCheckIcon : ClipboardDocumentIcon"
           />
         </template>
         <template #tooltip>
@@ -41,10 +47,6 @@
 </template>
 
 <script setup lang="ts">
-import {
-  ClipboardDocumentCheckIcon,
-  ClipboardDocumentIcon
-} from '@heroicons/vue/24/outline'
 import ElmLanguageIcon from '../icon/ElmLanguageIcon.vue'
 import ElmInlineText from '../inline/ElmInlineText.vue'
 import ElmShikiHighlighter from './ElmShikiHighlighter.vue'
@@ -52,6 +54,7 @@ import { useClipboard, useIntersectionObserver } from '@vueuse/core'
 import ElmTooltip from '../containments/ElmTooltip.vue'
 import type { Property } from 'csstype'
 import { ref } from 'vue'
+import { Icon } from '@iconify/vue/dist/iconify.js'
 
 export interface ElmCodeBlockProps {
   /**

--- a/packages/core/src/components/containments/ElmSnackbar.vue
+++ b/packages/core/src/components/containments/ElmSnackbar.vue
@@ -13,7 +13,6 @@
 </template>
 
 <script setup lang="ts">
-// import { XMarkIcon } from '@heroicons/vue/24/outline'
 import { VNode } from 'vue'
 import ElmInlineText from '../inline/ElmInlineText.vue'
 import { Icon } from '@iconify/vue/dist/iconify.js'

--- a/packages/core/src/components/containments/ElmSnackbar.vue
+++ b/packages/core/src/components/containments/ElmSnackbar.vue
@@ -2,7 +2,7 @@
   <div :class="$style.snackbar">
     <ElmInlineText v-if="props.label != null" :text="props.label" />
     <component v-else :is="() => props.children" />
-    <XMarkIcon :class="$style.icon" @click="close" />
+    <Icon :class="$style.icon" icon="mdi:cross-circle-outline" @click="close" />
     <div
       :class="$style.progress"
       :style="{
@@ -13,9 +13,10 @@
 </template>
 
 <script setup lang="ts">
-import { XMarkIcon } from '@heroicons/vue/24/outline'
+// import { XMarkIcon } from '@heroicons/vue/24/outline'
 import { VNode } from 'vue'
 import ElmInlineText from '../inline/ElmInlineText.vue'
+import { Icon } from '@iconify/vue/dist/iconify.js'
 
 export interface ElmSnackbarProps {
   label?: string
@@ -50,8 +51,8 @@ const props = withDefaults(defineProps<ElmSnackbarProps>(), {
 .icon {
   padding: 0.25rem;
   border-radius: 50%;
-  width: 1rem;
-  height: 1rem;
+  width: 1.25rem;
+  height: 1.25rem;
   cursor: pointer;
   transition: background-color 200ms;
 

--- a/packages/core/src/components/containments/ElmToggle.vue
+++ b/packages/core/src/components/containments/ElmToggle.vue
@@ -2,7 +2,10 @@
   <div :class="$style.toggle" :style="{ '--margin-block': margin }">
     <div :class="$style.summary" @click="handleClick">
       <div :style="{ display: 'flex', gap: '0.5rem' }">
-        <ChevronRightIcon
+        <Icon
+          icon="mdi:chevron-right"
+          width="24"
+          height="24"
           :class="$style.icon"
           :style="{ '--rotate': isOpen ? '90deg' : '0deg' }"
         />
@@ -11,7 +14,10 @@
           <slot v-else name="summary" />
         </div>
       </div>
-      <PlusIcon
+      <Icon
+        icon="mdi:plus"
+        width="24"
+        height="24"
         :class="$style.icon"
         :style="{
           '--rotate': isOpen ? '135deg' : '0deg',
@@ -30,7 +36,7 @@
 
 <script setup lang="ts">
 import ElmInlineText from '../inline/ElmInlineText.vue'
-import { ChevronRightIcon, PlusIcon } from '@heroicons/vue/24/outline'
+import { Icon } from '@iconify/vue/dist/iconify.js'
 import type { Property } from 'csstype'
 
 export interface ElmToggleProps {

--- a/packages/core/src/components/data/ElmStatusMessage.vue
+++ b/packages/core/src/components/data/ElmStatusMessage.vue
@@ -1,17 +1,26 @@
 <template>
   <transition mode="out-in">
     <div v-if="status === 'pending'" :class="$style.wrapper">
-      <ArrowPathIcon :class="$style.icon" :style="{ color: '#6987b8' }" />
+      <Icon
+        icon="heroicons:arrow-path-solid"
+        :class="$style.icon"
+        :style="{ color: '#6987b8' }"
+      />
       <ElmInlineText :text="message" color="#6987b8" />
     </div>
 
     <div v-else-if="status === 'error'" :class="$style.wrapper">
-      <XMarkIcon :class="$style.icon" :style="{ color: '#c56565' }" />
+      <Icon
+        icon="ic:outline-error"
+        :class="$style.icon"
+        :style="{ color: '#c56565' }"
+      />
       <ElmInlineText :text="message" color="#c56565" />
     </div>
 
     <div v-else-if="status === 'warning'" :class="$style.wrapper">
-      <ExclamationTriangleIcon
+      <Icon
+        icon="heroicons:exclamation-triangle"
         :class="$style.icon"
         :style="{ color: '#cdb57b' }"
       />
@@ -19,19 +28,18 @@
     </div>
 
     <div v-else :class="$style.wrapper">
-      <CheckIcon :class="$style.icon" :style="{ color: '#59b57c' }" />
+      <Icon
+        icon="heroicons:check-circle"
+        :class="$style.icon"
+        :style="{ color: '#59b57c' }"
+      />
       <ElmInlineText :text="message" color="#59b57c" />
     </div>
   </transition>
 </template>
 
 <script setup lang="ts">
-import {
-  ArrowPathIcon,
-  CheckIcon,
-  ExclamationTriangleIcon,
-  XMarkIcon
-} from '@heroicons/vue/24/outline'
+import { Icon } from '@iconify/vue/dist/iconify.js'
 import ElmInlineText from '../inline/ElmInlineText.vue'
 
 export interface ElmStatusMessageProps {

--- a/packages/core/src/components/form/ElmButton.stories.tsx
+++ b/packages/core/src/components/form/ElmButton.stories.tsx
@@ -1,7 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/vue3'
 import ElmButton from './ElmButton.vue'
 import ElmInlineText from '../inline/ElmInlineText.vue'
-import { PencilSquareIcon } from '@heroicons/vue/24/outline'
+import { Icon } from '@iconify/vue/dist/iconify.js'
+import { h } from 'vue'
 
 const meta: Meta<typeof ElmButton> = {
   title: 'Components/Form/ElmButton',
@@ -34,11 +35,14 @@ export const Flex: Story = {
   args: { block: true },
   render: (args) => ({
     setup: () => ({ args }),
-    components: { ElmButton, PencilSquareIcon },
+    components: {
+      ElmButton,
+      icon: h(Icon, { icon: 'mdi:library-edit', width: 16 })
+    },
     template: `
         <div style="display: flex; gap: 1rem;">
-          <ElmButton v-bind="args"><PencilSquareIcon style="width: 16px;" />elm-button</ElmButton>
-          <ElmButton v-bind="args"><PencilSquareIcon style="width: 16px;" />elm-button</ElmButton>
+          <ElmButton v-bind="args"><icon />elm-button</ElmButton>
+          <ElmButton v-bind="args"><icon />elm-button</ElmButton>
         </div>
       `
   })
@@ -52,11 +56,14 @@ export const WithPrimary: Story = {
   args: { block: true },
   render: (args) => ({
     setup: () => ({ args }),
-    components: { ElmButton, PencilSquareIcon },
+    components: {
+      ElmButton,
+      icon: h(Icon, { icon: 'mdi:library-edit', width: 16 })
+    },
     template: `
         <div style="display: flex; gap: 1rem;">
-          <ElmButton v-bind="args" primary><PencilSquareIcon style="width: 16px;" />elm-button</ElmButton>
-          <ElmButton v-bind="args"><PencilSquareIcon style="width: 16px;" />elm-button</ElmButton>
+          <ElmButton v-bind="args" primary><icon />elm-button</ElmButton>
+          <ElmButton v-bind="args"><icon />elm-button</ElmButton>
         </div>
       `
   })

--- a/packages/core/src/components/form/ElmTextField.stories.tsx
+++ b/packages/core/src/components/form/ElmTextField.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/vue3'
 import ElmTextField from './ElmTextField.vue'
-import { EnvelopeIcon } from '@heroicons/vue/24/outline'
+import { Icon } from '@iconify/vue/dist/iconify.js'
+import { h } from 'vue'
 
 const meta: Meta<typeof ElmTextField> = {
   title: 'Components/Form/ElmTextField',
@@ -18,6 +19,6 @@ export const Primary: Story = {
     maxLength: 20,
     suffix: '@46ki75.com',
     placeholder: 'Enter your email',
-    icon: EnvelopeIcon
+    icon: h(Icon, { icon: 'mdi:envelope-outline' })
   }
 }

--- a/packages/core/src/components/form/ElmTextField.vue
+++ b/packages/core/src/components/form/ElmTextField.vue
@@ -45,13 +45,17 @@
           <ElmInlineText v-if="suffix != null" :text="suffix" />
         </span>
 
-        <component
+        <Icon
           v-if="isPassword"
-          :is="type === 'text' ? EyeIcon : EyeSlashIcon"
+          :icon="type === 'text' ? 'heroicons:eye' : 'heroicons:eye-slash'"
           :class="$style.icon"
           @click="handleVisibleSwitch"
         />
-        <BackspaceIcon :class="$style.icon" @click="handleDelete" />
+        <Icon
+          icon="heroicons:backspace-16-solid"
+          :class="$style.icon"
+          @click="handleDelete"
+        />
       </div>
     </div>
 
@@ -65,9 +69,8 @@
 </template>
 
 <script setup lang="ts">
-import { BackspaceIcon } from '@heroicons/vue/24/solid'
 import ElmInlineText from '../inline/ElmInlineText.vue'
-import { EyeIcon, EyeSlashIcon } from '@heroicons/vue/24/outline'
+import { Icon } from '@iconify/vue/dist/iconify.js'
 import { ref, type VNode, type FunctionalComponent } from 'vue'
 import { nanoid } from 'nanoid'
 

--- a/packages/core/src/components/form/ElmTotp.vue
+++ b/packages/core/src/components/form/ElmTotp.vue
@@ -16,7 +16,7 @@
           {{ char }}
         </span>
       </div>
-      <BackspaceIcon :class="$style.icon" @click="reset" />
+      <Icon :icon="'heroicons:backspace'" :class="$style.icon" @click="reset" />
     </div>
 
     <input
@@ -33,7 +33,7 @@
 </template>
 
 <script setup lang="ts">
-import { BackspaceIcon } from '@heroicons/vue/24/outline'
+import { Icon } from '@iconify/vue/dist/iconify.js'
 import { useFocus } from '@vueuse/core'
 import { nextTick, onMounted, ref, computed } from 'vue'
 

--- a/packages/core/src/components/form/ElmTotp.vue
+++ b/packages/core/src/components/form/ElmTotp.vue
@@ -59,8 +59,9 @@ const { focused } = useFocus(targetRef)
 const selectedIndex = ref<number | null>(0)
 
 const select = (index: number) => {
-  selectText(index)
-  selectedIndex.value = index
+  const maxIndex = Math.min(index, inputModel.value.length)
+  selectText(maxIndex)
+  selectedIndex.value = maxIndex
 }
 
 const selectText = (index: number): void => {

--- a/packages/core/src/components/headings/ElmFragmentIdentifier.vue
+++ b/packages/core/src/components/headings/ElmFragmentIdentifier.vue
@@ -1,12 +1,20 @@
 <template>
   <div :class="$style.fragment">
-    <HashtagIcon :class="$style.icon" @click="handleHashClick(id)" />
-    <LinkIcon :class="$style.icon" @click="handleLinkClick(id)" />
+    <Icon
+      icon="mdi:hashtag-box-outline"
+      :class="$style.icon"
+      @click="handleHashClick(id)"
+    />
+    <Icon
+      icon="mdi:link-box-variant-outline"
+      :class="$style.icon"
+      @click="handleLinkClick(id)"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
-import { HashtagIcon, LinkIcon } from '@heroicons/vue/24/outline'
+import { Icon } from '@iconify/vue/dist/iconify.js'
 import { useClipboard } from '@vueuse/core'
 import { nextTick, onMounted } from 'vue'
 
@@ -58,10 +66,10 @@ onMounted(() => {
 }
 
 .icon {
-  padding: 0.25rem;
+  padding: 1px;
   border-radius: 0.25rem;
-  width: 20px;
-  height: 20px;
+  width: 24px;
+  height: 24px;
   color: #6987b8;
   transition: background-color 200ms;
   cursor: pointer;

--- a/packages/core/src/components/icon/ElmBookmarkIcon.vue
+++ b/packages/core/src/components/icon/ElmBookmarkIcon.vue
@@ -12,7 +12,11 @@
       :alt="`favicon of ${name ?? href}`"
     />
 
-    <GlobeAsiaAustraliaIcon v-else :class="$style['favicon-svg']" />
+    <Icon
+      icon="material-symbols-light:globe-asia"
+      v-else
+      :class="$style['favicon-svg']"
+    />
 
     <div :class="$style.text">
       <ElmInlineText :text="name ?? href" size=".6rem" />
@@ -21,7 +25,7 @@
 </template>
 
 <script setup lang="ts">
-import { GlobeAsiaAustraliaIcon } from '@heroicons/vue/24/outline'
+import { Icon } from '@iconify/vue/dist/iconify.js'
 import ElmInlineText from '../inline/ElmInlineText.vue'
 
 export interface ElmBookmarkIconProps {

--- a/packages/core/src/components/icon/ElmLanguageIcon.vue
+++ b/packages/core/src/components/icon/ElmLanguageIcon.vue
@@ -7,9 +7,8 @@
 </template>
 
 <script setup lang="ts">
-import { defineAsyncComponent, ref } from 'vue'
-
-import { CommandLineIcon } from '@heroicons/vue/24/outline'
+import { defineAsyncComponent, h, ref } from 'vue'
+import { Icon as Iconify } from '@iconify/vue/dist/iconify.js'
 import { watch } from 'vue'
 
 export interface ElmLanguageIconProps {
@@ -26,6 +25,12 @@ export interface ElmLanguageIconProps {
 
 const props = withDefaults(defineProps<ElmLanguageIconProps>(), {
   size: 24
+})
+
+const CommandLineIcon = h(Iconify, {
+  icon: 'heroicons:command-line',
+  width: props.size,
+  height: props.size
 })
 
 const render = () => {

--- a/packages/core/src/components/icon/ElmLoginIcon.vue
+++ b/packages/core/src/components/icon/ElmLoginIcon.vue
@@ -1,19 +1,18 @@
 <template>
   <ElmTooltip>
     <template #original>
-      <component
-        :class="$style.icon"
-        :style="{
-          '--width': size,
-          '--color': isLogin ? '#b36472' : '#6987b8'
-        }"
-        :is="
+      <Icon
+        :icon="
           isLoading
-            ? h(ElmDotLoadingIcon, { size: size })
+            ? 'line-md:loading-loop'
             : isLogin
-              ? ArrowRightStartOnRectangleIcon
-              : ArrowRightEndOnRectangleIcon
+              ? 'mdi:logout-variant'
+              : 'mdi:login-variant'
         "
+        :class="$style.icon"
+        :style="{ '--color': isLogin ? '#b36472' : '#6987b8' }"
+        :width="size"
+        :height="size"
       />
     </template>
     <template #tooltip>
@@ -25,14 +24,9 @@
 </template>
 
 <script setup lang="ts">
-import {
-  ArrowRightEndOnRectangleIcon,
-  ArrowRightStartOnRectangleIcon
-} from '@heroicons/vue/24/outline'
+import { Icon } from '@iconify/vue/dist/iconify.js'
 import ElmTooltip from '../containments/ElmTooltip.vue'
 import ElmInlineText from '../inline/ElmInlineText.vue'
-import ElmDotLoadingIcon from './ElmDotLoadingIcon.vue'
-import { h } from 'vue'
 
 export interface ElmLoginIconProps {
   /**
@@ -59,8 +53,7 @@ withDefaults(defineProps<ElmLoginIconProps>(), {
 <style module lang="scss">
 .icon {
   box-sizing: border-box;
-  width: var(--width);
-  padding: 0.25rem;
+  padding: 0.125rem;
   border-radius: 0.25rem;
   color: var(--color);
   cursor: pointer;

--- a/packages/core/src/components/inline/ElmInlineLink.stories.tsx
+++ b/packages/core/src/components/inline/ElmInlineLink.stories.tsx
@@ -12,7 +12,7 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Primary: Story = {
-  args: { text: 'elm-inline-link', href: 'https://example.com' }
+  args: { text: 'elm-inline-link', href: 'https://google.com' }
 }
 
 export const OnClick: Story = {

--- a/packages/core/src/components/inline/ElmInlineLink.vue
+++ b/packages/core/src/components/inline/ElmInlineLink.vue
@@ -7,16 +7,22 @@
     rel="noopener noreferrer"
     @click="handleClick"
   >
+    <img
+      :class="$style.favicon"
+      :src="imageSrc"
+      alt="favicon"
+      @error="handleError"
+    />
     {{ text }}
-    <component
-      :is="
+    <Icon
+      :icon="
         iconType != null
           ? iconType === 'internal'
-            ? ChevronRightIcon
-            : ArrowTopRightOnSquareIcon
+            ? 'heroicons:arrow-top-right-on-square-20-solid'
+            : 'heroicons:chevron-right-20-solid'
           : openInNewTab
-            ? ArrowTopRightOnSquareIcon
-            : ChevronRightIcon
+            ? 'heroicons:arrow-top-right-on-square-20-solid'
+            : 'heroicons:chevron-right-20-solid'
       "
       :class="$style.icon"
     />
@@ -24,11 +30,9 @@
 </template>
 
 <script setup lang="ts">
-import {
-  ArrowTopRightOnSquareIcon,
-  ChevronRightIcon
-} from '@heroicons/vue/24/outline'
+import { Icon } from '@iconify/vue/dist/iconify.js'
 import type { Property } from 'csstype'
+import { ref } from 'vue'
 
 export interface ElmInlineLinkProps {
   /**
@@ -78,9 +82,21 @@ function handleClick(event: MouseEvent) {
     props.onClick()
   }
 }
+
+const imageSrc = ref(`https://logo.clearbit.com/${props.href}`)
+
+const handleError = () => {
+  imageSrc.value =
+    'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="gray" d="M17.9 17.39c-.26-.8-1.01-1.39-1.9-1.39h-1v-3a1 1 0 0 0-1-1H8v-2h2a1 1 0 0 0 1-1V7h2a2 2 0 0 0 2-2v-.41a7.984 7.984 0 0 1 2.9 12.8M11 19.93c-3.95-.49-7-3.85-7-7.93c0-.62.08-1.22.21-1.79L9 15v1a2 2 0 0 0 2 2m1-16A10 10 0 0 0 2 12a10 10 0 0 0 10 10a10 10 0 0 0 10-10A10 10 0 0 0 12 2"/></svg>'
+}
 </script>
 
 <style module lang="scss">
+.favicon {
+  width: calc(var(--font-size) + 0.25rem);
+  height: calc(var(--font-size) + 0.25rem);
+}
+
 .link {
   all: unset;
   box-sizing: border-box;

--- a/packages/core/src/components/media/ElmFile.vue
+++ b/packages/core/src/components/media/ElmFile.vue
@@ -1,7 +1,7 @@
 <template>
   <div :class="$style.file" :style="{ '--margin-block': margin }">
     <div :class="$style['left-container']">
-      <DocumentIcon :class="$style.icon" />
+      <Icon icon="mdi:folder-file-outline" :class="$style.icon" />
       <ElmInlineText
         :text="
           name ?? getLastPathSegmentWithoutQueryOrHash(src) ?? 'unknown file'
@@ -13,7 +13,8 @@
       <span :style="{ opacity: 0.6 }"
         ><ElmInlineText v-if="filesize" :text="filesize"
       /></span>
-      <ArrowDownTrayIcon
+      <Icon
+        icon="mdi:tray-download"
         :class="$style['download-icon']"
         @click="
           () => {
@@ -31,7 +32,7 @@
 </template>
 
 <script setup lang="ts">
-import { ArrowDownTrayIcon, DocumentIcon } from '@heroicons/vue/24/outline'
+import { Icon } from '@iconify/vue/dist/iconify.js'
 import ElmInlineText from '../inline/ElmInlineText.vue'
 import { Property } from 'csstype'
 
@@ -97,6 +98,7 @@ async function downloadFile(url: string, filename: string) {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  border-radius: 0.25rem;
 
   background-color: rgba(white, 0.2);
   [data-theme='dark'] & {
@@ -111,6 +113,7 @@ async function downloadFile(url: string, filename: string) {
 
     .icon {
       width: 20px;
+      height: 20px;
       transition: color 200ms;
       color: rgba(black, 0.8);
       [data-theme='dark'] & {
@@ -128,6 +131,8 @@ async function downloadFile(url: string, filename: string) {
     .download-icon {
       padding: 0.125rem;
       width: 20px;
+      height: 20px;
+      border-radius: 0.125rem;
       cursor: pointer;
       transition:
         color 200ms,

--- a/packages/core/src/components/media/ElmImage.vue
+++ b/packages/core/src/components/media/ElmImage.vue
@@ -1,7 +1,6 @@
 <template>
   <transition mode="out-in">
     <div v-if="error" :class="$style.error">
-      <PhotoIcon :style="{ height: 24 }" />
       <ElmInlineText text="Error loading image" color="#c56565" size="1.5rem" />
     </div>
 
@@ -61,7 +60,6 @@ import ElmDotLoadingIcon from '../icon/ElmDotLoadingIcon.vue'
 import { onKeyStroke, useImage } from '@vueuse/core'
 import type { Property } from 'csstype'
 import ElmInlineText from '../inline/ElmInlineText.vue'
-import { PhotoIcon } from '@heroicons/vue/24/outline'
 
 export interface ElmImageProps {
   /**

--- a/packages/core/src/components/navigation/ElmBookmark.vue
+++ b/packages/core/src/components/navigation/ElmBookmark.vue
@@ -29,12 +29,12 @@
 
         <div :class="$style.date" v-if="createdAt != null || updatedAt != null">
           <template v-if="createdAt != null">
-            <CalendarDaysIcon :class="$style.icon" />
+            <Icon icon="mdi:calendar-edit" :class="$style.icon" />
             <ElmInlineText :text="`${createdAt}`" size=".8rem" />
           </template>
 
           <template v-if="updatedAt != null">
-            <ArrowPathIcon :class="$style.icon" />
+            <Icon icon="mdi:calendar-sync" :class="$style.icon" />
             <ElmInlineText :text="`${updatedAt}`" size=".8rem" />
           </template>
         </div>
@@ -48,7 +48,7 @@
 </template>
 
 <script setup lang="ts">
-import { CalendarDaysIcon, ArrowPathIcon } from '@heroicons/vue/24/outline'
+import { Icon } from '@iconify/vue/dist/iconify.js'
 import ElmInlineLink from '../inline/ElmInlineLink.vue'
 import ElmInlineText from '../inline/ElmInlineText.vue'
 import ElmImage from '../media/ElmImage.vue'
@@ -224,6 +224,7 @@ function handleClick(event: MouseEvent) {
 
   .icon {
     width: 16px;
+    height: 16px;
 
     color: rgba(black, 0.7);
     [data-theme='dark'] & {

--- a/packages/core/src/components/navigation/ElmBreadcrumb.vue
+++ b/packages/core/src/components/navigation/ElmBreadcrumb.vue
@@ -8,14 +8,14 @@
   >
     <template v-for="(link, index) in links">
       <div :class="$style['link-container']" @click="link.onClick">
-        <component
+        <Icon
           :class="[$style.icon, $style.fade]"
-          :is="
+          :icon="
             index === 0
-              ? HomeIcon
+              ? 'material-symbols:house'
               : index === links.length - 1
-                ? DocumentTextIcon
-                : FolderOpenIcon
+                ? 'material-symbols:file-copy-rounded'
+                : 'material-symbols:folder'
           "
           :style="{
             '--delay': `${index * 100}ms`
@@ -29,8 +29,8 @@
           }"
         />
       </div>
-
-      <ChevronRightIcon
+      <Icon
+        icon="mdi-light:chevron-right"
         v-if="links.length !== index + 1"
         :class="[$style.chevron, $style.fade]"
         :style="{
@@ -42,12 +42,7 @@
 </template>
 
 <script setup lang="ts">
-import {
-  ChevronRightIcon,
-  DocumentTextIcon,
-  FolderOpenIcon,
-  HomeIcon
-} from '@heroicons/vue/24/outline'
+import { Icon } from '@iconify/vue/dist/iconify.js'
 import ElmInlineText from '../inline/ElmInlineText.vue'
 import { ref } from 'vue'
 import { useIntersectionObserver } from '@vueuse/core'
@@ -89,6 +84,7 @@ useIntersectionObserver(target, ([{ isIntersecting }], _) => {
 
   .icon {
     width: 20px;
+    height: 20px;
     color: rgba(black, 0.7);
     [data-theme='dark'] & {
       color: rgba(white, 0.7);
@@ -96,8 +92,8 @@ useIntersectionObserver(target, ([{ isIntersecting }], _) => {
   }
 
   .chevron {
-    width: 12px;
-    height: 12px;
+    width: 16px;
+    height: 16px;
     color: gray;
   }
 

--- a/packages/core/src/components/navigation/ElmTableOfContents.vue
+++ b/packages/core/src/components/navigation/ElmTableOfContents.vue
@@ -14,14 +14,14 @@
         />
       </sup>
       <ElmInlineText :text="heading.text" />
-      <BarsArrowDownIcon :class="$style.icon" />
+      <Icon icon="heroicons:bars-arrow-down" :class="$style.icon" />
     </a>
   </nav>
 </template>
 
 <script setup lang="ts">
-import { BarsArrowDownIcon } from '@heroicons/vue/24/outline'
 import ElmInlineText from '../inline/ElmInlineText.vue'
+import { Icon } from '@iconify/vue/dist/iconify.js'
 
 export interface ElmTableOfContentsProps {
   headings: Array<{
@@ -65,6 +65,7 @@ withDefaults(defineProps<ElmTableOfContentsProps>(), {})
 
     .icon {
       width: 12px;
+      height: 12px;
       color: #6987b8;
     }
   }

--- a/packages/core/src/components/others/ElmColorSample.vue
+++ b/packages/core/src/components/others/ElmColorSample.vue
@@ -10,7 +10,8 @@
           @click="copy(hex)"
         >
           <transition>
-            <CheckIcon
+            <Icon
+              icon="mdi:check"
               v-if="copied"
               :style="{ width: '16px', color: 'white' }"
             />
@@ -31,7 +32,7 @@
 import { parseToHsl, parseToRgb, rgbToColorString } from 'polished'
 import ElmTooltip from '../containments/ElmTooltip.vue'
 import { useClipboard } from '@vueuse/core'
-import { CheckIcon } from '@heroicons/vue/24/outline'
+import { Icon } from '@iconify/vue/dist/iconify.js'
 
 export interface ElmColorSampleProps {
   /**

--- a/packages/core/src/components/typography/ElmCallout.vue
+++ b/packages/core/src/components/typography/ElmCallout.vue
@@ -9,8 +9,9 @@
     }"
   >
     <div :class="$style.header">
-      <component
-        :is="colors[type].icon"
+      <Icon
+        :icon="colors[type].icon"
+        class="icon"
         :class="$style.icon"
         :style="{ '--icon-color': colors[type].code }"
       />
@@ -23,26 +24,32 @@
 </template>
 
 <script setup lang="ts">
-import {
-  ChartBarSquareIcon,
-  LightBulbIcon,
-  ShieldCheckIcon,
-  ExclamationTriangleIcon,
-  XCircleIcon
-} from '@heroicons/vue/24/outline'
+import { Icon } from '@iconify/vue/dist/iconify.js'
 import ElmInlineText from '../inline/ElmInlineText.vue'
-import { ref, type FunctionalComponent } from 'vue'
+import { ref } from 'vue'
 import { rgba } from 'polished'
 import { useIntersectionObserver } from '@vueuse/core'
 
 export type AlertType = 'note' | 'tip' | 'important' | 'warning' | 'caution'
 
-const colors: Record<AlertType, { code: string; icon: FunctionalComponent }> = {
-  note: { code: '#6987b8', icon: ChartBarSquareIcon },
-  tip: { code: '#59b57c', icon: LightBulbIcon },
-  important: { code: '#9771bd', icon: ShieldCheckIcon },
-  warning: { code: '#b8a36e', icon: ExclamationTriangleIcon },
-  caution: { code: '#b36472', icon: XCircleIcon }
+const colors: Record<AlertType, { code: string; icon: string }> = {
+  note: {
+    code: '#6987b8',
+    icon: 'mdi:information-slab-circle-outline'
+  },
+  tip: { code: '#59b57c', icon: 'mdi:lightbulb-on-outline' },
+  important: {
+    code: '#9771bd',
+    icon: 'mdi:message-alert-outline'
+  },
+  warning: {
+    code: '#b8a36e',
+    icon: 'mdi:warning-outline'
+  },
+  caution: {
+    code: '#b36472',
+    icon: 'mdi:car-brake-warning'
+  }
 }
 
 export interface ElmCalloutProps {
@@ -98,6 +105,7 @@ useIntersectionObserver(target, ([{ isIntersecting }], _) => {
 
 .icon {
   width: 20px;
+  height: 20px;
   color: var(--icon-color);
 }
 </style>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,9 +24,6 @@ importers:
       '@chromatic-com/storybook':
         specifier: ^3.2.4
         version: 3.2.4(react@18.3.1)(storybook@8.5.0(prettier@3.3.3))
-      '@heroicons/vue':
-        specifier: ^2.2.0
-        version: 2.2.0(vue@3.5.13(typescript@5.7.3))
       '@iconify/vue':
         specifier: ^4.3.0
         version: 4.3.0(vue@3.5.13(typescript@5.7.3))
@@ -1018,11 +1015,6 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
-
-  '@heroicons/vue@2.2.0':
-    resolution: {integrity: sha512-G3dbSxoeEKqbi/DFalhRxJU4mTXJn7GwZ7ae8NuEQzd1bqdd0jAbdaBZlHPcvPD2xI1iGzNVB4k20Un2AguYPw==}
-    peerDependencies:
-      vue: '>= 3'
 
   '@iconify/types@2.0.0':
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
@@ -4490,7 +4482,7 @@ snapshots:
       '@babel/traverse': 7.25.9
       '@babel/types': 7.26.0
       convert-source-map: 2.0.0
-      debug: 4.4.0(supports-color@9.4.0)
+      debug: 4.4.0
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -4630,7 +4622,7 @@ snapshots:
       '@babel/parser': 7.26.2
       '@babel/template': 7.25.9
       '@babel/types': 7.26.0
-      debug: 4.4.0(supports-color@9.4.0)
+      debug: 4.4.0
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -5136,10 +5128,6 @@ snapshots:
 
   '@esbuild/win32-x64@0.24.2':
     optional: true
-
-  '@heroicons/vue@2.2.0(vue@3.5.13(typescript@5.7.3))':
-    dependencies:
-      vue: 3.5.13(typescript@5.7.3)
 
   '@iconify/types@2.0.0': {}
 
@@ -6648,6 +6636,10 @@ snapshots:
     dependencies:
       ms: 2.0.0
 
+  debug@4.4.0:
+    dependencies:
+      ms: 2.1.3
+
   debug@4.4.0(supports-color@9.4.0):
     dependencies:
       ms: 2.1.3
@@ -6755,7 +6747,7 @@ snapshots:
 
   esbuild-register@3.6.0(esbuild@0.24.2):
     dependencies:
-      debug: 4.4.0(supports-color@9.4.0)
+      debug: 4.4.0
       esbuild: 0.24.2
     transitivePeerDependencies:
       - supports-color
@@ -8749,7 +8741,7 @@ snapshots:
       '@volar/typescript': 2.4.11
       '@vue/language-core': 2.2.0(typescript@5.7.3)
       compare-versions: 6.1.1
-      debug: 4.4.0(supports-color@9.4.0)
+      debug: 4.4.0
       kolorist: 1.8.0
       local-pkg: 0.5.1
       magic-string: 0.30.17


### PR DESCRIPTION
Replace Heroicons with Iconify components in multiple components and adjust related icon sizes. Fix text selection logic in ElmTotp to prevent out-of-bounds index.