### PR TITLE
Update version to 1.0.0-alpha.25 and rename ElmImage to ElmBlockImage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,7 +292,7 @@ checksum = "7c6ba7d4eec39eaa9ab24d44a0e73a7949a1095a8b3f3abb11eddf27dbb56a53"
 
 [[package]]
 name = "elmethis-notion"
-version = "1.0.0-alpha.24"
+version = "1.0.0-alpha.25"
 dependencies = [
  "async-recursion",
  "dotenvy",

--- a/crates/elmethis-notion/Cargo.toml
+++ b/crates/elmethis-notion/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elmethis-notion"
-version = "1.0.0-alpha.24"
+version = "1.0.0-alpha.25"
 edition = "2024"
 description = "Notion to Elmethis"
 authors = ["Chomolungma Shirayuki"]

--- a/crates/elmethis-notion/src/block.rs
+++ b/crates/elmethis-notion/src/block.rs
@@ -16,7 +16,7 @@ pub enum Block {
     ElmHeading1(ElmHeading1),
     ElmHeading2(ElmHeading2),
     ElmHeading3(ElmHeading3),
-    ElmImage(ElmBlockImage),
+    ElmBlockImage(ElmBlockImage),
     ElmKatex(ElmKatex),
     ElmParagraph(ElmParagraph),
     ElmBlockQuote(ElmBlockQuote),

--- a/crates/elmethis-notion/src/client.rs
+++ b/crates/elmethis-notion/src/client.rs
@@ -413,7 +413,7 @@ impl Client {
                         margin: "2rem".to_string(),
                     };
 
-                    let image_block = crate::block::Block::ElmImage(crate::block::ElmBlockImage {
+                    let image_block = crate::block::Block::ElmBlockImage(crate::block::ElmBlockImage {
                         props,
                         id: block.id.clone(),
                     });


### PR DESCRIPTION
Bump the version of the `elmethis-notion` package and rename the `ElmImage` variant to `ElmBlockImage` in the block and client modules.