### PR TITLE
Update ElmBlockImage component and versioning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,7 +292,7 @@ checksum = "7c6ba7d4eec39eaa9ab24d44a0e73a7949a1095a8b3f3abb11eddf27dbb56a53"
 
 [[package]]
 name = "elmethis-notion"
-version = "1.0.0-alpha.25"
+version = "1.0.0-alpha.26"
 dependencies = [
  "async-recursion",
  "dotenvy",

--- a/crates/elmethis-notion/Cargo.toml
+++ b/crates/elmethis-notion/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elmethis-notion"
-version = "1.0.0-alpha.25"
+version = "1.0.0-alpha.26"
 edition = "2024"
 description = "Notion to Elmethis"
 authors = ["Chomolungma Shirayuki"]

--- a/crates/elmethis-notion/src/client.rs
+++ b/crates/elmethis-notion/src/client.rs
@@ -394,15 +394,19 @@ impl Client {
                     let (src, alt) = match image {
                         notionrs::object::file::File::External(f) => (
                             f.external.url,
-                            f.caption.map(|rich_text| {
-                                rich_text.iter().map(|t| t.to_string()).collect::<String>()
-                            }),
+                            f.caption
+                                .map(|rich_text| {
+                                    rich_text.iter().map(|t| t.to_string()).collect::<String>()
+                                })
+                                .filter(|s| !s.trim().is_empty()),
                         ),
                         notionrs::object::file::File::Uploaded(f) => (
                             f.file.url,
-                            f.caption.map(|rich_text| {
-                                rich_text.iter().map(|t| t.to_string()).collect::<String>()
-                            }),
+                            f.caption
+                                .map(|rich_text| {
+                                    rich_text.iter().map(|t| t.to_string()).collect::<String>()
+                                })
+                                .filter(|s| !s.trim().is_empty()),
                         ),
                     };
 
@@ -412,10 +416,11 @@ impl Client {
                         enable_modal: true,
                     };
 
-                    let image_block = crate::block::Block::ElmBlockImage(crate::block::ElmBlockImage {
-                        props,
-                        id: block.id.clone(),
-                    });
+                    let image_block =
+                        crate::block::Block::ElmBlockImage(crate::block::ElmBlockImage {
+                            props,
+                            id: block.id.clone(),
+                        });
 
                     blocks.push(image_block);
                 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elmethis/core",
-  "version": "1.0.0-alpha.184",
+  "version": "1.0.0-alpha.185",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/components/media/ElmBlockImage.vue
+++ b/packages/core/src/components/media/ElmBlockImage.vue
@@ -36,7 +36,10 @@
   </div>
 
   <transition>
-    <div v-if="!isLoading && alt != null" :class="$style['alt-container']">
+    <div
+      v-if="!isLoading && alt != null && alt.trim() !== ''"
+      :class="$style['alt-container']"
+    >
       <Icon icon="material-symbols:image-outline" />
       <div :class="$style['alt-text']">
         <ElmInlineText :text="alt" size="0.8rem" />


### PR DESCRIPTION
Enhance the ElmBlockImage component to ensure it only renders when alt text is non-empty. Update the package version to 1.0.0-alpha.26 and improve image caption handling in the Client.