### PR TITLE
Add ElmInlineIcon component with support for block conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,7 +292,7 @@ checksum = "7c6ba7d4eec39eaa9ab24d44a0e73a7949a1095a8b3f3abb11eddf27dbb56a53"
 
 [[package]]
 name = "elmethis-notion"
-version = "1.0.0-alpha.14"
+version = "1.0.0-alpha.15"
 dependencies = [
  "async-recursion",
  "dotenvy",

--- a/crates/elmethis-notion/Cargo.toml
+++ b/crates/elmethis-notion/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elmethis-notion"
-version = "1.0.0-alpha.14"
+version = "1.0.0-alpha.15"
 edition = "2024"
 description = "Notion to Elmethis"
 authors = ["Chomolungma Shirayuki"]

--- a/crates/elmethis-notion/src/block.rs
+++ b/crates/elmethis-notion/src/block.rs
@@ -28,6 +28,7 @@ pub enum Block {
     ElmTableRow(ElmTableRow),
     ElmTableCell(ElmTableCell),
     ElmInlineText(ElmInlineText),
+    ElmInlineIcon(ElmInlineIcon),
 }
 
 // ListItem
@@ -276,4 +277,17 @@ pub struct ElmInlineTextProps {
     pub strikethrough: bool,
     pub code: bool,
     pub color: Option<String>,
+}
+
+// InlineIcon
+#[derive(Serialize, Clone)]
+pub struct ElmInlineIcon {
+    pub id: String,
+    pub props: ElmInlineIconProps,
+}
+
+#[derive(Serialize, Clone)]
+pub struct ElmInlineIconProps {
+    pub src: String,
+    pub alt: String,
 }

--- a/crates/elmethis-notion/src/client.rs
+++ b/crates/elmethis-notion/src/client.rs
@@ -625,47 +625,71 @@ impl Client {
     pub fn convert_rich_text(
         rich_text: Vec<notionrs::object::rich_text::RichText>,
     ) -> Vec<crate::block::Block> {
-        let mut blocks: Vec<crate::block::Block> = Vec::new();
+        let blocks: Vec<crate::block::Block> = rich_text
+            .iter()
+            .map(|r| {
+                if let notionrs::object::rich_text::RichText::Mention { mention, .. } = r {
+                    if let notionrs::object::rich_text::mention::Mention::CustomEmoji {
+                        custom_emoji,
+                    } = mention
+                    {
+                        let props = crate::block::ElmInlineIconProps {
+                            src: custom_emoji.url.to_string(),
+                            alt: custom_emoji.name.to_string(),
+                        };
 
-        for r in rich_text {
-            let annotations = match r {
-                notionrs::object::rich_text::RichText::Text { annotations, .. } => annotations,
-                notionrs::object::rich_text::RichText::Mention { annotations, .. } => annotations,
-                notionrs::object::rich_text::RichText::Equation { annotations, .. } => annotations,
-            };
+                        let block =
+                            crate::block::Block::ElmInlineIcon(crate::block::ElmInlineIcon {
+                                id: custom_emoji.id.to_string(),
+                                props,
+                            });
 
-            let plain_text = match r {
-                notionrs::object::rich_text::RichText::Text { plain_text, .. } => plain_text,
-                notionrs::object::rich_text::RichText::Mention { plain_text, .. } => plain_text,
-                notionrs::object::rich_text::RichText::Equation { plain_text, .. } => plain_text,
-            };
+                        return block;
+                    }
+                }
 
-            let props = crate::block::ElmInlineTextProps {
-                text: plain_text,
-                bold: annotations.bold,
-                italic: annotations.italic,
-                underline: annotations.underline,
-                strikethrough: annotations.strikethrough,
-                code: annotations.code,
-                color: match annotations.color {
-                    notionrs::object::color::Color::Default => None,
-                    notionrs::object::color::Color::Blue => Some(String::from("#6987b8")),
-                    notionrs::object::color::Color::Brown => Some(String::from("#8b4c3f")),
-                    notionrs::object::color::Color::Gray => Some(String::from("#868e9c")),
-                    notionrs::object::color::Color::Green => Some(String::from("#59b57c")),
-                    notionrs::object::color::Color::Orange => Some(String::from("#bf7e71")),
-                    notionrs::object::color::Color::Pink => Some(String::from("#c9699e")),
-                    notionrs::object::color::Color::Purple => Some(String::from("#9771bd")),
-                    notionrs::object::color::Color::Red => Some(String::from("#b36472")),
-                    notionrs::object::color::Color::Yellow => Some(String::from("#b8a36e")),
-                    _ => None,
-                },
-            };
+                let annotations = match r {
+                    notionrs::object::rich_text::RichText::Text { annotations, .. } => annotations,
+                    notionrs::object::rich_text::RichText::Mention { annotations, .. } => {
+                        annotations
+                    }
+                    notionrs::object::rich_text::RichText::Equation { annotations, .. } => {
+                        annotations
+                    }
+                };
 
-            blocks.push(crate::block::Block::ElmInlineText(
-                crate::block::ElmInlineText { props },
-            ));
-        }
+                let plain_text = match r {
+                    notionrs::object::rich_text::RichText::Text { plain_text, .. } => plain_text,
+                    notionrs::object::rich_text::RichText::Mention { plain_text, .. } => plain_text,
+                    notionrs::object::rich_text::RichText::Equation { plain_text, .. } => {
+                        plain_text
+                    }
+                };
+
+                let props = crate::block::ElmInlineTextProps {
+                    text: plain_text.to_string(),
+                    bold: annotations.bold,
+                    italic: annotations.italic,
+                    underline: annotations.underline,
+                    strikethrough: annotations.strikethrough,
+                    code: annotations.code,
+                    color: match annotations.color {
+                        notionrs::object::color::Color::Default => None,
+                        notionrs::object::color::Color::Blue => Some(String::from("#6987b8")),
+                        notionrs::object::color::Color::Brown => Some(String::from("#8b4c3f")),
+                        notionrs::object::color::Color::Gray => Some(String::from("#868e9c")),
+                        notionrs::object::color::Color::Green => Some(String::from("#59b57c")),
+                        notionrs::object::color::Color::Orange => Some(String::from("#bf7e71")),
+                        notionrs::object::color::Color::Pink => Some(String::from("#c9699e")),
+                        notionrs::object::color::Color::Purple => Some(String::from("#9771bd")),
+                        notionrs::object::color::Color::Red => Some(String::from("#b36472")),
+                        notionrs::object::color::Color::Yellow => Some(String::from("#b8a36e")),
+                        _ => None,
+                    },
+                };
+                crate::block::Block::ElmInlineText(crate::block::ElmInlineText { props })
+            })
+            .collect();
 
         blocks
     }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elmethis/core",
-  "version": "1.0.0-alpha.157",
+  "version": "1.0.0-alpha.158",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/components/inline/ElmInlineIcon.stories.tsx
+++ b/packages/core/src/components/inline/ElmInlineIcon.stories.tsx
@@ -11,4 +11,8 @@ const meta: Meta<typeof ElmInlineIcon> = {
 export default meta
 type Story = StoryObj<typeof meta>
 
-export const Primary: Story = {}
+export const Primary: Story = {
+  args: {
+    src: 'https://rust-lang.org/logos/rust-logo-512x512.png'
+  }
+}

--- a/packages/core/src/components/inline/ElmInlineIcon.stories.tsx
+++ b/packages/core/src/components/inline/ElmInlineIcon.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from '@storybook/vue3'
+import ElmInlineIcon from './ElmInlineIcon.vue'
+
+const meta: Meta<typeof ElmInlineIcon> = {
+  title: 'Components/Inline/ElmInlineIcon',
+  component: ElmInlineIcon,
+  tags: ['autodocs'],
+  args: {}
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Primary: Story = {}

--- a/packages/core/src/components/inline/ElmInlineIcon.vue
+++ b/packages/core/src/components/inline/ElmInlineIcon.vue
@@ -1,0 +1,21 @@
+<template>
+  <img :class="$style.icon" :src="src" :alt="alt" />
+</template>
+
+<script setup lang="ts">
+export interface ElmInlineIconProps {
+  // URL of the icon.
+  src: string
+
+  alt?: string
+}
+
+withDefaults(defineProps<ElmInlineIconProps>(), {})
+</script>
+
+<style module lang="scss">
+.icon {
+  display: inline;
+  height: 1em;
+}
+</style>

--- a/packages/core/src/components/inline/ElmInlineIcon.vue
+++ b/packages/core/src/components/inline/ElmInlineIcon.vue
@@ -15,7 +15,25 @@ withDefaults(defineProps<ElmInlineIconProps>(), {})
 
 <style module lang="scss">
 .icon {
-  display: inline;
-  height: 1em;
+  margin: 0;
+  padding: 0;
+  padding-inline: 0.125rem;
+  display: inline-block;
+  vertical-align: middle;
+  height: 1.5em;
+
+  &::selection {
+    filter: brightness(1000%);
+    background-color: var(--color, rgba(black, 0.25));
+  }
+
+  [data-theme='dark'] & {
+    color: var(--color, rgba(white, 0.7));
+
+    &::selection {
+      color: rgba(black, 0.7);
+      background-color: var(--color, rgba(white, 0.25));
+    }
+  }
 }
 </style>

--- a/packages/core/src/components/inline/ElmInlineText.vue
+++ b/packages/core/src/components/inline/ElmInlineText.vue
@@ -113,9 +113,11 @@ const render = () => {
 
 <style module lang="scss">
 .text {
+  padding: 0;
+  margin: 0;
   color: var(--color, rgba(black, 0.7));
-  font-size: var(--font-size);
-  line-height: var(--font-size);
+  font-size: var(--font-size, 1rem);
+  line-height: var(--font-size, 1rem);
   background-color: var(--background-color);
 
   &::selection {

--- a/packages/core/src/components/renderer/ElmJsonRenderer.stories.tsx
+++ b/packages/core/src/components/renderer/ElmJsonRenderer.stories.tsx
@@ -35,6 +35,29 @@ export const Primary: Story = {
   }
 }
 
+export const InlineIcon: Story = {
+  args: {
+    json: [
+      {
+        type: 'ElmInlineText',
+        props: { text: 'Rust: A language ' }
+      },
+      {
+        type: 'ElmInlineIcon',
+        props: {
+          src: 'https://upload.wikimedia.org/wikipedia/commons/thumb/d/d5/Rust_programming_language_black_logo.svg/800px-Rust_programming_language_black_logo.svg.png'
+        }
+      },
+      {
+        type: 'ElmInlineText',
+        props: {
+          text: ' empowering everyone to build reliable and efficient software.'
+        }
+      }
+    ]
+  }
+}
+
 export const Callout: Story = {
   args: {
     json: [

--- a/packages/core/src/components/renderer/ElmJsonRenderer.vue
+++ b/packages/core/src/components/renderer/ElmJsonRenderer.vue
@@ -5,6 +5,7 @@
 <script setup lang="ts">
 import ElmInlineText, { ElmInlineTextProps } from '../inline/ElmInlineText.vue'
 import ElmInlineLink, { ElmInlineLinkProps } from '../inline/ElmInlineLink.vue'
+import ElmInlineIcon, { ElmInlineIconProps } from '../inline/ElmInlineIcon.vue'
 import ElmCallout, { ElmCalloutProps } from '../typography/ElmCallout.vue'
 import ElmBulletedList, {
   ElmBulletedListProps
@@ -48,6 +49,7 @@ import { h, markRaw, VNode } from 'vue'
 type ComponentType =
   | 'ElmInlineText'
   | 'ElmInlineLink'
+  | 'ElmInlineIcon'
   | 'ElmCallout'
   | 'ElmBulletedList'
   | 'ElmNumberedList'
@@ -79,6 +81,7 @@ type ComponentType =
 type ComponentProps =
   | ElmInlineTextProps
   | ElmInlineLinkProps
+  | ElmInlineIconProps
   | ElmCalloutProps
   | ElmBulletedListProps
   | ElmNumberedListProps
@@ -124,6 +127,12 @@ interface ElmInlineLinkJsonComponent extends JsonComponentBase {
   type: 'ElmInlineLink'
   id?: string
   props?: ElmInlineLinkProps
+}
+
+interface ElmInlineIconJsonComponent extends JsonComponentBase {
+  type: 'ElmInlineIcon'
+  id?: string
+  props?: ElmInlineIconProps
 }
 
 interface ElmCalloutJsonComponent extends JsonComponentBase {
@@ -291,6 +300,7 @@ interface ElmColumnListJsonComponent extends JsonComponentBase {
 type JsonComponent =
   | ElmInlineTextJsonComponent
   | ElmInlineLinkJsonComponent
+  | ElmInlineIconJsonComponent
   | ElmCalloutJsonComponent
   | ElmBulletedListJsonComponent
   | ElmNumberedListJsonComponent
@@ -328,6 +338,7 @@ withDefaults(defineProps<ElmJsonRendererProps>(), {})
 const componentMap: Record<ComponentType, any> = {
   ElmInlineText: markRaw(ElmInlineText),
   ElmInlineLink: markRaw(ElmInlineLink),
+  ElmInlineIcon: markRaw(ElmInlineIcon),
   ElmCallout: markRaw(ElmCallout),
   ElmBulletedList: markRaw(ElmBulletedList),
   ElmNumberedList: markRaw(ElmNumberedList),


### PR DESCRIPTION
Introduce the ElmInlineIcon component along with Storybook documentation. Enhance existing components to support inline icons and update styling. Bump version numbers for related packages.