### PR TITLE
Replace Heroicons with Iconify across components and update version

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elmethis/core",
-  "version": "1.0.0-alpha.131",
+  "version": "1.0.0-alpha.132",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/components/containments/ElmToggle.vue
+++ b/packages/core/src/components/containments/ElmToggle.vue
@@ -2,7 +2,8 @@
   <div :class="$style.toggle" :style="{ '--margin-block': margin }">
     <div :class="$style.summary" @click="handleClick">
       <div :style="{ display: 'flex', gap: '0.5rem' }">
-        <ChevronRightIcon
+        <Icon
+          icon="mdi:chevron-right"
           :class="$style.icon"
           :style="{ '--rotate': isOpen ? '90deg' : '0deg' }"
         />
@@ -11,7 +12,8 @@
           <slot v-else name="summary" />
         </div>
       </div>
-      <PlusIcon
+      <Icon
+        icon="mdi:plus"
         :class="$style.icon"
         :style="{
           '--rotate': isOpen ? '135deg' : '0deg',
@@ -30,7 +32,7 @@
 
 <script setup lang="ts">
 import ElmInlineText from '../inline/ElmInlineText.vue'
-import { ChevronRightIcon, PlusIcon } from '@heroicons/vue/24/outline'
+import { Icon } from '@iconify/vue'
 import type { Property } from 'csstype'
 
 export interface ElmToggleProps {
@@ -60,7 +62,9 @@ const handleClick = (event: Event): void => {
 <style module lang="scss">
 .toggle {
   margin-block: var(--margin-block);
-  box-shadow: 0 0 0.25rem rgba(black, 0.05);
+  box-shadow: 0 0 0.25rem rgba(black, 0.25);
+  border-radius: 0.25rem;
+  overflow: hidden;
 }
 .summary {
   box-sizing: border-box;
@@ -73,7 +77,6 @@ const handleClick = (event: Event): void => {
   align-items: center;
   gap: 0.5rem;
 
-  border: solid 1px rgba(black, 0.1);
   background-color: rgba(black, 0.05);
   [data-theme='dark'] & {
     border-color: rgba(white, 0.1);
@@ -83,6 +86,7 @@ const handleClick = (event: Event): void => {
 
 .icon {
   width: 1.25rem;
+  height: 1.25rem;
   color: var(--color, #59b57c);
   transform: rotate(var(--rotate, 0deg));
   transition: transform 200ms;
@@ -95,7 +99,7 @@ const handleClick = (event: Event): void => {
 
   border: solid 1px rgba(black, 0.1);
   border-top: none;
-  background-color: rgba(black, 0.025);
+  background-color: rgba(white, 0.025);
   [data-theme='dark'] & {
     border-color: rgba(white, 0.1);
     background-color: rgba(white, 0.025);

--- a/packages/core/src/components/data/ElmStatusMessage.vue
+++ b/packages/core/src/components/data/ElmStatusMessage.vue
@@ -1,17 +1,26 @@
 <template>
   <transition mode="out-in">
     <div v-if="status === 'pending'" :class="$style.wrapper">
-      <ArrowPathIcon :class="$style.icon" :style="{ color: '#6987b8' }" />
+      <Icon
+        icon="mdi:rotate-clockwise"
+        :class="$style.icon"
+        :style="{ color: '#6987b8' }"
+      />
       <ElmInlineText :text="message" color="#6987b8" />
     </div>
 
     <div v-else-if="status === 'error'" :class="$style.wrapper">
-      <XMarkIcon :class="$style.icon" :style="{ color: '#c56565' }" />
+      <Icon
+        icon="uis:exclamation-circle"
+        :class="$style.icon"
+        :style="{ color: '#c56565' }"
+      />
       <ElmInlineText :text="message" color="#c56565" />
     </div>
 
     <div v-else-if="status === 'warning'" :class="$style.wrapper">
-      <ExclamationTriangleIcon
+      <Icon
+        icon="ic:baseline-warning"
         :class="$style.icon"
         :style="{ color: '#cdb57b' }"
       />
@@ -19,19 +28,18 @@
     </div>
 
     <div v-else :class="$style.wrapper">
-      <CheckIcon :class="$style.icon" :style="{ color: '#59b57c' }" />
+      <Icon
+        icon="material-symbols-light:check-circle"
+        :class="$style.icon"
+        :style="{ color: '#59b57c' }"
+      />
       <ElmInlineText :text="message" color="#59b57c" />
     </div>
   </transition>
 </template>
 
 <script setup lang="ts">
-import {
-  ArrowPathIcon,
-  CheckIcon,
-  ExclamationTriangleIcon,
-  XMarkIcon
-} from '@heroicons/vue/24/outline'
+import { Icon } from '@iconify/vue'
 import ElmInlineText from '../inline/ElmInlineText.vue'
 
 export interface ElmStatusMessageProps {

--- a/packages/core/src/components/form/ElmButton.stories.tsx
+++ b/packages/core/src/components/form/ElmButton.stories.tsx
@@ -1,7 +1,11 @@
 import type { Meta, StoryObj } from '@storybook/vue3'
 import ElmButton from './ElmButton.vue'
 import ElmInlineText from '../inline/ElmInlineText.vue'
-import { PencilSquareIcon } from '@heroicons/vue/24/outline'
+
+import { Icon } from '@iconify/vue'
+import { h } from 'vue'
+
+const PencilSquareIcon = h(Icon, { icon: 'heroicons:pencil-square-16-solid' })
 
 const meta: Meta<typeof ElmButton> = {
   title: 'Components/Form/ElmButton',

--- a/packages/core/src/components/form/ElmTextField.stories.tsx
+++ b/packages/core/src/components/form/ElmTextField.stories.tsx
@@ -1,6 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/vue3'
 import ElmTextField from './ElmTextField.vue'
-import { EnvelopeIcon } from '@heroicons/vue/24/outline'
+
+import { Icon } from '@iconify/vue'
+import { h } from 'vue'
+
+const EnvelopeIcon = h(Icon, { icon: 'heroicons:envelope' })
 
 const meta: Meta<typeof ElmTextField> = {
   title: 'Components/Form/ElmTextField',

--- a/packages/core/src/components/form/ElmTextField.vue
+++ b/packages/core/src/components/form/ElmTextField.vue
@@ -45,13 +45,18 @@
           <ElmInlineText v-if="suffix != null" :text="suffix" />
         </span>
 
-        <component
+        <Icon
           v-if="isPassword"
-          :is="type === 'text' ? EyeIcon : EyeSlashIcon"
+          :icon="type === 'text' ? 'heroicons:eye' : 'heroicons:eye-slash'"
           :class="$style.icon"
           @click="handleVisibleSwitch"
         />
-        <BackspaceIcon :class="$style.icon" @click="handleDelete" />
+
+        <Icon
+          icon="heroicons:backspace-16-solid"
+          :class="$style.icon"
+          @click="handleDelete"
+        />
       </div>
     </div>
 
@@ -65,9 +70,8 @@
 </template>
 
 <script setup lang="ts">
-import { BackspaceIcon } from '@heroicons/vue/24/solid'
+import { Icon } from '@iconify/vue'
 import ElmInlineText from '../inline/ElmInlineText.vue'
-import { EyeIcon, EyeSlashIcon } from '@heroicons/vue/24/outline'
 import { ref, type VNode, type FunctionalComponent } from 'vue'
 import { nanoid } from 'nanoid'
 

--- a/packages/core/src/components/form/ElmTotp.vue
+++ b/packages/core/src/components/form/ElmTotp.vue
@@ -16,7 +16,8 @@
           {{ char }}
         </span>
       </div>
-      <BackspaceIcon :class="$style.icon" @click="reset" />
+
+      <Icon icon="heroicons:backspace" :class="$style.icon" @click="reset" />
     </div>
 
     <input
@@ -33,7 +34,7 @@
 </template>
 
 <script setup lang="ts">
-import { BackspaceIcon } from '@heroicons/vue/24/outline'
+import { Icon } from '@iconify/vue'
 import { useFocus } from '@vueuse/core'
 import { nextTick, onMounted, ref, computed } from 'vue'
 

--- a/packages/core/src/components/headings/ElmFragmentIdentifier.vue
+++ b/packages/core/src/components/headings/ElmFragmentIdentifier.vue
@@ -1,12 +1,20 @@
 <template>
   <div :class="$style.fragment">
-    <HashtagIcon :class="$style.icon" @click="handleHashClick(id)" />
-    <LinkIcon :class="$style.icon" @click="handleLinkClick(id)" />
+    <Icon
+      icon="mdi:hashtag-box-outline"
+      :class="$style.icon"
+      @click="handleHashClick(id)"
+    />
+    <Icon
+      icon="mdi:link-box-variant-outline"
+      :class="$style.icon"
+      @click="handleLinkClick(id)"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
-import { HashtagIcon, LinkIcon } from '@heroicons/vue/24/outline'
+import { Icon } from '@iconify/vue'
 import { useClipboard } from '@vueuse/core'
 import { nextTick, onMounted } from 'vue'
 

--- a/packages/core/src/components/icon/ElmBookmarkIcon.vue
+++ b/packages/core/src/components/icon/ElmBookmarkIcon.vue
@@ -12,7 +12,7 @@
       :alt="`favicon of ${name ?? href}`"
     />
 
-    <GlobeAsiaAustraliaIcon v-else :class="$style['favicon-svg']" />
+    <Icon v-else icon="mdi:globe" :class="$style['favicon-svg']" />
 
     <div :class="$style.text">
       <ElmInlineText :text="name ?? href" size=".6rem" />
@@ -21,7 +21,7 @@
 </template>
 
 <script setup lang="ts">
-import { GlobeAsiaAustraliaIcon } from '@heroicons/vue/24/outline'
+import { Icon } from '@iconify/vue'
 import ElmInlineText from '../inline/ElmInlineText.vue'
 
 export interface ElmBookmarkIconProps {

--- a/packages/core/src/components/icon/ElmLoginIcon.vue
+++ b/packages/core/src/components/icon/ElmLoginIcon.vue
@@ -1,18 +1,18 @@
 <template>
   <ElmTooltip>
     <template #original>
-      <component
+      <Icon
         :class="$style.icon"
         :style="{
           '--width': size,
-          '--color': isLogin ? '#b36472' : '#6987b8'
+          '--color': isLoading ? 'gray' : isLogin ? '#b36472' : '#6987b8'
         }"
-        :is="
+        :icon="
           isLoading
-            ? h(ElmDotLoadingIcon, { size: size })
+            ? 'svg-spinners:ring-resize'
             : isLogin
-              ? ArrowRightStartOnRectangleIcon
-              : ArrowRightEndOnRectangleIcon
+              ? 'mdi:logout-variant'
+              : 'mdi:login-variant'
         "
       />
     </template>
@@ -25,14 +25,9 @@
 </template>
 
 <script setup lang="ts">
-import {
-  ArrowRightEndOnRectangleIcon,
-  ArrowRightStartOnRectangleIcon
-} from '@heroicons/vue/24/outline'
+import { Icon } from '@iconify/vue'
 import ElmTooltip from '../containments/ElmTooltip.vue'
 import ElmInlineText from '../inline/ElmInlineText.vue'
-import ElmDotLoadingIcon from './ElmDotLoadingIcon.vue'
-import { h } from 'vue'
 
 export interface ElmLoginIconProps {
   /**
@@ -60,6 +55,7 @@ withDefaults(defineProps<ElmLoginIconProps>(), {
 .icon {
   box-sizing: border-box;
   width: var(--width);
+  height: var(--width);
   padding: 0.25rem;
   border-radius: 0.25rem;
   color: var(--color);

--- a/packages/core/src/components/inline/ElmInlineLink.stories.tsx
+++ b/packages/core/src/components/inline/ElmInlineLink.stories.tsx
@@ -12,7 +12,7 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Primary: Story = {
-  args: { text: 'elm-inline-link', href: 'https://example.com' }
+  args: { text: 'elm-inline-link', href: 'https://google.com' }
 }
 
 export const OnClick: Story = {

--- a/packages/core/src/components/inline/ElmInlineLink.vue
+++ b/packages/core/src/components/inline/ElmInlineLink.vue
@@ -7,16 +7,18 @@
     rel="noopener noreferrer"
     @click="handleClick"
   >
+    <img :src="src" alt="favicon" @error="handleError" :class="$style.icon" />
+
     {{ text }}
-    <component
-      :is="
+    <Icon
+      :icon="
         iconType != null
           ? iconType === 'internal'
-            ? ChevronRightIcon
-            : ArrowTopRightOnSquareIcon
+            ? 'mdi:chevron-right'
+            : 'mdi:external-link'
           : openInNewTab
-            ? ArrowTopRightOnSquareIcon
-            : ChevronRightIcon
+            ? 'mdi:external-link'
+            : 'mdi:chevron-right'
       "
       :class="$style.icon"
     />
@@ -24,11 +26,9 @@
 </template>
 
 <script setup lang="ts">
-import {
-  ArrowTopRightOnSquareIcon,
-  ChevronRightIcon
-} from '@heroicons/vue/24/outline'
+import { Icon } from '@iconify/vue'
 import type { Property } from 'csstype'
+import { ref } from 'vue'
 
 export interface ElmInlineLinkProps {
   /**
@@ -78,6 +78,12 @@ function handleClick(event: MouseEvent) {
     props.onClick()
   }
 }
+
+const src = ref(`https://logo.clearbit.com/${props.href}`)
+
+const handleError = () => {
+  src.value = `data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="gray" d="M17.9 17.39c-.26-.8-1.01-1.39-1.9-1.39h-1v-3a1 1 0 0 0-1-1H8v-2h2a1 1 0 0 0 1-1V7h2a2 2 0 0 0 2-2v-.41a7.984 7.984 0 0 1 2.9 12.8M11 19.93c-3.95-.49-7-3.85-7-7.93c0-.62.08-1.22.21-1.79L9 15v1a2 2 0 0 0 2 2m1-16A10 10 0 0 0 2 12a10 10 0 0 0 10 10a10 10 0 0 0 10-10A10 10 0 0 0 12 2"/></svg>`
+}
 </script>
 
 <style module lang="scss">
@@ -122,6 +128,7 @@ function handleClick(event: MouseEvent) {
 
   .icon {
     width: var(--font-size);
+    height: var(--font-size);
   }
 }
 </style>

--- a/packages/core/src/components/media/ElmFile.vue
+++ b/packages/core/src/components/media/ElmFile.vue
@@ -1,7 +1,7 @@
 <template>
   <div :class="$style.file" :style="{ '--margin-block': margin }">
     <div :class="$style['left-container']">
-      <DocumentIcon :class="$style.icon" />
+      <Icon icon="mdi:file-outline" :class="$style.icon" />
       <ElmInlineText
         :text="
           name ?? getLastPathSegmentWithoutQueryOrHash(src) ?? 'unknown file'
@@ -13,7 +13,8 @@
       <span :style="{ opacity: 0.6 }"
         ><ElmInlineText v-if="filesize" :text="filesize"
       /></span>
-      <ArrowDownTrayIcon
+      <Icon
+        icon="mdi:download"
         :class="$style['download-icon']"
         @click="
           () => {
@@ -31,7 +32,7 @@
 </template>
 
 <script setup lang="ts">
-import { ArrowDownTrayIcon, DocumentIcon } from '@heroicons/vue/24/outline'
+import { Icon } from '@iconify/vue'
 import ElmInlineText from '../inline/ElmInlineText.vue'
 import { Property } from 'csstype'
 
@@ -111,6 +112,7 @@ async function downloadFile(url: string, filename: string) {
 
     .icon {
       width: 20px;
+      height: 20px;
       transition: color 200ms;
       color: rgba(black, 0.8);
       [data-theme='dark'] & {
@@ -128,6 +130,7 @@ async function downloadFile(url: string, filename: string) {
     .download-icon {
       padding: 0.125rem;
       width: 20px;
+      height: 20px;
       cursor: pointer;
       transition:
         color 200ms,

--- a/packages/core/src/components/media/ElmImage.vue
+++ b/packages/core/src/components/media/ElmImage.vue
@@ -1,7 +1,6 @@
 <template>
   <transition mode="out-in">
     <div v-if="error" :class="$style.error">
-      <PhotoIcon :style="{ height: 24 }" />
       <ElmInlineText text="Error loading image" color="#c56565" size="1.5rem" />
     </div>
 
@@ -61,7 +60,6 @@ import ElmDotLoadingIcon from '../icon/ElmDotLoadingIcon.vue'
 import { onKeyStroke, useImage } from '@vueuse/core'
 import type { Property } from 'csstype'
 import ElmInlineText from '../inline/ElmInlineText.vue'
-import { PhotoIcon } from '@heroicons/vue/24/outline'
 
 export interface ElmImageProps {
   /**

--- a/packages/core/src/components/navigation/ElmBookmark.vue
+++ b/packages/core/src/components/navigation/ElmBookmark.vue
@@ -29,12 +29,12 @@
 
         <div :class="$style.date" v-if="createdAt != null || updatedAt != null">
           <template v-if="createdAt != null">
-            <CalendarDaysIcon :class="$style.icon" />
+            <Icon icon="mdi:calendar-month" :class="$style.icon" />
             <ElmInlineText :text="`${createdAt}`" size=".8rem" />
           </template>
 
           <template v-if="updatedAt != null">
-            <ArrowPathIcon :class="$style.icon" />
+            <Icon icon="mdi:calendar-refresh" :class="$style.icon" />
             <ElmInlineText :text="`${updatedAt}`" size=".8rem" />
           </template>
         </div>
@@ -48,7 +48,7 @@
 </template>
 
 <script setup lang="ts">
-import { CalendarDaysIcon, ArrowPathIcon } from '@heroicons/vue/24/outline'
+import { Icon } from '@iconify/vue'
 import ElmInlineLink from '../inline/ElmInlineLink.vue'
 import ElmInlineText from '../inline/ElmInlineText.vue'
 import ElmImage from '../media/ElmImage.vue'
@@ -224,6 +224,7 @@ function handleClick(event: MouseEvent) {
 
   .icon {
     width: 16px;
+    height: 16px;
 
     color: rgba(black, 0.7);
     [data-theme='dark'] & {

--- a/packages/core/src/components/navigation/ElmBreadcrumb.vue
+++ b/packages/core/src/components/navigation/ElmBreadcrumb.vue
@@ -8,14 +8,14 @@
   >
     <template v-for="(link, index) in links">
       <div :class="$style['link-container']" @click="link.onClick">
-        <component
+        <Icon
           :class="[$style.icon, $style.fade]"
-          :is="
+          :icon="
             index === 0
-              ? HomeIcon
+              ? 'mdi:home'
               : index === links.length - 1
-                ? DocumentTextIcon
-                : FolderOpenIcon
+                ? 'mdi:file-document-multiple-outline'
+                : 'mdi:folder-open-outline'
           "
           :style="{
             '--delay': `${index * 100}ms`
@@ -30,7 +30,8 @@
         />
       </div>
 
-      <ChevronRightIcon
+      <Icon
+        icon="mdi:chevron-right"
         v-if="links.length !== index + 1"
         :class="[$style.chevron, $style.fade]"
         :style="{
@@ -42,12 +43,7 @@
 </template>
 
 <script setup lang="ts">
-import {
-  ChevronRightIcon,
-  DocumentTextIcon,
-  FolderOpenIcon,
-  HomeIcon
-} from '@heroicons/vue/24/outline'
+import { Icon } from '@iconify/vue'
 import ElmInlineText from '../inline/ElmInlineText.vue'
 import { ref } from 'vue'
 import { useIntersectionObserver } from '@vueuse/core'
@@ -89,6 +85,7 @@ useIntersectionObserver(target, ([{ isIntersecting }], _) => {
 
   .icon {
     width: 20px;
+    height: 20px;
     color: rgba(black, 0.7);
     [data-theme='dark'] & {
       color: rgba(white, 0.7);
@@ -96,8 +93,8 @@ useIntersectionObserver(target, ([{ isIntersecting }], _) => {
   }
 
   .chevron {
-    width: 12px;
-    height: 12px;
+    width: 16px;
+    height: 16px;
     color: gray;
   }
 

--- a/packages/core/src/components/navigation/ElmTableOfContents.vue
+++ b/packages/core/src/components/navigation/ElmTableOfContents.vue
@@ -14,13 +14,13 @@
         />
       </sup>
       <ElmInlineText :text="heading.text" />
-      <BarsArrowDownIcon :class="$style.icon" />
+      <Icon icon="heroicons:bars-arrow-down" :class="$style.icon" />
     </a>
   </nav>
 </template>
 
 <script setup lang="ts">
-import { BarsArrowDownIcon } from '@heroicons/vue/24/outline'
+import { Icon } from '@iconify/vue'
 import ElmInlineText from '../inline/ElmInlineText.vue'
 
 export interface ElmTableOfContentsProps {
@@ -65,6 +65,7 @@ withDefaults(defineProps<ElmTableOfContentsProps>(), {})
 
     .icon {
       width: 12px;
+      height: 12px;
       color: #6987b8;
     }
   }

--- a/packages/core/src/components/others/ElmColorSample.vue
+++ b/packages/core/src/components/others/ElmColorSample.vue
@@ -10,9 +10,12 @@
           @click="copy(hex)"
         >
           <transition>
-            <CheckIcon
+            <Icon
+              icon="heroicons:check"
               v-if="copied"
-              :style="{ width: '16px', color: 'white' }"
+              :style="{ color: 'white' }"
+              width="16"
+              height="16"
             />
           </transition>
         </div>
@@ -31,7 +34,7 @@
 import { parseToHsl, parseToRgb, rgbToColorString } from 'polished'
 import ElmTooltip from '../containments/ElmTooltip.vue'
 import { useClipboard } from '@vueuse/core'
-import { CheckIcon } from '@heroicons/vue/24/outline'
+import { Icon } from '@iconify/vue'
 
 export interface ElmColorSampleProps {
   /**

--- a/packages/core/src/components/typography/ElmCallout.vue
+++ b/packages/core/src/components/typography/ElmCallout.vue
@@ -9,8 +9,8 @@
     }"
   >
     <div :class="$style.header">
-      <component
-        :is="colors[type].icon"
+      <Icon
+        :icon="colors[type].icon"
         :class="$style.icon"
         :style="{ '--icon-color': colors[type].code }"
       />
@@ -23,26 +23,20 @@
 </template>
 
 <script setup lang="ts">
-import {
-  ChartBarSquareIcon,
-  LightBulbIcon,
-  ShieldCheckIcon,
-  ExclamationTriangleIcon,
-  XCircleIcon
-} from '@heroicons/vue/24/outline'
+import { Icon } from '@iconify/vue'
 import ElmInlineText from '../inline/ElmInlineText.vue'
-import { ref, type FunctionalComponent } from 'vue'
+import { ref } from 'vue'
 import { rgba } from 'polished'
 import { useIntersectionObserver } from '@vueuse/core'
 
 export type AlertType = 'note' | 'tip' | 'important' | 'warning' | 'caution'
 
-const colors: Record<AlertType, { code: string; icon: FunctionalComponent }> = {
-  note: { code: '#6987b8', icon: ChartBarSquareIcon },
-  tip: { code: '#59b57c', icon: LightBulbIcon },
-  important: { code: '#9771bd', icon: ShieldCheckIcon },
-  warning: { code: '#b8a36e', icon: ExclamationTriangleIcon },
-  caution: { code: '#b36472', icon: XCircleIcon }
+const colors: Record<AlertType, { code: string; icon: string }> = {
+  note: { code: '#6987b8', icon: 'mdi:information-slab-box-outline' },
+  tip: { code: '#59b57c', icon: 'heroicons:light-bulb' },
+  important: { code: '#9771bd', icon: 'heroicons:shield-exclamation' },
+  warning: { code: '#b8a36e', icon: 'heroicons:exclamation-triangle' },
+  caution: { code: '#b36472', icon: 'heroicons:x-circle' }
 }
 
 export interface ElmCalloutProps {
@@ -98,6 +92,7 @@ useIntersectionObserver(target, ([{ isIntersecting }], _) => {
 
 .icon {
   width: 20px;
+  height: 20px;
   color: var(--icon-color);
 }
 </style>


### PR DESCRIPTION
Refactor components to utilize Iconify icons instead of Heroicons, enhancing consistency and flexibility. Update the version in package.json to 1.0.0-alpha.132 and modify the ElmInlineLink component's href to point to Google.