### PR TITLE
Enhance ElmBookmark with optional properties and favicon support

### DIFF
--- a/.code-workspace
+++ b/.code-workspace
@@ -24,6 +24,9 @@
   "settings": {
     "terminal.integrated.env.linux": {},
     "editor.defaultFormatter": "esbenp.prettier-vscode",
-    "editor.formatOnSave": true
+    "editor.formatOnSave": true,
+    "[rust]": {
+      "editor.defaultFormatter": "rust-lang.rust-analyzer"
+    }
   }
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,7 +292,7 @@ checksum = "7c6ba7d4eec39eaa9ab24d44a0e73a7949a1095a8b3f3abb11eddf27dbb56a53"
 
 [[package]]
 name = "elmethis-notion"
-version = "1.0.0-alpha.7"
+version = "1.0.0-alpha.8"
 dependencies = [
  "async-recursion",
  "dotenvy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,7 +292,7 @@ checksum = "7c6ba7d4eec39eaa9ab24d44a0e73a7949a1095a8b3f3abb11eddf27dbb56a53"
 
 [[package]]
 name = "elmethis-notion"
-version = "1.0.0-alpha.6"
+version = "1.0.0-alpha.7"
 dependencies = [
  "async-recursion",
  "dotenvy",

--- a/crates/elmethis-notion/Cargo.toml
+++ b/crates/elmethis-notion/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elmethis-notion"
-version = "1.0.0-alpha.7"
+version = "1.0.0-alpha.8"
 edition = "2021"
 description = "Notion to Elmethis"
 authors = ["Chomolungma Shirayuki"]

--- a/crates/elmethis-notion/Cargo.toml
+++ b/crates/elmethis-notion/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elmethis-notion"
-version = "1.0.0-alpha.6"
+version = "1.0.0-alpha.7"
 edition = "2021"
 description = "Notion to Elmethis"
 authors = ["Chomolungma Shirayuki"]

--- a/crates/elmethis-notion/src/block.rs
+++ b/crates/elmethis-notion/src/block.rs
@@ -54,9 +54,9 @@ pub struct ElmBookmark {
 
 #[derive(Serialize, Clone, Default)]
 pub struct ElmBookmarkProps {
-    pub title: String,
-    pub description: String,
-    pub image: String,
+    pub title: Option<String>,
+    pub description: Option<String>,
+    pub image: Option<String>,
     pub url: String,
     pub margin: String,
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elmethis/core",
-  "version": "1.0.0-alpha.138",
+  "version": "1.0.0-alpha.139",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/components/navigation/ElmBookmark.stories.tsx
+++ b/packages/core/src/components/navigation/ElmBookmark.stories.tsx
@@ -21,7 +21,8 @@ export const Primary: Story = {
       'https://web-toolbox.dev/__og-image__/static/en/tools/ogp-checker/og.png',
     url: 'https://web-toolbox.dev/en/tools/ogp-checker',
     createdAt: '2021-08-01',
-    updatedAt: '2021-08-01'
+    updatedAt: '2021-08-01',
+    favicon: 'https://pnpm.io/img/favicon.png'
   }
 }
 
@@ -82,6 +83,7 @@ export const NoImage: Story = {
   args: {
     url: 'https://pnpm.io/',
     title: '	Fast, disk space efficient package manager | pnpm',
-    description: 'Fast, disk space efficient package manager'
+    description: 'Fast, disk space efficient package manager',
+    favicon: 'https://pnpm.io/img/favicon.png'
   }
 }

--- a/packages/core/src/components/navigation/ElmBookmark.stories.tsx
+++ b/packages/core/src/components/navigation/ElmBookmark.stories.tsx
@@ -77,3 +77,11 @@ export const InvalidImage: Story = {
     image: 'https://pnpm.io/'
   }
 }
+
+export const NoImage: Story = {
+  args: {
+    url: 'https://pnpm.io/',
+    title: '	Fast, disk space efficient package manager | pnpm',
+    description: 'Fast, disk space efficient package manager'
+  }
+}

--- a/packages/core/src/components/navigation/ElmBookmark.vue
+++ b/packages/core/src/components/navigation/ElmBookmark.vue
@@ -13,14 +13,18 @@
       </div>
 
       <div :class="$style.typography">
-        <div :class="$style.title"><ElmInlineText :text="title" bold /></div>
+        <div :class="$style.title">
+          <ElmInlineText :text="title ?? 'No title provided'" bold />
+        </div>
 
         <div>
           <ElmInlineText
             :text="
-              description.length > 100
-                ? description.slice(0, 100) + '...'
-                : description
+              description == null
+                ? 'No description provided'
+                : description.length > 100
+                  ? description.slice(0, 100) + '...'
+                  : description
             "
             size=".8rem"
             :style="{ opacity: 0.6 }"
@@ -69,7 +73,7 @@ export interface ElmBookmarkProps {
   /**
    * The title of the bookmark.
    */
-  title: string
+  title?: string
 
   /**
    * The description of the bookmark.

--- a/packages/core/src/components/navigation/ElmBookmark.vue
+++ b/packages/core/src/components/navigation/ElmBookmark.vue
@@ -44,7 +44,14 @@
         </div>
 
         <div v-if="!hideUrl && url != null" :class="$style.link">
-          <div><ElmInlineLink :text="url" href="#" size=".8rem" /></div>
+          <div>
+            <ElmInlineText
+              :text="`${url}`"
+              size=".8rem"
+              color="#aebed9"
+              :style="{ opacity: 0.8 }"
+            />
+          </div>
         </div>
       </div>
     </a>
@@ -53,7 +60,6 @@
 
 <script setup lang="ts">
 import { Icon } from '@iconify/vue'
-import ElmInlineLink from '../inline/ElmInlineLink.vue'
 import ElmInlineText from '../inline/ElmInlineText.vue'
 import ElmImage from '../media/ElmImage.vue'
 import type { Property } from 'csstype'
@@ -111,6 +117,11 @@ export interface ElmBookmarkProps {
    * The margin of the bookmark.
    */
   margin?: Property.MarginBlock
+
+  /**
+   * The URL of the favicon.
+   */
+  favicon?: string
 }
 
 const props = withDefaults(defineProps<ElmBookmarkProps>(), {
@@ -131,18 +142,31 @@ function handleClick(event: MouseEvent) {
 <style module lang="scss">
 .parent {
   container-type: inline-size;
+  border-radius: 0.25rem;
+  box-shadow: 0 0 0.125rem rgba(black, 0.1);
+  overflow: hidden;
+
+  transition:
+    background-color 200ms,
+    transform 200ms;
+
+  &:hover {
+    background-color: rgba(#6987b8, 0.1);
+    transform: translateX(-0.125rem) translateY(-0.125rem);
+  }
+
+  &:active {
+    background-color: rgba(#59b57c, 0.1);
+    transform: translateX(0) translateY(0);
+  }
 }
 
 .bookmark {
   all: unset;
   margin-block: var(--margin-block);
   display: flex;
-  box-shadow: 0 0 0.125rem rgba(black, 0.15);
   cursor: pointer;
-  transition:
-    background-color 200ms,
-    transform 200ms;
-  background-color: rgba(white, 0.2);
+  background-color: rgba(white, 0.5);
 
   [data-theme='dark'] & {
     background-color: rgba(black, 0.2);
@@ -156,16 +180,6 @@ function handleClick(event: MouseEvent) {
       flex-direction: column;
       height: auto;
     }
-  }
-
-  &:hover {
-    background-color: rgba(#6987b8, 0.1);
-    transform: translateX(-0.125rem) translateY(-0.125rem);
-  }
-
-  &:active {
-    background-color: rgba(#59b57c, 0.1);
-    transform: translateX(0) translateY(0);
   }
 
   .image {

--- a/packages/core/src/components/navigation/ElmBookmark.vue
+++ b/packages/core/src/components/navigation/ElmBookmark.vue
@@ -8,7 +8,7 @@
       :style="{ '--margin-block': margin }"
       @click="handleClick"
     >
-      <div :class="$style.image">
+      <div v-if="image != null" :class="$style.image">
         <ElmImage :src="image" />
       </div>
 
@@ -80,7 +80,7 @@ export interface ElmBookmarkProps {
    * The image to display.
    * This can be a URL or a base64-encoded image.
    */
-  image: string
+  image?: string
 
   /**
    * The URL to navigate to.

--- a/packages/core/src/components/navigation/ElmBookmark.vue
+++ b/packages/core/src/components/navigation/ElmBookmark.vue
@@ -44,14 +44,13 @@
         </div>
 
         <div v-if="!hideUrl && url != null" :class="$style.link">
-          <div>
-            <ElmInlineText
-              :text="`${url}`"
-              size=".8rem"
-              color="#aebed9"
-              :style="{ opacity: 0.8 }"
-            />
-          </div>
+          <img
+            v-if="favicon"
+            :src="favicon"
+            alt="favicon"
+            :class="$style.favicon"
+          />
+          <ElmInlineText :text="`${url}`" size=".8rem" color="#6987b8" />
         </div>
       </div>
     </a>
@@ -222,14 +221,6 @@ function handleClick(event: MouseEvent) {
       text-overflow: ellipsis;
     }
 
-    .link {
-      width: 100%;
-      display: flex;
-      justify-content: flex-end;
-      white-space: nowrap;
-      text-overflow: ellipsis;
-    }
-
     .date {
       width: 100%;
       display: flex;
@@ -249,5 +240,20 @@ function handleClick(event: MouseEvent) {
       color: rgba(white, 0.7);
     }
   }
+}
+
+.link {
+  width: 100%;
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  gap: 0.5rem;
+}
+
+.favicon {
+  width: 16px;
+  height: 16px;
 }
 </style>


### PR DESCRIPTION
Introduce optional title, description, and image properties in ElmBookmarkProps. Replace ElmInlineLink with ElmInlineText for URL display and add favicon support. Update related components and stories accordingly. Bump version for elmethis-notion and @elmethis/core.