### PR TITLE
feat(table, tabs): horizontal scroll on narrow viewports

### DIFF
--- a/packages/qwik/package.json
+++ b/packages/qwik/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elmethis/qwik",
-  "version": "1.0.0-alpha.30",
+  "version": "1.0.0-alpha.31",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/qwik/src/components/containments/elm-tabs.module.css
+++ b/packages/qwik/src/components/containments/elm-tabs.module.css
@@ -15,11 +15,16 @@
   display: flex;
   flex-direction: row;
   border-bottom: solid 1px oklch(from var(--elmethis-color-primary) l c h / 30%);
+  overflow-x: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--elmethis-color-primary-weak)
+    var(--elmethis-color-surface-base);
 }
 
 .tab {
   box-sizing: border-box;
   min-width: 6rem;
+  flex-shrink: 0;
   padding: 1rem;
   margin: 0;
   cursor: pointer;

--- a/packages/qwik/src/components/containments/elm-tabs.module.css
+++ b/packages/qwik/src/components/containments/elm-tabs.module.css
@@ -17,7 +17,7 @@
   border-bottom: solid 1px oklch(from var(--elmethis-color-primary) l c h / 30%);
   overflow-x: auto;
   scrollbar-width: thin;
-  scrollbar-color: var(--elmethis-color-primary-weak)
+  scrollbar-color: var(--elmethis-color-neutral-weak)
     var(--elmethis-color-surface-base);
 }
 

--- a/packages/qwik/src/components/containments/elm-tabs.stories.tsx
+++ b/packages/qwik/src/components/containments/elm-tabs.stories.tsx
@@ -148,6 +148,41 @@ export const Controlled: Story = {
   render: () => <ControlledTabs />,
 };
 
+// Many tabs in a narrow (mobile-sized) frame. The tab list scrolls
+// horizontally instead of clipping the tabs that overflow the container.
+const scrollTabs = [
+  { value: "overview", label: "Overview" },
+  { value: "metrics", label: "Metrics" },
+  { value: "activity", label: "Activity" },
+  { value: "settings", label: "Settings" },
+  { value: "billing", label: "Billing" },
+  { value: "members", label: "Members" },
+];
+
+export const Scrollable: Story = {
+  render: () => (
+    <div
+      style={{ maxWidth: "320px", border: "1px dashed gray", padding: "8px" }}
+    >
+      <ElmTabs defaultValue="overview">
+        <ElmTabList>
+          {scrollTabs.map((tab) => (
+            <ElmTab key={tab.value} value={tab.value}>
+              <ElmInlineText>{tab.label}</ElmInlineText>
+            </ElmTab>
+          ))}
+        </ElmTabList>
+
+        {scrollTabs.map((tab) => (
+          <ElmTabPanel key={tab.value} value={tab.value}>
+            <ElmInlineText>{tab.label} content</ElmInlineText>
+          </ElmTabPanel>
+        ))}
+      </ElmTabs>
+    </div>
+  ),
+};
+
 // ---------------------------------------------------------------------------
 // Interaction tests. These exercise behavior via play functions and are
 // excluded from autodocs to keep the Docs page focused on visual examples.

--- a/packages/qwik/src/components/table/elm-table.module.css
+++ b/packages/qwik/src/components/table/elm-table.module.css
@@ -1,5 +1,65 @@
-.elm-table {
+/* Non-scrolling frame: owns the outer spacing and pins the edge shadows so they
+   stay glued to the viewport edges while the table scrolls underneath. */
+.elm-table-frame {
+  position: relative;
+  width: 100%;
   margin-block-start: var(--elmethis-margin-block-start);
+}
+
+.elm-table-frame::before,
+.elm-table-frame::after {
+  content: "";
+  position: absolute;
+  inset-block: 0;
+  width: 1.5rem;
+  z-index: 2;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 200ms;
+}
+
+.elm-table-frame::before {
+  inset-inline-start: 0;
+  background: linear-gradient(
+    to right,
+    oklch(from var(--elmethis-color-surface-sunken) l c h / 50%),
+    transparent
+  );
+}
+
+.elm-table-frame::after {
+  inset-inline-end: 0;
+  background: linear-gradient(
+    to left,
+    oklch(from var(--elmethis-color-surface-sunken) l c h / 50%),
+    transparent
+  );
+}
+
+/* Shadows are revealed only when there is content to scroll toward, set from the
+   scroll position in elm-table.tsx. */
+.elm-table-frame[data-overflow-start]::before {
+  opacity: 1;
+}
+
+.elm-table-frame[data-overflow-end]::after {
+  opacity: 1;
+}
+
+/* The actual scroller. Mirrors the house pattern from elm-code-block. */
+.elm-table-scroll {
+  overflow-x: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--elmethis-color-primary-weak)
+    var(--elmethis-color-surface-base);
+}
+
+.elm-table-scroll:focus-visible {
+  outline: 2px solid var(--elmethis-color-primary);
+  outline-offset: 2px;
+}
+
+.elm-table {
   border-collapse: collapse;
   border-spacing: 0;
   box-shadow: 0 0 0.125rem rgb(0 0 0 / 20%);
@@ -26,4 +86,32 @@
   flex-grow: 1;
   height: 1px;
   background-color: rgb(128 128 128 / 20%);
+}
+
+/* Sticky label column. When the first column holds row headers, pin it so the
+   labels stay visible while the data columns scroll. The structural
+   `:first-child` selector targets the lead cell of every row regardless of
+   whether the caller threaded a `columnIndex` prop, and an opaque background
+   (matched to each row's stripe) keeps scrolled cells from bleeding through. */
+.sticky-row-header :where(thead, tbody) tr > :first-child {
+  position: sticky;
+  inset-inline-start: 0;
+  z-index: 1;
+  box-shadow: 1px 0 0 oklch(from var(--elmethis-color-primary-weak) l c h / 50%);
+}
+
+.sticky-row-header thead tr > :first-child {
+  background-color: var(--elmethis-color-surface-sunken);
+}
+
+.sticky-row-header tbody tr:nth-child(odd) > :first-child {
+  background-color: var(--elmethis-color-surface-raised);
+}
+
+.sticky-row-header tbody tr:nth-child(even) > :first-child {
+  background-color: var(--elmethis-color-surface-base);
+}
+
+.sticky-row-header tbody tr:hover > :first-child {
+  background-color: var(--elmethis-color-surface-sunken);
 }

--- a/packages/qwik/src/components/table/elm-table.stories.tsx
+++ b/packages/qwik/src/components/table/elm-table.stories.tsx
@@ -17,6 +17,51 @@ const meta: Meta<ElmTableProps> = {
 export default meta;
 type Story = StoryObj<ElmTableProps>;
 
+/**
+ * Wide table inside a narrow (mobile-sized) frame. The table scrolls
+ * horizontally, edge shadows hint at off-screen columns, and the row-header
+ * column stays pinned via `hasRowHeader`. The wrapper becomes a focusable,
+ * labeled scroll region while it overflows.
+ */
+export const ScrollableWithRowHeader: Story = {
+  args: { caption: "Monthly Revenue", hasRowHeader: true },
+  render() {
+    const regions = ["North", "South", "East", "West"];
+    const months = ["January", "February", "March", "April", "May", "June"];
+    return (
+      <div
+        style={{ maxWidth: "360px", border: "1px dashed gray", padding: "8px" }}
+      >
+        <ElmTable {...this.args}>
+          <ElmTableHeader>
+            <ElmTableRow>
+              <ElmTableCell isHeader text="Region" />
+              {months.map((month) => (
+                <ElmTableCell key={month} isHeader text={month} />
+              ))}
+            </ElmTableRow>
+          </ElmTableHeader>
+
+          <ElmTableBody>
+            {regions.map((region, row) => (
+              <ElmTableRow key={region}>
+                <ElmTableCell columnIndex={0} text={region} />
+                {months.map((month, col) => (
+                  <ElmTableCell
+                    key={month}
+                    columnIndex={col + 1}
+                    text={`${(row + 1) * (col + 1) * 1000}`}
+                  />
+                ))}
+              </ElmTableRow>
+            ))}
+          </ElmTableBody>
+        </ElmTable>
+      </div>
+    );
+  },
+};
+
 export const Primary: Story = {
   render() {
     return (

--- a/packages/qwik/src/components/table/elm-table.tsx
+++ b/packages/qwik/src/components/table/elm-table.tsx
@@ -5,6 +5,7 @@ import {
   useContextProvider,
   useSignal,
   useTask$,
+  useVisibleTask$,
 } from "@qwik.dev/core";
 import styles from "./elm-table.module.css";
 import textStyles from "../../styles/text.module.css";
@@ -31,22 +32,81 @@ export const ElmTable = component$<ElmTableProps>((props) => {
   });
   useContextProvider(HasRowHeaderContext, hasRowHeader);
 
+  // Horizontal-overflow state, mirrored from the scroll container so the table
+  // can expose a keyboard-focusable, labeled scroll region only while it
+  // overflows and reveal edge shadows that hint at columns past the viewport.
+  // Stays false during SSR, so the scroll affordances are pure progressive
+  // enhancement and never reach the server markup.
+  const scrollRef = useSignal<HTMLDivElement>();
+  const canScroll = useSignal(false);
+  const atStart = useSignal(true);
+  const atEnd = useSignal(true);
+
+  // eslint-disable-next-line qwik/no-use-visible-task
+  useVisibleTask$(
+    ({ cleanup }) => {
+      const el = scrollRef.value;
+      if (el == null) return;
+
+      const measure = () => {
+        const max = el.scrollWidth - el.clientWidth;
+        canScroll.value = max > 1;
+        atStart.value = el.scrollLeft <= 1;
+        atEnd.value = el.scrollLeft >= max - 1;
+      };
+
+      measure();
+      el.addEventListener("scroll", measure, { passive: true });
+      cleanup(() => el.removeEventListener("scroll", measure));
+
+      // Guarded for the createDOM/happy-dom test env, which lacks ResizeObserver.
+      if (typeof ResizeObserver !== "undefined") {
+        const observer = new ResizeObserver(measure);
+        observer.observe(el);
+        cleanup(() => observer.disconnect());
+      }
+    },
+    { strategy: "document-ready" },
+  );
+
   return (
-    <table class={[styles["elm-table"], textStyles.text, className]} {...rest}>
-      {caption && (
-        <caption>
-          <span class={styles.caption}>
-            <span class={styles.spacing}></span>
+    <div
+      class={styles["elm-table-frame"]}
+      data-overflow-start={canScroll.value && !atStart.value ? "" : undefined}
+      data-overflow-end={canScroll.value && !atEnd.value ? "" : undefined}
+    >
+      <div
+        ref={scrollRef}
+        class={styles["elm-table-scroll"]}
+        tabIndex={canScroll.value ? 0 : undefined}
+        role={canScroll.value && caption != null ? "region" : undefined}
+        aria-label={canScroll.value && caption != null ? caption : undefined}
+      >
+        <table
+          class={[
+            styles["elm-table"],
+            textStyles.text,
+            hasRowHeader.value && styles["sticky-row-header"],
+            className,
+          ]}
+          {...rest}
+        >
+          {caption && (
+            <caption>
+              <span class={styles.caption}>
+                <span class={styles.spacing}></span>
 
-            <span class={styles["caption-inner"]}>
-              <ElmInlineText>{caption}</ElmInlineText>
-            </span>
+                <span class={styles["caption-inner"]}>
+                  <ElmInlineText>{caption}</ElmInlineText>
+                </span>
 
-            <span class={styles.spacing}></span>
-          </span>
-        </caption>
-      )}
-      <Slot />
-    </table>
+                <span class={styles.spacing}></span>
+              </span>
+            </caption>
+          )}
+          <Slot />
+        </table>
+      </div>
+    </div>
   );
 });

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elmethis/react",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "React component library for elmethis.",
   "publishConfig": {
     "access": "public"

--- a/packages/react/src/components/containments/elm-tabs.module.css
+++ b/packages/react/src/components/containments/elm-tabs.module.css
@@ -15,11 +15,16 @@
   display: flex;
   flex-direction: row;
   border-bottom: solid 1px oklch(from var(--elmethis-color-primary) l c h / 30%);
+  overflow-x: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--elmethis-color-primary-weak)
+    var(--elmethis-color-surface-base);
 }
 
 .tab {
   box-sizing: border-box;
   min-width: 6rem;
+  flex-shrink: 0;
   padding: 1rem;
   margin: 0;
   cursor: pointer;

--- a/packages/react/src/components/containments/elm-tabs.module.css
+++ b/packages/react/src/components/containments/elm-tabs.module.css
@@ -17,7 +17,7 @@
   border-bottom: solid 1px oklch(from var(--elmethis-color-primary) l c h / 30%);
   overflow-x: auto;
   scrollbar-width: thin;
-  scrollbar-color: var(--elmethis-color-primary-weak)
+  scrollbar-color: var(--elmethis-color-neutral-weak)
     var(--elmethis-color-surface-base);
 }
 

--- a/packages/react/src/components/containments/elm-tabs.stories.tsx
+++ b/packages/react/src/components/containments/elm-tabs.stories.tsx
@@ -85,3 +85,36 @@ const ControlledTabs = () => {
 export const Controlled: Story = {
   render: () => <ControlledTabs />,
 };
+
+// Many tabs in a narrow (mobile-sized) frame. The tab list scrolls
+// horizontally instead of clipping the tabs that overflow the container.
+const scrollTabs = [
+  { value: "overview", label: "Overview" },
+  { value: "metrics", label: "Metrics" },
+  { value: "activity", label: "Activity" },
+  { value: "settings", label: "Settings" },
+  { value: "billing", label: "Billing" },
+  { value: "members", label: "Members" },
+];
+
+export const Scrollable: Story = {
+  render: () => (
+    <div style={{ maxWidth: 320, border: "1px dashed gray", padding: 8 }}>
+      <ElmTabs defaultValue="overview">
+        <ElmTabList>
+          {scrollTabs.map((tab) => (
+            <ElmTab key={tab.value} value={tab.value}>
+              {tab.label}
+            </ElmTab>
+          ))}
+        </ElmTabList>
+
+        {scrollTabs.map((tab) => (
+          <ElmTabPanel key={tab.value} value={tab.value}>
+            {tab.label} content
+          </ElmTabPanel>
+        ))}
+      </ElmTabs>
+    </div>
+  ),
+};

--- a/packages/react/src/components/table/elm-table.module.css
+++ b/packages/react/src/components/table/elm-table.module.css
@@ -1,5 +1,65 @@
-.elm-table {
+/* Non-scrolling frame: owns the outer spacing and pins the edge shadows so they
+   stay glued to the viewport edges while the table scrolls underneath. */
+.elm-table-frame {
+  position: relative;
+  width: 100%;
   margin-block-start: var(--elmethis-margin-block-start);
+}
+
+.elm-table-frame::before,
+.elm-table-frame::after {
+  content: "";
+  position: absolute;
+  inset-block: 0;
+  width: 1.5rem;
+  z-index: 2;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 200ms;
+}
+
+.elm-table-frame::before {
+  inset-inline-start: 0;
+  background: linear-gradient(
+    to right,
+    oklch(from var(--elmethis-color-surface-sunken) l c h / 50%),
+    transparent
+  );
+}
+
+.elm-table-frame::after {
+  inset-inline-end: 0;
+  background: linear-gradient(
+    to left,
+    oklch(from var(--elmethis-color-surface-sunken) l c h / 50%),
+    transparent
+  );
+}
+
+/* Shadows are revealed only when there is content to scroll toward, set from the
+   scroll position in elm-table.tsx. */
+.elm-table-frame[data-overflow-start]::before {
+  opacity: 1;
+}
+
+.elm-table-frame[data-overflow-end]::after {
+  opacity: 1;
+}
+
+/* The actual scroller. Mirrors the house pattern from elm-code-block. */
+.elm-table-scroll {
+  overflow-x: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--elmethis-color-primary-weak)
+    var(--elmethis-color-surface-base);
+}
+
+.elm-table-scroll:focus-visible {
+  outline: 2px solid var(--elmethis-color-primary);
+  outline-offset: 2px;
+}
+
+.elm-table {
   border-collapse: collapse;
   border-spacing: 0;
   box-shadow: 0 0 0.125rem rgb(0 0 0 / 20%);
@@ -26,4 +86,32 @@
   flex-grow: 1;
   height: 1px;
   background-color: rgb(128 128 128 / 20%);
+}
+
+/* Sticky label column. When the first column holds row headers, pin it so the
+   labels stay visible while the data columns scroll. The structural
+   `:first-child` selector targets the lead cell of every row regardless of
+   whether the caller threaded a `columnIndex` prop, and an opaque background
+   (matched to each row's stripe) keeps scrolled cells from bleeding through. */
+.sticky-row-header :where(thead, tbody) tr > :first-child {
+  position: sticky;
+  inset-inline-start: 0;
+  z-index: 1;
+  box-shadow: 1px 0 0 oklch(from var(--elmethis-color-primary-weak) l c h / 50%);
+}
+
+.sticky-row-header thead tr > :first-child {
+  background-color: var(--elmethis-color-surface-sunken);
+}
+
+.sticky-row-header tbody tr:nth-child(odd) > :first-child {
+  background-color: var(--elmethis-color-surface-raised);
+}
+
+.sticky-row-header tbody tr:nth-child(even) > :first-child {
+  background-color: var(--elmethis-color-surface-base);
+}
+
+.sticky-row-header tbody tr:hover > :first-child {
+  background-color: var(--elmethis-color-surface-sunken);
 }

--- a/packages/react/src/components/table/elm-table.stories.tsx
+++ b/packages/react/src/components/table/elm-table.stories.tsx
@@ -17,6 +17,48 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+/**
+ * Wide table inside a narrow (mobile-sized) frame. The table scrolls
+ * horizontally, edge shadows hint at off-screen columns, and the row-header
+ * column stays pinned via `hasRowHeader`. The wrapper becomes a focusable,
+ * labeled scroll region while it overflows.
+ */
+export const ScrollableWithRowHeader: Story = {
+  args: { caption: "Monthly Revenue", hasRowHeader: true },
+  render: (args) => (
+    <div style={{ maxWidth: 360, border: "1px dashed gray", padding: 8 }}>
+      <ElmTable {...args}>
+        <ElmTableHeader>
+          <ElmTableRow>
+            <ElmTableCell isHeader text="Region" />
+            <ElmTableCell isHeader text="January" />
+            <ElmTableCell isHeader text="February" />
+            <ElmTableCell isHeader text="March" />
+            <ElmTableCell isHeader text="April" />
+            <ElmTableCell isHeader text="May" />
+            <ElmTableCell isHeader text="June" />
+          </ElmTableRow>
+        </ElmTableHeader>
+
+        <ElmTableBody>
+          {["North", "South", "East", "West"].map((region, row) => (
+            <ElmTableRow key={region}>
+              <ElmTableCell columnIndex={0} text={region} />
+              {Array.from({ length: 6 }, (_, col) => (
+                <ElmTableCell
+                  key={col}
+                  columnIndex={col + 1}
+                  text={`${(row + 1) * (col + 1) * 1000}`}
+                />
+              ))}
+            </ElmTableRow>
+          ))}
+        </ElmTableBody>
+      </ElmTable>
+    </div>
+  ),
+};
+
 export const Primary: Story = {
   render: (args) => (
     <ElmTable {...args}>

--- a/packages/react/src/components/table/elm-table.tsx
+++ b/packages/react/src/components/table/elm-table.tsx
@@ -1,5 +1,5 @@
 import type { ComponentPropsWithoutRef } from "react";
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { clsx } from "clsx";
 
 import styles from "./elm-table.module.css";
@@ -13,6 +13,55 @@ export interface ElmTableProps extends ComponentPropsWithoutRef<"table"> {
   hasRowHeader?: boolean;
 }
 
+/**
+ * Tracks horizontal overflow of the scroll container so the table can react to
+ * it: expose a keyboard-focusable, labeled scroll region only while it actually
+ * overflows, and reveal edge shadows that hint at columns past the viewport.
+ *
+ * Server render reports "no overflow" (the effect never runs), so the scroll
+ * affordances are pure progressive enhancement and never reach the SSR markup.
+ */
+const useScrollOverflow = () => {
+  const ref = useRef<HTMLDivElement>(null);
+  const [edges, setEdges] = useState({
+    canScroll: false,
+    atStart: true,
+    atEnd: true,
+  });
+
+  useEffect(() => {
+    const el = ref.current;
+    if (el == null) return;
+
+    const measure = () => {
+      const max = el.scrollWidth - el.clientWidth;
+      const next = {
+        canScroll: max > 1,
+        atStart: el.scrollLeft <= 1,
+        atEnd: el.scrollLeft >= max - 1,
+      };
+      setEdges((prev) =>
+        prev.canScroll === next.canScroll &&
+        prev.atStart === next.atStart &&
+        prev.atEnd === next.atEnd
+          ? prev
+          : next,
+      );
+    };
+
+    measure();
+    el.addEventListener("scroll", measure, { passive: true });
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    return () => {
+      el.removeEventListener("scroll", measure);
+      observer.disconnect();
+    };
+  }, []);
+
+  return { ref, ...edges };
+};
+
 export const ElmTable = ({
   className,
   caption,
@@ -25,27 +74,48 @@ export const ElmTable = ({
     [hasRowHeader],
   );
 
+  const { ref, canScroll, atStart, atEnd } = useScrollOverflow();
+
   return (
     <HasRowHeaderContext.Provider value={hasRowHeaderValue}>
-      <table
-        className={clsx(styles["elm-table"], textStyles.text, className)}
-        {...rest}
+      <div
+        className={styles["elm-table-frame"]}
+        data-overflow-start={canScroll && !atStart ? "" : undefined}
+        data-overflow-end={canScroll && !atEnd ? "" : undefined}
       >
-        {caption && (
-          <caption>
-            <span className={styles.caption}>
-              <span className={styles.spacing}></span>
+        <div
+          ref={ref}
+          className={styles["elm-table-scroll"]}
+          tabIndex={canScroll ? 0 : undefined}
+          role={canScroll && caption != null ? "region" : undefined}
+          aria-label={canScroll && caption != null ? caption : undefined}
+        >
+          <table
+            className={clsx(
+              styles["elm-table"],
+              textStyles.text,
+              hasRowHeader && styles["sticky-row-header"],
+              className,
+            )}
+            {...rest}
+          >
+            {caption && (
+              <caption>
+                <span className={styles.caption}>
+                  <span className={styles.spacing}></span>
 
-              <span className={styles["caption-inner"]}>
-                <ElmInlineText>{caption}</ElmInlineText>
-              </span>
+                  <span className={styles["caption-inner"]}>
+                    <ElmInlineText>{caption}</ElmInlineText>
+                  </span>
 
-              <span className={styles.spacing}></span>
-            </span>
-          </caption>
-        )}
-        {children}
-      </table>
+                  <span className={styles.spacing}></span>
+                </span>
+              </caption>
+            )}
+            {children}
+          </table>
+        </div>
+      </div>
     </HasRowHeaderContext.Provider>
   );
 };

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elmethis/vue",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Vue 3 component library for elmethis.",
   "publishConfig": {
     "access": "public"

--- a/packages/vue/src/components/containments/elm-tabs.module.css
+++ b/packages/vue/src/components/containments/elm-tabs.module.css
@@ -15,11 +15,16 @@
   display: flex;
   flex-direction: row;
   border-bottom: solid 1px oklch(from var(--elmethis-color-primary) l c h / 30%);
+  overflow-x: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--elmethis-color-primary-weak)
+    var(--elmethis-color-surface-base);
 }
 
 .tab {
   box-sizing: border-box;
   min-width: 6rem;
+  flex-shrink: 0;
   padding: 1rem;
   margin: 0;
   cursor: pointer;

--- a/packages/vue/src/components/containments/elm-tabs.module.css
+++ b/packages/vue/src/components/containments/elm-tabs.module.css
@@ -17,7 +17,7 @@
   border-bottom: solid 1px oklch(from var(--elmethis-color-primary) l c h / 30%);
   overflow-x: auto;
   scrollbar-width: thin;
-  scrollbar-color: var(--elmethis-color-primary-weak)
+  scrollbar-color: var(--elmethis-color-neutral-weak)
     var(--elmethis-color-surface-base);
 }
 

--- a/packages/vue/src/components/containments/elm-tabs.stories.tsx
+++ b/packages/vue/src/components/containments/elm-tabs.stories.tsx
@@ -48,6 +48,35 @@ export const DefaultSelected: Story = {
   render: () => sampleTemplate("tab3"),
 };
 
+// Many tabs in a narrow (mobile-sized) frame. The tab list scrolls
+// horizontally instead of clipping the tabs that overflow the container.
+export const Scrollable: Story = {
+  render: () => ({
+    components: { ElmTabs, ElmTabList, ElmTab, ElmTabPanel },
+    setup() {
+      const tabs = [
+        { value: "overview", label: "Overview" },
+        { value: "metrics", label: "Metrics" },
+        { value: "activity", label: "Activity" },
+        { value: "settings", label: "Settings" },
+        { value: "billing", label: "Billing" },
+        { value: "members", label: "Members" },
+      ];
+      return { tabs };
+    },
+    template: `
+      <div style="max-width: 320px; border: 1px dashed gray; padding: 8px">
+        <ElmTabs default-value="overview">
+          <ElmTabList>
+            <ElmTab v-for="t in tabs" :key="t.value" :value="t.value">{{ t.label }}</ElmTab>
+          </ElmTabList>
+          <ElmTabPanel v-for="t in tabs" :key="t.value" :value="t.value">{{ t.label }} content</ElmTabPanel>
+        </ElmTabs>
+      </div>
+    `,
+  }),
+};
+
 export const Controlled: Story = {
   render: () => ({
     components: { ElmTabs, ElmTabList, ElmTab, ElmTabPanel, ElmParagraph },

--- a/packages/vue/src/components/table/elm-table.module.css
+++ b/packages/vue/src/components/table/elm-table.module.css
@@ -1,5 +1,65 @@
-.elm-table {
+/* Non-scrolling frame: owns the outer spacing and pins the edge shadows so they
+   stay glued to the viewport edges while the table scrolls underneath. */
+.elm-table-frame {
+  position: relative;
+  width: 100%;
   margin-block-start: var(--elmethis-margin-block-start);
+}
+
+.elm-table-frame::before,
+.elm-table-frame::after {
+  content: "";
+  position: absolute;
+  inset-block: 0;
+  width: 1.5rem;
+  z-index: 2;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 200ms;
+}
+
+.elm-table-frame::before {
+  inset-inline-start: 0;
+  background: linear-gradient(
+    to right,
+    oklch(from var(--elmethis-color-surface-sunken) l c h / 50%),
+    transparent
+  );
+}
+
+.elm-table-frame::after {
+  inset-inline-end: 0;
+  background: linear-gradient(
+    to left,
+    oklch(from var(--elmethis-color-surface-sunken) l c h / 50%),
+    transparent
+  );
+}
+
+/* Shadows are revealed only when there is content to scroll toward, set from the
+   scroll position in elm-table.tsx. */
+.elm-table-frame[data-overflow-start]::before {
+  opacity: 1;
+}
+
+.elm-table-frame[data-overflow-end]::after {
+  opacity: 1;
+}
+
+/* The actual scroller. Mirrors the house pattern from elm-code-block. */
+.elm-table-scroll {
+  overflow-x: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--elmethis-color-primary-weak)
+    var(--elmethis-color-surface-base);
+}
+
+.elm-table-scroll:focus-visible {
+  outline: 2px solid var(--elmethis-color-primary);
+  outline-offset: 2px;
+}
+
+.elm-table {
   border-collapse: collapse;
   border-spacing: 0;
   box-shadow: 0 0 0.125rem rgb(0 0 0 / 20%);
@@ -26,4 +86,32 @@
   flex-grow: 1;
   height: 1px;
   background-color: rgb(128 128 128 / 20%);
+}
+
+/* Sticky label column. When the first column holds row headers, pin it so the
+   labels stay visible while the data columns scroll. The structural
+   `:first-child` selector targets the lead cell of every row regardless of
+   whether the caller threaded a `columnIndex` prop, and an opaque background
+   (matched to each row's stripe) keeps scrolled cells from bleeding through. */
+.sticky-row-header :where(thead, tbody) tr > :first-child {
+  position: sticky;
+  inset-inline-start: 0;
+  z-index: 1;
+  box-shadow: 1px 0 0 oklch(from var(--elmethis-color-primary-weak) l c h / 50%);
+}
+
+.sticky-row-header thead tr > :first-child {
+  background-color: var(--elmethis-color-surface-sunken);
+}
+
+.sticky-row-header tbody tr:nth-child(odd) > :first-child {
+  background-color: var(--elmethis-color-surface-raised);
+}
+
+.sticky-row-header tbody tr:nth-child(even) > :first-child {
+  background-color: var(--elmethis-color-surface-base);
+}
+
+.sticky-row-header tbody tr:hover > :first-child {
+  background-color: var(--elmethis-color-surface-sunken);
 }

--- a/packages/vue/src/components/table/elm-table.stories.tsx
+++ b/packages/vue/src/components/table/elm-table.stories.tsx
@@ -18,6 +18,55 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+/**
+ * Wide table inside a narrow (mobile-sized) frame. The table scrolls
+ * horizontally, edge shadows hint at off-screen columns, and the row-header
+ * column stays pinned via `hasRowHeader`. The wrapper becomes a focusable,
+ * labeled scroll region while it overflows.
+ */
+export const ScrollableWithRowHeader: Story = {
+  args: { caption: "Monthly Revenue", hasRowHeader: true },
+  render: (args) => ({
+    components: {
+      ElmTable,
+      ElmTableHeader,
+      ElmTableBody,
+      ElmTableRow,
+      ElmTableCell,
+    },
+    setup() {
+      const regions = ["North", "South", "East", "West"];
+      const months = ["January", "February", "March", "April", "May", "June"];
+      const cell = (row: number, col: number) =>
+        String((row + 1) * (col + 1) * 1000);
+      return { args, regions, months, cell };
+    },
+    template: `
+      <div :style="{ maxWidth: '360px', border: '1px dashed gray', padding: '8px' }">
+        <ElmTable v-bind="args">
+          <ElmTableHeader>
+            <ElmTableRow>
+              <ElmTableCell is-header text="Region" />
+              <ElmTableCell v-for="m in months" :key="m" is-header :text="m" />
+            </ElmTableRow>
+          </ElmTableHeader>
+          <ElmTableBody>
+            <ElmTableRow v-for="(region, row) in regions" :key="region">
+              <ElmTableCell :column-index="0" :text="region" />
+              <ElmTableCell
+                v-for="(m, col) in months"
+                :key="m"
+                :column-index="col + 1"
+                :text="cell(row, col)"
+              />
+            </ElmTableRow>
+          </ElmTableBody>
+        </ElmTable>
+      </div>
+    `,
+  }),
+};
+
 export const Primary: Story = {
   render: (args) => ({
     components: {

--- a/packages/vue/src/components/table/elm-table.tsx
+++ b/packages/vue/src/components/table/elm-table.tsx
@@ -1,4 +1,12 @@
-import { computed, defineComponent, provide, type HTMLAttributes } from "vue";
+import {
+  computed,
+  defineComponent,
+  onBeforeUnmount,
+  onMounted,
+  provide,
+  ref,
+  type HTMLAttributes,
+} from "vue";
 import { clsx } from "clsx";
 
 import styles from "./elm-table.module.css";
@@ -14,35 +22,110 @@ export interface ElmTableProps extends HTMLAttributes {
 
 export const ElmTable = defineComponent({
   name: "ElmTable",
+  // Wrappers now sit above <table>, so attr fallthrough is disabled and the
+  // native attrs (class, id, style, listeners…) are forwarded onto <table>
+  // manually below — matching where they landed before the wrappers existed.
+  inheritAttrs: false,
   props: {
     caption: { type: String, default: undefined },
     hasRowHeader: { type: Boolean, default: false },
   },
-  setup(props, { slots }) {
+  setup(props, { attrs, slots }) {
     provide(
       HasRowHeaderContext,
       computed(() => props.hasRowHeader),
     );
 
-    // `class` (and other native attrs) ride attr fallthrough onto <table>;
-    // Vue merges the fallthrough class with the binding below.
-    return () => (
-      <table class={clsx(styles["elm-table"], textStyles.text)}>
-        {props.caption && (
-          <caption>
-            <span class={styles.caption}>
-              <span class={styles.spacing}></span>
+    // Horizontal-overflow state, mirrored from the scroll container so the
+    // table can expose a keyboard-focusable, labeled scroll region only while
+    // it overflows and reveal edge shadows that hint at columns past the
+    // viewport. Stays false during SSR, so the scroll affordances are pure
+    // progressive enhancement and never reach the server markup.
+    const scrollRef = ref<HTMLDivElement | null>(null);
+    const canScroll = ref(false);
+    const atStart = ref(true);
+    const atEnd = ref(true);
 
-              <span class={styles["caption-inner"]}>
-                <ElmInlineText>{props.caption}</ElmInlineText>
-              </span>
+    const measure = () => {
+      const el = scrollRef.value;
+      if (el == null) return;
+      const max = el.scrollWidth - el.clientWidth;
+      canScroll.value = max > 1;
+      atStart.value = el.scrollLeft <= 1;
+      atEnd.value = el.scrollLeft >= max - 1;
+    };
 
-              <span class={styles.spacing}></span>
-            </span>
-          </caption>
-        )}
-        {slots.default?.()}
-      </table>
-    );
+    let observer: ResizeObserver | null = null;
+    onMounted(() => {
+      const el = scrollRef.value;
+      if (el == null) return;
+      measure();
+      el.addEventListener("scroll", measure, { passive: true });
+      // Guarded for the jsdom test env, which lacks ResizeObserver.
+      if (typeof ResizeObserver !== "undefined") {
+        observer = new ResizeObserver(measure);
+        observer.observe(el);
+      }
+    });
+    onBeforeUnmount(() => {
+      scrollRef.value?.removeEventListener("scroll", measure);
+      observer?.disconnect();
+    });
+
+    return () => {
+      const { class: className, ...restAttrs } = attrs as Record<
+        string,
+        unknown
+      >;
+
+      return (
+        <div
+          class={styles["elm-table-frame"]}
+          data-overflow-start={
+            canScroll.value && !atStart.value ? "" : undefined
+          }
+          data-overflow-end={canScroll.value && !atEnd.value ? "" : undefined}
+        >
+          <div
+            ref={scrollRef}
+            class={styles["elm-table-scroll"]}
+            tabindex={canScroll.value ? 0 : undefined}
+            role={
+              canScroll.value && props.caption != null ? "region" : undefined
+            }
+            aria-label={
+              canScroll.value && props.caption != null
+                ? props.caption
+                : undefined
+            }
+          >
+            <table
+              class={clsx(
+                styles["elm-table"],
+                textStyles.text,
+                props.hasRowHeader && styles["sticky-row-header"],
+                className as string | undefined,
+              )}
+              {...restAttrs}
+            >
+              {props.caption && (
+                <caption>
+                  <span class={styles.caption}>
+                    <span class={styles.spacing}></span>
+
+                    <span class={styles["caption-inner"]}>
+                      <ElmInlineText>{props.caption}</ElmInlineText>
+                    </span>
+
+                    <span class={styles.spacing}></span>
+                  </span>
+                </caption>
+              )}
+              {slots.default?.()}
+            </table>
+          </div>
+        </div>
+      );
+    };
   },
 });


### PR DESCRIPTION
## Summary

Wide `ElmTable`s and overflowing `ElmTabs` lists no longer break out of / get clipped on mobile — both now scroll horizontally. Ported across **react**, **qwik**, and **vue** (qwik is the lead per `CLAUDE.md`).

### `ElmTable` — responsive scroll container
- Wraps the table in a non-scrolling frame + `overflow-x: auto` scroller, so wide tables scroll instead of overflowing the page.
- **Edge shadows** that appear only when there's off-screen content (toggled from scroll position).
- A keyboard-focusable, caption-labeled `role="region"` — but only while it overflows, so there's no dead tab stop on tables that fit.
- **Sticky row-header column** when `hasRowHeader` is set, so the label column stays visible while data scrolls.
- Overflow state is detected client-side (`ResizeObserver` + scroll listener) and stays `false` during SSR — pure progressive enhancement, never in the server markup.
- Themed thin scrollbar via `scrollbar-color`.

### `ElmTabs` — scroll the tab list instead of clipping
- The tab list was a flex row with no overflow handling inside `.elm-tabs { overflow: hidden }`, so tabs past the container width were clipped and unreachable.
- `.tab-container` gets `overflow-x: auto` + themed thin scrollbar; `.tab` gets `flex-shrink: 0` so tabs keep their width and scroll rather than cram.

Each package also gains a `ScrollableWithRowHeader` (table) and `Scrollable` (tabs) story demonstrating the overflow.

## Verification
- Unit tests, `tsc`/`vue-tsc`, eslint, and stylelint pass in all three packages.
- Live-checked in a 320–390px viewport (react, qwik, vue): overflow detection, focusable labeled region, edge-shadow toggling on scroll, pinned sticky `<th>` column, and tab-list scroll all behave identically. The qwik resumability path (`useVisibleTask$` + `document-ready`) was confirmed working.

## Versions
- `@elmethis/react` 0.10.0 → 0.11.0
- `@elmethis/vue` 0.8.0 → 0.9.0
- `@elmethis/qwik` 1.0.0-alpha.30 → 1.0.0-alpha.31

## Follow-up
`ElmTabs` tabs are `<div onClick>` with no ARIA roles / keyboard support (pre-existing) — tracked in #1649. With real focus management, scroll-into-view follows focus for free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)