### PR TITLE
fix(button): clear ripple setTimeout on unmount

### DIFF
--- a/packages/qwik/src/components/form/elm-button.tsx
+++ b/packages/qwik/src/components/form/elm-button.tsx
@@ -4,6 +4,7 @@ import {
   PropsOf,
   Slot,
   useSignal,
+  useTask$,
   type CSSProperties,
   type QRL,
 } from "@qwik.dev/core";
@@ -37,6 +38,7 @@ export interface ElmButtonProps extends PropsOf<"button"> {
 
 export const ElmButton = component$<ElmButtonProps>((props) => {
   const clicked = useSignal(false);
+  const timer = useSignal<ReturnType<typeof setTimeout>>();
   const {
     class: className,
     onClick$,
@@ -48,11 +50,17 @@ export const ElmButton = component$<ElmButtonProps>((props) => {
     ...rest
   } = props;
 
+  // Clear the ripple timer on unmount so it can't write to a destroyed signal.
+  useTask$(({ cleanup }) => {
+    cleanup(() => clearTimeout(timer.value));
+  });
+
   const handleClick = $(async () => {
     if (!props.isLoading && !props.disabled) {
       if (onClick$) {
         clicked.value = true;
-        setTimeout(() => (clicked.value = false), 300);
+        clearTimeout(timer.value);
+        timer.value = setTimeout(() => (clicked.value = false), 300);
         await onClick$();
       }
     }

--- a/packages/react/src/components/form/elm-button.spec.tsx
+++ b/packages/react/src/components/form/elm-button.spec.tsx
@@ -81,6 +81,23 @@ describe("[CSR] ElmButton — onClick", () => {
     fireEvent.click(container.querySelector("button")!);
     expect(onClick).not.toHaveBeenCalled();
   });
+
+  it("clears the ripple timer on unmount (no setState after unmount)", () => {
+    vi.useFakeTimers();
+    try {
+      const onClick = vi.fn();
+      const { container, unmount } = render(
+        <ElmButton onClick={onClick}>Go</ElmButton>,
+      );
+      fireEvent.click(container.querySelector("button")!);
+      unmount();
+      // Advancing past the 300ms ripple timer must not fire a setState on the
+      // now-unmounted component.
+      expect(() => vi.advanceTimersByTime(300)).not.toThrow();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe("[SSR] ElmButton", () => {

--- a/packages/react/src/components/form/elm-button.tsx
+++ b/packages/react/src/components/form/elm-button.tsx
@@ -1,4 +1,6 @@
 import {
+  useEffect,
+  useRef,
   useState,
   type ComponentPropsWithoutRef,
   type CSSProperties,
@@ -41,12 +43,16 @@ export const ElmButton = ({
   ...props
 }: ElmButtonProps) => {
   const [clicked, setClicked] = useState(false);
+  const timer = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  useEffect(() => () => clearTimeout(timer.current), []);
 
   const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
     if (!isLoading && !disabled) {
       if (onClick) {
         setClicked(true);
-        setTimeout(() => setClicked(false), 300);
+        clearTimeout(timer.current);
+        timer.current = setTimeout(() => setClicked(false), 300);
         onClick(event);
       }
     }

--- a/packages/vue/src/components/form/elm-button.tsx
+++ b/packages/vue/src/components/form/elm-button.tsx
@@ -1,5 +1,6 @@
 import {
   defineComponent,
+  onUnmounted,
   ref,
   type CSSProperties,
   type HTMLAttributes,
@@ -48,6 +49,10 @@ export const ElmButton = defineComponent({
   },
   setup(props, { attrs, slots }) {
     const clicked = ref(false);
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    // Clear the ripple timer on unmount so it can't write to a destroyed ref.
+    onUnmounted(() => clearTimeout(timer));
 
     return () => {
       const {
@@ -61,7 +66,8 @@ export const ElmButton = defineComponent({
         if (!props.isLoading && !props.disabled) {
           if (typeof onClick === "function") {
             clicked.value = true;
-            setTimeout(() => (clicked.value = false), 300);
+            clearTimeout(timer);
+            timer = setTimeout(() => (clicked.value = false), 300);
             (onClick as (event: MouseEvent) => void)(event);
           }
         }


### PR DESCRIPTION
The ripple timer scheduled on click was fire-and-forget, so it fired ~300ms later even after the component unmounted, writing state to a destroyed component. In react this surfaced as a flaky unhandled "window is not defined" error during the unit run; it is a latent defect for any consumer that unmounts an ElmButton shortly after a click.

Track the timer and clear it on unmount (and before re-scheduling) in react, qwik, and vue for parity. Adds a react regression test that unmounts after a click and advances timers.

Closes #1620

## Description

Please provide a brief description of the changes in this PR.

## Checklist

- [ ] All unit tests have passed.
- [ ] Code has been self-reviewed.
- [ ] Documentation has been updated (if applicable).
- [ ] Target branch is correct.

## Related Issues

Link any related issues or provide context if none.

## Additional Notes

Add any additional information or context.
