### PR TITLE
feat(ag-ui-stub): add deterministic LLM-free AG-UI test-double package

### DIFF
--- a/.github/workflows/ag-ui-stub.yml
+++ b/.github/workflows/ag-ui-stub.yml
@@ -1,0 +1,151 @@
+name: AG-UI Stub
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+env:
+  NODE_VERSION: 22.x
+
+jobs:
+  lint:
+    name: Lint (@elmethis/ag-ui-stub)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: "https://registry.npmjs.org"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Lint
+        run: pnpm run lint
+        working-directory: packages/ag-ui-stub
+
+  format-check:
+    name: Format Check (@elmethis/ag-ui-stub)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: "https://registry.npmjs.org"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Format Check
+        run: pnpm run fmt.check
+        working-directory: packages/ag-ui-stub
+
+  type-check:
+    name: Type Check (@elmethis/ag-ui-stub)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: "https://registry.npmjs.org"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Type Check
+        run: pnpm run build.types
+        working-directory: packages/ag-ui-stub
+
+  build:
+    name: Build (@elmethis/ag-ui-stub)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: "https://registry.npmjs.org"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build
+        run: pnpm run build
+        working-directory: packages/ag-ui-stub
+
+  test-unit:
+    name: Test Unit (@elmethis/ag-ui-stub)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: "https://registry.npmjs.org"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Test Unit (with coverage)
+        run: pnpm run test.coverage
+        working-directory: packages/ag-ui-stub
+
+      # Visibility only — never fails the build.
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: packages/ag-ui-stub/coverage/lcov.info
+          flags: ag-ui-stub
+          fail_ci_if_error: false

--- a/packages/ag-ui-stub/.gitignore
+++ b/packages/ag-ui-stub/.gitignore
@@ -1,0 +1,1 @@
+coverage/

--- a/packages/ag-ui-stub/README.md
+++ b/packages/ag-ui-stub/README.md
@@ -1,0 +1,56 @@
+# @elmethis/ag-ui-stub
+
+A deterministic, **LLM-free** AG-UI test double. It speaks the same wire
+contract as a real agent backend (POST `RunAgentInput` → SSE stream of
+`BaseEvent`s) but replays canned, scripted scenarios — so Storybook, unit tests,
+and `*.browser.spec.tsx` can exercise every branch of the `@elmethis`
+ag-ui-client components without an API key, network, cost, or flakiness.
+
+> `@ag-ui/*` is pinned to **0.0.57** to match `@ag-ui/client` in
+> `@elmethis/qwik`, so encoded event shapes line up with what the components
+> expect. (The `copilotkit` backend tracks the separate `@ag-ui/mastra` 1.x
+> line.)
+
+## Two layers
+
+### 1. `agUiResponse` — the framework-agnostic primitive
+
+```ts
+import { agUiResponse, scenarios } from "@elmethis/ag-ui-stub";
+
+const response = agUiResponse(scenarios["tool-call"], runAgentInput);
+// → Web-standard Response, body is the AG-UI SSE stream
+```
+
+Runs anywhere (Hono, Node, workerd) — and with **no server at all** in tests.
+`HttpAgent` accepts an injected `fetch`, so:
+
+```ts
+import { HttpAgent } from "@ag-ui/client";
+import { createStubFetch } from "@elmethis/ag-ui-stub";
+
+const agent = new HttpAgent({
+  url: "http://stub/agent/tool-call/run",
+  fetch: createStubFetch(), // scenario picked from the URL path
+});
+```
+
+### 2. The Hono server — for Storybook & manual dev
+
+```sh
+pnpm --filter @elmethis/ag-ui-stub serve   # PORT=19103
+# POST http://localhost:19103/stub/agent/<scenario>/run  (optional ?delay=<ms>)
+```
+
+Point a Storybook story's `url` at it instead of the live backend.
+
+## Scenarios
+
+`full` (a complete reason → act → state → answer run, with `STEP_*`
+delimiters), `text-stream`, `tool-call`, `state`, `reasoning`, `interrupt`
+(HITL, honors `resume`), `messages-snapshot`, `error`, `long-stream`. The
+single-feature ones each map to a renderer branch a real LLM rarely triggers on
+demand; `full` drives them all at once in one realistic stream.
+
+`chunkDelayMs` (or the server's `?delay=`) paces chunks for streaming UI; it
+defaults to `0` so tests run at full speed.

--- a/packages/ag-ui-stub/eslint.config.js
+++ b/packages/ag-ui-stub/eslint.config.js
@@ -1,0 +1,31 @@
+import js from "@eslint/js";
+import globals from "globals";
+import tseslint from "typescript-eslint";
+import { defineConfig, globalIgnores } from "eslint/config";
+
+export default defineConfig([
+  globalIgnores(["dist", "node_modules"]),
+  {
+    files: ["**/*.{ts,tsx}"],
+    extends: [js.configs.recommended, tseslint.configs.recommended],
+    languageOptions: {
+      ecmaVersion: 2020,
+      globals: {
+        ...globals.node,
+        ...globals.browser,
+      },
+    },
+    rules: {
+      "@typescript-eslint/no-empty-object-type": "off",
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          varsIgnorePattern: "^_",
+          argsIgnorePattern: "^_",
+          destructuredArrayIgnorePattern: "^_",
+          caughtErrorsIgnorePattern: "^_",
+        },
+      ],
+    },
+  },
+]);

--- a/packages/ag-ui-stub/package.json
+++ b/packages/ag-ui-stub/package.json
@@ -1,0 +1,70 @@
+{
+  "name": "@elmethis/ag-ui-stub",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Deterministic, LLM-free AG-UI test-double server: a Web-standard Response/SSE generator plus a Hono harness used to exercise the @elmethis ag-ui-client components.",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.mts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./scenarios": {
+      "import": {
+        "types": "./dist/scenarios.d.mts",
+        "default": "./dist/scenarios.mjs"
+      },
+      "require": {
+        "types": "./dist/scenarios.d.cts",
+        "default": "./dist/scenarios.cjs"
+      }
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsdown",
+    "dev": "tsdown --watch",
+    "serve": "PORT=19103 tsx watch src/server.ts",
+    "start": "PORT=19103 tsx src/server.ts",
+    "fmt": "prettier --write ./src",
+    "fmt.check": "prettier --check ./src",
+    "lint": "eslint \"src/**/*.ts*\"",
+    "build.types": "tsc --noEmit -p tsconfig.json",
+    "test.unit": "vitest --run",
+    "test.coverage": "vitest --run --coverage",
+    "check": "concurrently -g \"pnpm:fmt.check\" \"pnpm:lint\" \"pnpm:build.types\"",
+    "check.ci": "concurrently -g \"pnpm:check\" \"pnpm:build\" \"pnpm:test.unit\""
+  },
+  "dependencies": {
+    "@ag-ui/core": "0.0.57",
+    "@ag-ui/encoder": "0.0.57",
+    "@hono/node-server": "^2.0.4",
+    "consola": "^3.4.2",
+    "hono": "^4.12.25"
+  },
+  "devDependencies": {
+    "@eslint/js": "latest",
+    "@types/node": "25.7.0",
+    "@vitest/coverage-v8": "^4.1.9",
+    "concurrently": "^10.0.3",
+    "eslint": "^10.5.0",
+    "globals": "^17.6.0",
+    "prettier": "3.8.4",
+    "tsdown": "^0.22.3",
+    "tsx": "^4.22.4",
+    "typescript": "5.9.3",
+    "typescript-eslint": "^8.61.1",
+    "vitest": "^4.1.8"
+  }
+}

--- a/packages/ag-ui-stub/src/delay.ts
+++ b/packages/ag-ui-stub/src/delay.ts
@@ -1,0 +1,9 @@
+/**
+ * Build a `delay()` thunk for a scenario. A non-positive delay resolves
+ * immediately (no timer scheduled) so deterministic tests run at full speed;
+ * a positive delay paces each chunk for Storybook / manual streaming demos.
+ */
+export function makeDelay(ms: number): () => Promise<void> {
+  if (!Number.isFinite(ms) || ms <= 0) return () => Promise.resolve();
+  return () => new Promise<void>((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/ag-ui-stub/src/encode.ts
+++ b/packages/ag-ui-stub/src/encode.ts
@@ -1,0 +1,37 @@
+import type { BaseEvent } from "@ag-ui/core";
+import { EventEncoder } from "@ag-ui/encoder";
+
+/** The content type AG-UI `HttpAgent` requests and this stub always serves. */
+export const SSE_CONTENT_TYPE = "text/event-stream";
+
+/**
+ * Encode an async stream of AG-UI events as a Server-Sent Events
+ * `ReadableStream`. The stream is *pull-based*: exactly one event is encoded
+ * per consumer `pull`, so a slow client applies real backpressure to the
+ * scenario generator (exercised by the `long-stream` scenario).
+ */
+export function eventsToSseStream(
+  events: AsyncIterable<BaseEvent>,
+): ReadableStream<Uint8Array> {
+  const encoder = new EventEncoder();
+  const textEncoder = new TextEncoder();
+  const iterator = events[Symbol.asyncIterator]();
+
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      try {
+        const { value, done } = await iterator.next();
+        if (done) {
+          controller.close();
+          return;
+        }
+        controller.enqueue(textEncoder.encode(encoder.encodeSSE(value)));
+      } catch (error) {
+        controller.error(error);
+      }
+    },
+    async cancel() {
+      await iterator.return?.();
+    },
+  });
+}

--- a/packages/ag-ui-stub/src/events.ts
+++ b/packages/ag-ui-stub/src/events.ts
@@ -1,0 +1,190 @@
+import {
+  EventType,
+  type Interrupt,
+  type Message,
+  type ReasoningEndEvent,
+  type ReasoningMessageContentEvent,
+  type ReasoningMessageEndEvent,
+  type ReasoningMessageStartEvent,
+  type ReasoningStartEvent,
+  type RunErrorEvent,
+  type RunFinishedEvent,
+  type RunStartedEvent,
+  type StepFinishedEvent,
+  type StepStartedEvent,
+  type StateDeltaEvent,
+  type StateSnapshotEvent,
+  type MessagesSnapshotEvent,
+  type TextMessageContentEvent,
+  type TextMessageEndEvent,
+  type TextMessageStartEvent,
+  type ToolCallArgsEvent,
+  type ToolCallEndEvent,
+  type ToolCallResultEvent,
+  type ToolCallStartEvent,
+} from "@ag-ui/core";
+
+/**
+ * Typed event factories. Every helper sets the discriminating `type` field, so
+ * scenarios stay terse and can never drift from the `@ag-ui/core` schema.
+ */
+
+type Role = TextMessageStartEvent["role"];
+
+// — Run lifecycle —
+
+export const runStarted = (
+  threadId: string,
+  runId: string,
+): RunStartedEvent => ({ type: EventType.RUN_STARTED, threadId, runId });
+
+export const runFinished = (
+  threadId: string,
+  runId: string,
+): RunFinishedEvent => ({ type: EventType.RUN_FINISHED, threadId, runId });
+
+export const runFinishedInterrupt = (
+  threadId: string,
+  runId: string,
+  interrupts: Interrupt[],
+): RunFinishedEvent => ({
+  type: EventType.RUN_FINISHED,
+  threadId,
+  runId,
+  outcome: { type: "interrupt", interrupts },
+});
+
+export const runError = (message: string, code?: string): RunErrorEvent => ({
+  type: EventType.RUN_ERROR,
+  message,
+  ...(code !== undefined ? { code } : {}),
+});
+
+// — Steps —
+
+export const stepStarted = (stepName: string): StepStartedEvent => ({
+  type: EventType.STEP_STARTED,
+  stepName,
+});
+
+export const stepFinished = (stepName: string): StepFinishedEvent => ({
+  type: EventType.STEP_FINISHED,
+  stepName,
+});
+
+// — Text messages —
+
+export const textStart = (
+  messageId: string,
+  role: Role = "assistant",
+): TextMessageStartEvent => ({
+  type: EventType.TEXT_MESSAGE_START,
+  messageId,
+  role,
+});
+
+export const textContent = (
+  messageId: string,
+  delta: string,
+): TextMessageContentEvent => ({
+  type: EventType.TEXT_MESSAGE_CONTENT,
+  messageId,
+  delta,
+});
+
+export const textEnd = (messageId: string): TextMessageEndEvent => ({
+  type: EventType.TEXT_MESSAGE_END,
+  messageId,
+});
+
+// — Tool calls —
+
+export const toolCallStart = (
+  toolCallId: string,
+  toolCallName: string,
+  parentMessageId?: string,
+): ToolCallStartEvent => ({
+  type: EventType.TOOL_CALL_START,
+  toolCallId,
+  toolCallName,
+  ...(parentMessageId !== undefined ? { parentMessageId } : {}),
+});
+
+export const toolCallArgs = (
+  toolCallId: string,
+  delta: string,
+): ToolCallArgsEvent => ({
+  type: EventType.TOOL_CALL_ARGS,
+  toolCallId,
+  delta,
+});
+
+export const toolCallEnd = (toolCallId: string): ToolCallEndEvent => ({
+  type: EventType.TOOL_CALL_END,
+  toolCallId,
+});
+
+export const toolCallResult = (
+  toolCallId: string,
+  content: string,
+  messageId: string,
+): ToolCallResultEvent => ({
+  type: EventType.TOOL_CALL_RESULT,
+  messageId,
+  toolCallId,
+  content,
+});
+
+// — State —
+
+export const stateSnapshot = (snapshot: unknown): StateSnapshotEvent => ({
+  type: EventType.STATE_SNAPSHOT,
+  snapshot,
+});
+
+export const stateDelta = (
+  delta: StateDeltaEvent["delta"],
+): StateDeltaEvent => ({ type: EventType.STATE_DELTA, delta });
+
+export const messagesSnapshot = (
+  messages: Message[],
+): MessagesSnapshotEvent => ({
+  type: EventType.MESSAGES_SNAPSHOT,
+  messages,
+});
+
+// — Reasoning —
+
+export const reasoningStart = (messageId: string): ReasoningStartEvent => ({
+  type: EventType.REASONING_START,
+  messageId,
+});
+
+export const reasoningMessageStart = (
+  messageId: string,
+): ReasoningMessageStartEvent => ({
+  type: EventType.REASONING_MESSAGE_START,
+  messageId,
+  role: "reasoning",
+});
+
+export const reasoningMessageContent = (
+  messageId: string,
+  delta: string,
+): ReasoningMessageContentEvent => ({
+  type: EventType.REASONING_MESSAGE_CONTENT,
+  messageId,
+  delta,
+});
+
+export const reasoningMessageEnd = (
+  messageId: string,
+): ReasoningMessageEndEvent => ({
+  type: EventType.REASONING_MESSAGE_END,
+  messageId,
+});
+
+export const reasoningEnd = (messageId: string): ReasoningEndEvent => ({
+  type: EventType.REASONING_END,
+  messageId,
+});

--- a/packages/ag-ui-stub/src/index.ts
+++ b/packages/ag-ui-stub/src/index.ts
@@ -1,0 +1,18 @@
+/**
+ * @elmethis/ag-ui-stub — a deterministic, LLM-free AG-UI test double.
+ *
+ * Two layers:
+ * - {@link agUiResponse}: a Web-standard `Response` (SSE) generator usable in
+ *   any runtime and directly in tests via {@link createStubFetch}.
+ * - a Hono server (`src/server.ts`) that mounts the scenarios over HTTP for
+ *   Storybook and manual development.
+ */
+
+export { agUiResponse, type AgUiResponseOptions } from "./response";
+export { createStubFetch, type StubFetchOptions } from "./stub-fetch";
+export { runFrame, type RunFrameOptions } from "./run-frame";
+export { eventsToSseStream, SSE_CONTENT_TYPE } from "./encode";
+export { scenarios, scenarioNames, type ScenarioName } from "./scenarios";
+export type { Scenario, ScenarioContext } from "./types";
+
+export * as events from "./events";

--- a/packages/ag-ui-stub/src/response.spec.ts
+++ b/packages/ag-ui-stub/src/response.spec.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { agUiResponse } from "./response";
+import { scenarios } from "./scenarios";
+import { collectEvents, makeInput, typesOf } from "./test-support";
+
+describe("agUiResponse", () => {
+  it("serves a Server-Sent Events response", () => {
+    const response = agUiResponse(scenarios["text-stream"], makeInput());
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("text/event-stream");
+  });
+
+  it("wraps the scenario with RUN_STARTED / RUN_FINISHED echoing the ids", async () => {
+    const response = agUiResponse(
+      scenarios["text-stream"],
+      makeInput({ threadId: "T", runId: "R" }),
+    );
+    const events = await collectEvents(response);
+
+    expect(events[0]).toMatchObject({
+      type: "RUN_STARTED",
+      threadId: "T",
+      runId: "R",
+    });
+    expect(events.at(-1)).toMatchObject({
+      type: "RUN_FINISHED",
+      threadId: "T",
+      runId: "R",
+    });
+  });
+
+  it("streams a complete text triad between the lifecycle events", async () => {
+    const events = await collectEvents(
+      agUiResponse(scenarios["text-stream"], makeInput()),
+    );
+    const types = typesOf(events);
+
+    expect(types).toContain("TEXT_MESSAGE_START");
+    expect(types).toContain("TEXT_MESSAGE_CONTENT");
+    expect(types).toContain("TEXT_MESSAGE_END");
+    expect(types.indexOf("TEXT_MESSAGE_START")).toBeLessThan(
+      types.indexOf("TEXT_MESSAGE_END"),
+    );
+  });
+
+  it("merges custom headers over the SSE defaults", () => {
+    const response = agUiResponse(scenarios["text-stream"], makeInput(), {
+      headers: { "x-stub": "1" },
+    });
+    expect(response.headers.get("x-stub")).toBe("1");
+    expect(response.headers.get("content-type")).toBe("text/event-stream");
+  });
+});

--- a/packages/ag-ui-stub/src/response.ts
+++ b/packages/ag-ui-stub/src/response.ts
@@ -1,0 +1,37 @@
+import type { RunAgentInput } from "@ag-ui/core";
+
+import { SSE_CONTENT_TYPE, eventsToSseStream } from "./encode";
+import { runFrame } from "./run-frame";
+import type { Scenario } from "./types";
+
+export interface AgUiResponseOptions {
+  /** Delay between scenario chunks, in milliseconds. Defaults to `0`. */
+  chunkDelayMs?: number;
+  /** Extra response headers merged over the SSE defaults. */
+  headers?: RequestInit["headers"];
+}
+
+/**
+ * Run a {@link Scenario} against a `RunAgentInput` and return a Web-standard
+ * `Response` whose body is the AG-UI SSE event stream. Framework-agnostic: hand
+ * it back from a Hono/Express/Node handler, or call it directly from a test via
+ * {@link createStubFetch} — no server required.
+ */
+export function agUiResponse(
+  scenario: Scenario,
+  input: RunAgentInput,
+  options: AgUiResponseOptions = {},
+): Response {
+  const stream = eventsToSseStream(
+    runFrame(scenario, input, { chunkDelayMs: options.chunkDelayMs }),
+  );
+
+  return new Response(stream, {
+    status: 200,
+    headers: {
+      "content-type": SSE_CONTENT_TYPE,
+      "cache-control": "no-cache",
+      ...options.headers,
+    },
+  });
+}

--- a/packages/ag-ui-stub/src/run-frame.spec.ts
+++ b/packages/ag-ui-stub/src/run-frame.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import type { BaseEvent } from "@ag-ui/core";
+
+import { runError } from "./events";
+import { runFrame } from "./run-frame";
+import { makeInput, typesOf } from "./test-support";
+import type { Scenario } from "./types";
+
+async function drain(iterable: AsyncIterable<BaseEvent>): Promise<BaseEvent[]> {
+  const out: BaseEvent[] = [];
+  for await (const event of iterable) out.push(event);
+  return out;
+}
+
+describe("runFrame", () => {
+  it("appends a success RUN_FINISHED when the scenario emits no terminal", async () => {
+    const empty: Scenario = async function* () {};
+    const events = await drain(runFrame(empty, makeInput()));
+    expect(typesOf(events)).toEqual(["RUN_STARTED", "RUN_FINISHED"]);
+  });
+
+  it("does not append a second terminal when the scenario ends itself", async () => {
+    const erroring: Scenario = async function* () {
+      yield runError("boom");
+    };
+    const events = await drain(runFrame(erroring, makeInput()));
+    expect(typesOf(events)).toEqual(["RUN_STARTED", "RUN_ERROR"]);
+  });
+
+  it("converts an unexpected throw into a terminal RUN_ERROR", async () => {
+    // Throws before yielding by design — that's exactly the case under test.
+    // eslint-disable-next-line require-yield
+    const throwing: Scenario = async function* () {
+      throw new Error("scenario blew up");
+    };
+    const events = await drain(runFrame(throwing, makeInput()));
+    expect(typesOf(events)).toEqual(["RUN_STARTED", "RUN_ERROR"]);
+    expect(events.at(-1)).toMatchObject({
+      type: "RUN_ERROR",
+      message: "scenario blew up",
+    });
+  });
+});

--- a/packages/ag-ui-stub/src/run-frame.ts
+++ b/packages/ag-ui-stub/src/run-frame.ts
@@ -1,0 +1,46 @@
+import { EventType, type BaseEvent, type RunAgentInput } from "@ag-ui/core";
+
+import { makeDelay } from "./delay";
+import { runError, runFinished, runStarted } from "./events";
+import type { Scenario } from "./types";
+
+export interface RunFrameOptions {
+  /** Delay between scenario chunks, in milliseconds. Defaults to `0`. */
+  chunkDelayMs?: number;
+}
+
+const isTerminal = (event: BaseEvent): boolean =>
+  event.type === EventType.RUN_FINISHED || event.type === EventType.RUN_ERROR;
+
+/**
+ * Wrap a {@link Scenario} in a protocol-faithful run:
+ *
+ * - emits `RUN_STARTED` first, echoing the request's `threadId` / `runId`;
+ * - relays the scenario's events;
+ * - appends a success `RUN_FINISHED` only if the scenario didn't already emit
+ *   its own terminal event (interrupt outcome or `RUN_ERROR`);
+ * - converts an unexpected scenario throw into a `RUN_ERROR` so the stream
+ *   always ends on a valid terminal event.
+ */
+export async function* runFrame(
+  scenario: Scenario,
+  input: RunAgentInput,
+  options: RunFrameOptions = {},
+): AsyncIterable<BaseEvent> {
+  yield runStarted(input.threadId, input.runId);
+
+  const delay = makeDelay(options.chunkDelayMs ?? 0);
+  let terminated = false;
+
+  try {
+    for await (const event of scenario({ input, delay })) {
+      if (isTerminal(event)) terminated = true;
+      yield event;
+    }
+  } catch (error) {
+    yield runError(error instanceof Error ? error.message : String(error));
+    return;
+  }
+
+  if (!terminated) yield runFinished(input.threadId, input.runId);
+}

--- a/packages/ag-ui-stub/src/scenarios/error.ts
+++ b/packages/ag-ui-stub/src/scenarios/error.ts
@@ -1,0 +1,15 @@
+import { runError, textContent, textEnd, textStart } from "../events";
+import type { Scenario } from "../types";
+
+const MESSAGE_ID = "stub-error-1";
+
+/** Streams a little text, then ends the run with a `RUN_ERROR`. */
+export const error: Scenario = async function* () {
+  yield textStart(MESSAGE_ID);
+  yield textContent(MESSAGE_ID, "Starting a task that will fail…");
+  yield textEnd(MESSAGE_ID);
+  yield runError(
+    "Simulated failure from @elmethis/ag-ui-stub",
+    "STUB_SIMULATED_ERROR",
+  );
+};

--- a/packages/ag-ui-stub/src/scenarios/full.ts
+++ b/packages/ag-ui-stub/src/scenarios/full.ts
@@ -1,0 +1,78 @@
+import {
+  reasoningEnd,
+  reasoningMessageContent,
+  reasoningMessageEnd,
+  reasoningMessageStart,
+  reasoningStart,
+  stateDelta,
+  stateSnapshot,
+  stepFinished,
+  stepStarted,
+  textContent,
+  textEnd,
+  textStart,
+  toolCallArgs,
+  toolCallEnd,
+  toolCallResult,
+  toolCallStart,
+} from "../events";
+import type { Scenario } from "../types";
+
+const REASONING_ID = "stub-full-reasoning-1";
+const TOOL_CALL_ID = "stub-full-tool-1";
+const TOOL_PARENT_ID = "stub-full-tool-msg-1";
+const TOOL_RESULT_ID = "stub-full-tool-result-1";
+const ANSWER_ID = "stub-full-answer-1";
+
+/**
+ * A complete, realistic agent run that chains the building blocks into one
+ * stream: reason → act (tool call) → update shared state → answer. Phases are
+ * delimited with `STEP_STARTED` / `STEP_FINISHED` so the renderer's step
+ * handling is exercised too. This is the closest single endpoint to what a real
+ * agent backend produces.
+ */
+export const full: Scenario = async function* ({ delay }) {
+  // 1. Reason
+  yield stepStarted("reason");
+  yield reasoningStart(REASONING_ID);
+  yield reasoningMessageStart(REASONING_ID);
+  for (const chunk of ["I should ", "check the ", "weather first", "…"]) {
+    yield reasoningMessageContent(REASONING_ID, chunk);
+    await delay();
+  }
+  yield reasoningMessageEnd(REASONING_ID);
+  yield reasoningEnd(REASONING_ID);
+  yield stepFinished("reason");
+
+  // 2. Act — call a tool and receive its result
+  yield stepStarted("act");
+  yield toolCallStart(TOOL_CALL_ID, "get_weather", TOOL_PARENT_ID);
+  for (const chunk of ['{"locat', 'ion":"To', 'kyo"}']) {
+    yield toolCallArgs(TOOL_CALL_ID, chunk);
+    await delay();
+  }
+  yield toolCallEnd(TOOL_CALL_ID);
+  yield toolCallResult(
+    TOOL_CALL_ID,
+    JSON.stringify({ tempC: 21, sky: "clear" }),
+    TOOL_RESULT_ID,
+  );
+  yield stepFinished("act");
+
+  // 3. Update shared state
+  yield stateSnapshot({ location: "Tokyo", weather: null, status: "fetching" });
+  await delay();
+  yield stateDelta([
+    { op: "replace", path: "/weather", value: { tempC: 21, sky: "clear" } },
+    { op: "replace", path: "/status", value: "ready" },
+  ]);
+  await delay();
+
+  // 4. Answer
+  yield textStart(ANSWER_ID);
+  for (const chunk of ["It's ", "21°C ", "and ", "clear ", "in Tokyo", "."]) {
+    yield textContent(ANSWER_ID, chunk);
+    await delay();
+  }
+  yield textEnd(ANSWER_ID);
+};

--- a/packages/ag-ui-stub/src/scenarios/index.ts
+++ b/packages/ag-ui-stub/src/scenarios/index.ts
@@ -1,0 +1,43 @@
+import type { Scenario } from "../types";
+import { error } from "./error";
+import { full } from "./full";
+import { interrupt } from "./interrupt";
+import { longStream } from "./long-stream";
+import { messagesSnapshotScenario } from "./messages-snapshot";
+import { reasoning } from "./reasoning";
+import { state } from "./state";
+import { textStream } from "./text-stream";
+import { toolCall } from "./tool-call";
+
+/**
+ * The catalog of deterministic, LLM-free scenarios. Each one maps to a branch
+ * of the `@elmethis` ag-ui-client renderers — together they form the component
+ * test matrix.
+ */
+export const scenarios = {
+  full,
+  "text-stream": textStream,
+  "tool-call": toolCall,
+  state,
+  reasoning,
+  interrupt,
+  "messages-snapshot": messagesSnapshotScenario,
+  error,
+  "long-stream": longStream,
+} satisfies Record<string, Scenario>;
+
+export type ScenarioName = keyof typeof scenarios;
+
+export const scenarioNames = Object.keys(scenarios) as ScenarioName[];
+
+export {
+  error,
+  full,
+  interrupt,
+  longStream,
+  messagesSnapshotScenario,
+  reasoning,
+  state,
+  textStream,
+  toolCall,
+};

--- a/packages/ag-ui-stub/src/scenarios/interrupt.ts
+++ b/packages/ag-ui-stub/src/scenarios/interrupt.ts
@@ -1,0 +1,45 @@
+import {
+  runFinishedInterrupt,
+  stateSnapshot,
+  textContent,
+  textEnd,
+  textStart,
+} from "../events";
+import type { Scenario } from "../types";
+
+const INTERRUPT_ID = "stub-confirm-1";
+
+/**
+ * Human-in-the-loop confirmation. On the first run it emits a question, a state
+ * snapshot (so resume is mode-agnostic), then ends with an `interrupt` outcome.
+ * When the client resumes (`RunAgentInput.resume` is non-empty) it continues to
+ * a normal success completion.
+ */
+export const interrupt: Scenario = async function* ({ input }) {
+  const resumed = (input.resume?.length ?? 0) > 0;
+
+  if (!resumed) {
+    const askId = "stub-interrupt-ask-1";
+    yield textStart(askId);
+    yield textContent(askId, "I need your confirmation before continuing.");
+    yield textEnd(askId);
+
+    // State must be emitted before the interrupt so resume is mode-agnostic.
+    yield stateSnapshot({ status: "awaiting_confirmation" });
+
+    yield runFinishedInterrupt(input.threadId, input.runId, [
+      {
+        id: INTERRUPT_ID,
+        reason: "confirmation",
+        message: "Proceed with the action?",
+      },
+    ]);
+    return;
+  }
+
+  const doneId = "stub-interrupt-done-1";
+  yield textStart(doneId);
+  yield textContent(doneId, "Thanks — continuing now that you've confirmed.");
+  yield textEnd(doneId);
+  // runFrame appends the success RUN_FINISHED.
+};

--- a/packages/ag-ui-stub/src/scenarios/long-stream.ts
+++ b/packages/ag-ui-stub/src/scenarios/long-stream.ts
@@ -1,0 +1,19 @@
+import { textContent, textEnd, textStart } from "../events";
+import type { Scenario } from "../types";
+
+const MESSAGE_ID = "stub-long-1";
+const TOKEN_COUNT = 200;
+
+/**
+ * Emits many small content chunks to exercise backpressure and long-running
+ * streaming UI (typing indicators, `isRunning`). Deterministic — tokens are a
+ * simple counter, not random.
+ */
+export const longStream: Scenario = async function* ({ delay }) {
+  yield textStart(MESSAGE_ID);
+  for (let i = 0; i < TOKEN_COUNT; i += 1) {
+    yield textContent(MESSAGE_ID, `token-${i} `);
+    await delay();
+  }
+  yield textEnd(MESSAGE_ID);
+};

--- a/packages/ag-ui-stub/src/scenarios/messages-snapshot.ts
+++ b/packages/ag-ui-stub/src/scenarios/messages-snapshot.ts
@@ -1,0 +1,25 @@
+import type { Message } from "@ag-ui/core";
+
+import { messagesSnapshot } from "../events";
+import type { Scenario } from "../types";
+
+const MESSAGES: Message[] = [
+  { id: "stub-msg-user-1", role: "user", content: "What can you do?" },
+  {
+    id: "stub-msg-assistant-1",
+    role: "assistant",
+    content: "I'm a stubbed AG-UI agent for deterministic component tests.",
+  },
+];
+
+/**
+ * Replaces the full message history in one shot via `MESSAGES_SNAPSHOT`.
+ *
+ * Note: AG-UI has no *output* multimodal events — multimodality is an input
+ * concern carried by `RunAgentInput` and handled in the client's input
+ * components. This scenario covers the analogous server-emitted path (history
+ * replacement) that the message renderer needs to exercise.
+ */
+export const messagesSnapshotScenario: Scenario = async function* () {
+  yield messagesSnapshot(MESSAGES);
+};

--- a/packages/ag-ui-stub/src/scenarios/reasoning.ts
+++ b/packages/ag-ui-stub/src/scenarios/reasoning.ts
@@ -1,0 +1,40 @@
+import {
+  reasoningEnd,
+  reasoningMessageContent,
+  reasoningMessageEnd,
+  reasoningMessageStart,
+  reasoningStart,
+  textContent,
+  textEnd,
+  textStart,
+} from "../events";
+import type { Scenario } from "../types";
+
+const REASONING_ID = "stub-reasoning-1";
+const ANSWER_ID = "stub-reasoning-answer-1";
+const THOUGHT_CHUNKS = [
+  "Let me ",
+  "work through ",
+  "the request ",
+  "step by step",
+  "…",
+];
+
+/**
+ * Streams a visible reasoning summary (REASONING_START → MESSAGE triad →
+ * REASONING_END) and then the final assistant answer.
+ */
+export const reasoning: Scenario = async function* ({ delay }) {
+  yield reasoningStart(REASONING_ID);
+  yield reasoningMessageStart(REASONING_ID);
+  for (const chunk of THOUGHT_CHUNKS) {
+    yield reasoningMessageContent(REASONING_ID, chunk);
+    await delay();
+  }
+  yield reasoningMessageEnd(REASONING_ID);
+  yield reasoningEnd(REASONING_ID);
+
+  yield textStart(ANSWER_ID);
+  yield textContent(ANSWER_ID, "The answer is 42.");
+  yield textEnd(ANSWER_ID);
+};

--- a/packages/ag-ui-stub/src/scenarios/scenarios.spec.ts
+++ b/packages/ag-ui-stub/src/scenarios/scenarios.spec.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+
+import { agUiResponse } from "../response";
+import { collectEvents, makeInput, typesOf } from "../test-support";
+import { scenarioNames, scenarios } from "./index";
+
+const run = (name: keyof typeof scenarios, input = makeInput()) =>
+  collectEvents(agUiResponse(scenarios[name], input));
+
+describe("scenario catalog", () => {
+  it("every scenario produces a valid RUN_STARTED…terminal stream", async () => {
+    for (const name of scenarioNames) {
+      const types = typesOf(await run(name));
+      expect(types[0]).toBe("RUN_STARTED");
+      expect(["RUN_FINISHED", "RUN_ERROR"]).toContain(types.at(-1));
+    }
+  });
+
+  it("tool-call emits the full tool lifecycle in order", async () => {
+    const types = typesOf(await run("tool-call"));
+    expect(types).toEqual(
+      expect.arrayContaining([
+        "TOOL_CALL_START",
+        "TOOL_CALL_ARGS",
+        "TOOL_CALL_END",
+        "TOOL_CALL_RESULT",
+      ]),
+    );
+    expect(types.indexOf("TOOL_CALL_START")).toBeLessThan(
+      types.indexOf("TOOL_CALL_RESULT"),
+    );
+  });
+
+  it("state emits a snapshot before its deltas", async () => {
+    const types = typesOf(await run("state"));
+    expect(types.indexOf("STATE_SNAPSHOT")).toBeGreaterThanOrEqual(0);
+    expect(types.indexOf("STATE_SNAPSHOT")).toBeLessThan(
+      types.indexOf("STATE_DELTA"),
+    );
+  });
+
+  it("reasoning streams a reasoning block then the answer", async () => {
+    const types = typesOf(await run("reasoning"));
+    expect(types).toEqual(
+      expect.arrayContaining([
+        "REASONING_START",
+        "REASONING_MESSAGE_CONTENT",
+        "REASONING_END",
+        "TEXT_MESSAGE_START",
+      ]),
+    );
+  });
+
+  it("interrupt pauses with an interrupt outcome when not resumed", async () => {
+    const events = await run("interrupt");
+    const finish = events.at(-1) as {
+      type: string;
+      outcome?: { type: string };
+    };
+    expect(finish.type).toBe("RUN_FINISHED");
+    expect(finish.outcome).toMatchObject({ type: "interrupt" });
+  });
+
+  it("interrupt completes successfully once resumed", async () => {
+    const events = await run(
+      "interrupt",
+      makeInput({
+        resume: [{ interruptId: "stub-confirm-1", status: "resolved" }],
+      }),
+    );
+    const finish = events.at(-1) as { type: string; outcome?: unknown };
+    expect(finish.type).toBe("RUN_FINISHED");
+    expect(finish.outcome).toBeUndefined();
+  });
+
+  it("messages-snapshot replaces the history", async () => {
+    const types = typesOf(await run("messages-snapshot"));
+    expect(types).toContain("MESSAGES_SNAPSHOT");
+  });
+
+  it("error ends the run with RUN_ERROR", async () => {
+    const events = await run("error");
+    expect(events.at(-1)).toMatchObject({ type: "RUN_ERROR" });
+  });
+
+  it("full chains reason → act → state → answer with step delimiters", async () => {
+    const types = typesOf(await run("full"));
+
+    // Every phase is represented...
+    expect(types).toEqual(
+      expect.arrayContaining([
+        "STEP_STARTED",
+        "REASONING_START",
+        "TOOL_CALL_RESULT",
+        "STATE_DELTA",
+        "TEXT_MESSAGE_END",
+        "STEP_FINISHED",
+      ]),
+    );
+    // ...and they happen in order: reason, then act (tool), then answer.
+    expect(types.indexOf("REASONING_START")).toBeLessThan(
+      types.indexOf("TOOL_CALL_START"),
+    );
+    expect(types.indexOf("TOOL_CALL_RESULT")).toBeLessThan(
+      types.indexOf("TEXT_MESSAGE_START"),
+    );
+    // Each step is opened and closed.
+    const opened = types.filter((t) => t === "STEP_STARTED").length;
+    const closed = types.filter((t) => t === "STEP_FINISHED").length;
+    expect(opened).toBe(closed);
+    expect(opened).toBeGreaterThan(0);
+  });
+
+  it("long-stream emits many content chunks", async () => {
+    const events = await run("long-stream");
+    const contentCount = typesOf(events).filter(
+      (t) => t === "TEXT_MESSAGE_CONTENT",
+    ).length;
+    expect(contentCount).toBeGreaterThan(100);
+  });
+});

--- a/packages/ag-ui-stub/src/scenarios/state.ts
+++ b/packages/ag-ui-stub/src/scenarios/state.ts
@@ -1,0 +1,38 @@
+import {
+  stateDelta,
+  stateSnapshot,
+  textContent,
+  textEnd,
+  textStart,
+} from "../events";
+import type { Scenario } from "../types";
+
+const MESSAGE_ID = "stub-state-msg-1";
+
+/**
+ * Shared-state flow: a full `STATE_SNAPSHOT` followed by incremental
+ * `STATE_DELTA` patches (RFC 6902). Closes with a short text summary so the
+ * message list and state panel both update.
+ */
+export const state: Scenario = async function* ({ delay }) {
+  yield stateSnapshot({ counter: 0, items: [] as string[], status: "idle" });
+  await delay();
+
+  yield stateDelta([
+    { op: "replace", path: "/counter", value: 1 },
+    { op: "add", path: "/items/-", value: "first" },
+    { op: "replace", path: "/status", value: "running" },
+  ]);
+  await delay();
+
+  yield stateDelta([
+    { op: "replace", path: "/counter", value: 2 },
+    { op: "add", path: "/items/-", value: "second" },
+    { op: "replace", path: "/status", value: "done" },
+  ]);
+  await delay();
+
+  yield textStart(MESSAGE_ID);
+  yield textContent(MESSAGE_ID, "State now holds 2 items.");
+  yield textEnd(MESSAGE_ID);
+};

--- a/packages/ag-ui-stub/src/scenarios/text-stream.ts
+++ b/packages/ag-ui-stub/src/scenarios/text-stream.ts
@@ -1,0 +1,26 @@
+import { textContent, textEnd, textStart } from "../events";
+import type { Scenario } from "../types";
+
+const MESSAGE_ID = "stub-text-1";
+const CHUNKS = [
+  "Hello",
+  ", ",
+  "this ",
+  "is ",
+  "a ",
+  "stubbed ",
+  "AG-UI ",
+  "text ",
+  "stream",
+  ".",
+];
+
+/** Streams a single assistant message as a START / CONTENT×n / END triad. */
+export const textStream: Scenario = async function* ({ delay }) {
+  yield textStart(MESSAGE_ID);
+  for (const chunk of CHUNKS) {
+    yield textContent(MESSAGE_ID, chunk);
+    await delay();
+  }
+  yield textEnd(MESSAGE_ID);
+};

--- a/packages/ag-ui-stub/src/scenarios/tool-call.ts
+++ b/packages/ag-ui-stub/src/scenarios/tool-call.ts
@@ -1,0 +1,30 @@
+import {
+  toolCallArgs,
+  toolCallEnd,
+  toolCallResult,
+  toolCallStart,
+} from "../events";
+import type { Scenario } from "../types";
+
+const TOOL_CALL_ID = "stub-tool-1";
+const PARENT_MESSAGE_ID = "stub-tool-msg-1";
+const RESULT_MESSAGE_ID = "stub-tool-result-1";
+const ARG_CHUNKS = ['{"locat', 'ion":"To', 'kyo"}'];
+
+/**
+ * A full tool-call round-trip: START → ARGS×n → END → RESULT. Streams the
+ * arguments JSON in fragments so consumers exercise incremental arg assembly.
+ */
+export const toolCall: Scenario = async function* ({ delay }) {
+  yield toolCallStart(TOOL_CALL_ID, "get_weather", PARENT_MESSAGE_ID);
+  for (const chunk of ARG_CHUNKS) {
+    yield toolCallArgs(TOOL_CALL_ID, chunk);
+    await delay();
+  }
+  yield toolCallEnd(TOOL_CALL_ID);
+  yield toolCallResult(
+    TOOL_CALL_ID,
+    JSON.stringify({ tempC: 21, sky: "clear" }),
+    RESULT_MESSAGE_ID,
+  );
+};

--- a/packages/ag-ui-stub/src/server.ts
+++ b/packages/ag-ui-stub/src/server.ts
@@ -1,0 +1,64 @@
+import { serve } from "@hono/node-server";
+import type { RunAgentInput } from "@ag-ui/core";
+import { createConsola, LogLevels } from "consola";
+import { Hono } from "hono";
+import { cors } from "hono/cors";
+
+import { agUiResponse } from "./response";
+import { scenarioNames, scenarios, type ScenarioName } from "./scenarios";
+
+const envLevel = process.env.LOG_LEVEL as keyof typeof LogLevels | undefined;
+const logger = createConsola({
+  level:
+    envLevel && envLevel in LogLevels ? LogLevels[envLevel] : LogLevels.info,
+});
+
+const app = new Hono();
+
+app.use("*", cors());
+
+app.get("/", (c) =>
+  c.json({
+    name: "@elmethis/ag-ui-stub",
+    usage: "POST /stub/agent/:scenario/run  (optional ?delay=<ms>)",
+    scenarios: scenarioNames,
+  }),
+);
+
+// e.g. `POST http://localhost:19103/stub/agent/tool-call/run`
+app.post("/stub/agent/:scenario/run", async (c) => {
+  const name = c.req.param("scenario") as ScenarioName;
+  const scenario = scenarios[name];
+
+  if (scenario === undefined) {
+    return c.json(
+      { error: `Unknown scenario '${name}'`, scenarios: scenarioNames },
+      404,
+    );
+  }
+
+  const input = (await c.req.json()) as RunAgentInput;
+  const delayParam = c.req.query("delay");
+  const chunkDelayMs = delayParam ? Number.parseInt(delayParam, 10) : 0;
+
+  return agUiResponse(scenario, input, { chunkDelayMs });
+});
+
+const port = Number.parseInt(process.env.PORT ?? "19103", 10);
+const hostname = process.env.ADDRESS ?? "0.0.0.0";
+
+serve({ fetch: app.fetch, port, hostname }, (info) => {
+  // Show a clickable host: 0.0.0.0 / :: aren't dialable, localhost is.
+  const host =
+    info.address === "0.0.0.0" || info.address === "::"
+      ? "localhost"
+      : info.address;
+  const base = `http://${host}:${info.port}`;
+
+  logger.success("@elmethis/ag-ui-stub listening", { url: base });
+
+  const hints = scenarioNames
+    .map((name) => `POST ${base}/stub/agent/${name}/run`)
+    .join("\n");
+  logger.box(`Endpoints (append ?delay=<ms> to pace the stream):\n\n${hints}`);
+});

--- a/packages/ag-ui-stub/src/stub-fetch.spec.ts
+++ b/packages/ag-ui-stub/src/stub-fetch.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { createStubFetch } from "./stub-fetch";
+import { collectEvents, makeInput, typesOf } from "./test-support";
+
+const post = (fetchImpl: typeof fetch, url: string) =>
+  fetchImpl(url, { method: "POST", body: JSON.stringify(makeInput()) });
+
+describe("createStubFetch", () => {
+  it("resolves the scenario from the `/agent/:scenario/run` path", async () => {
+    const stubFetch = createStubFetch();
+    const response = await post(
+      stubFetch,
+      "http://localhost/stub/agent/tool-call/run",
+    );
+
+    expect(response.headers.get("content-type")).toBe("text/event-stream");
+    expect(typesOf(await collectEvents(response))).toContain("TOOL_CALL_START");
+  });
+
+  it("falls back to text-stream for an unknown scenario", async () => {
+    const stubFetch = createStubFetch();
+    const response = await post(
+      stubFetch,
+      "http://localhost/stub/agent/does-not-exist/run",
+    );
+
+    expect(typesOf(await collectEvents(response))).toContain(
+      "TEXT_MESSAGE_START",
+    );
+  });
+
+  it("honors a custom resolveScenario override", async () => {
+    const stubFetch = createStubFetch({
+      resolveScenario: () => undefined,
+      fallback: "error",
+    });
+    const response = await post(stubFetch, "http://localhost/whatever");
+
+    expect(typesOf(await collectEvents(response))).toContain("RUN_ERROR");
+  });
+});

--- a/packages/ag-ui-stub/src/stub-fetch.ts
+++ b/packages/ag-ui-stub/src/stub-fetch.ts
@@ -1,0 +1,60 @@
+import type { RunAgentInput } from "@ag-ui/core";
+
+import { agUiResponse, type AgUiResponseOptions } from "./response";
+import { scenarios, type ScenarioName } from "./scenarios";
+import type { Scenario } from "./types";
+
+export interface StubFetchOptions extends AgUiResponseOptions {
+  /**
+   * Resolve a scenario from the request URL and decoded input. Return
+   * `undefined` to fall through to URL-segment matching, then `fallback`.
+   */
+  resolveScenario?: (url: URL, input: RunAgentInput) => Scenario | undefined;
+  /** Scenario used when resolution fails. Defaults to `"text-stream"`. */
+  fallback?: ScenarioName;
+}
+
+/**
+ * Build a `fetch`-compatible function backed by the stub scenarios — no server,
+ * no ports. Pass it to `new HttpAgent({ url, fetch: createStubFetch() })` (the
+ * SDK injects it verbatim) or to `vi.stubGlobal("fetch", …)` for fully
+ * deterministic, CI-safe component tests.
+ *
+ * The scenario is taken from the URL path: `.../agent/<scenario>/run`, falling
+ * back to the last path segment, then to {@link StubFetchOptions.fallback}.
+ */
+export function createStubFetch(options: StubFetchOptions = {}): typeof fetch {
+  const {
+    resolveScenario,
+    fallback = "text-stream",
+    ...responseOptions
+  } = options;
+
+  const stubFetch = async (
+    input: Parameters<typeof fetch>[0],
+    init?: Parameters<typeof fetch>[1],
+  ): Promise<Response> => {
+    const request = new Request(input, init);
+    const url = new URL(request.url);
+    const agentInput = (await request.json()) as RunAgentInput;
+
+    const scenario =
+      resolveScenario?.(url, agentInput) ??
+      scenarioFromUrl(url) ??
+      scenarios[fallback];
+
+    return agUiResponse(scenario, agentInput, responseOptions);
+  };
+
+  return stubFetch as typeof fetch;
+}
+
+function scenarioFromUrl(url: URL): Scenario | undefined {
+  const segments = url.pathname.split("/").filter(Boolean);
+  const runIndex = segments.lastIndexOf("run");
+  const name =
+    runIndex > 0 ? segments[runIndex - 1] : segments[segments.length - 1];
+  return name !== undefined && name in scenarios
+    ? scenarios[name as ScenarioName]
+    : undefined;
+}

--- a/packages/ag-ui-stub/src/test-support.ts
+++ b/packages/ag-ui-stub/src/test-support.ts
@@ -1,0 +1,33 @@
+import type { BaseEvent, RunAgentInput } from "@ag-ui/core";
+
+/** Build a minimal valid `RunAgentInput` for tests. */
+export function makeInput(
+  overrides: Partial<RunAgentInput> = {},
+): RunAgentInput {
+  return {
+    threadId: "stub-thread",
+    runId: "stub-run",
+    messages: [],
+    tools: [],
+    context: [],
+    forwardedProps: {},
+    ...overrides,
+  };
+}
+
+/** Drain an AG-UI SSE `Response` into its decoded events. */
+export async function collectEvents(response: Response): Promise<BaseEvent[]> {
+  const text = await response.text();
+  return text
+    .split("\n\n")
+    .map((block) => block.trim())
+    .filter((block) => block.startsWith("data:"))
+    .map(
+      (block) =>
+        JSON.parse(block.slice(block.indexOf("data:") + 5).trim()) as BaseEvent,
+    );
+}
+
+/** The `type` discriminator of each event, in order. */
+export const typesOf = (events: BaseEvent[]): string[] =>
+  events.map((event) => event.type);

--- a/packages/ag-ui-stub/src/types.ts
+++ b/packages/ag-ui-stub/src/types.ts
@@ -1,0 +1,26 @@
+import type { BaseEvent, RunAgentInput } from "@ag-ui/core";
+
+/**
+ * Context handed to every scenario. Scenarios are pure async generators of the
+ * *middle* of a run — {@link runFrame} owns the surrounding `RUN_STARTED` /
+ * `RUN_FINISHED` lifecycle events.
+ */
+export interface ScenarioContext {
+  /** The decoded `RunAgentInput` from the client request. */
+  input: RunAgentInput;
+  /**
+   * Resolves after the configured `chunkDelayMs`. With the default delay of `0`
+   * (used in tests) it resolves immediately, so scenarios can `await delay()`
+   * between chunks without slowing down deterministic runs.
+   */
+  delay: () => Promise<void>;
+}
+
+/**
+ * A deterministic, LLM-free agent behavior. Yields the events that occur
+ * between `RUN_STARTED` and `RUN_FINISHED`. A scenario may emit its own
+ * terminal event (`RUN_FINISHED` with an interrupt outcome, or `RUN_ERROR`) to
+ * take control of how the run ends; otherwise a success `RUN_FINISHED` is
+ * appended automatically.
+ */
+export type Scenario = (ctx: ScenarioContext) => AsyncIterable<BaseEvent>;

--- a/packages/ag-ui-stub/tsconfig.json
+++ b/packages/ag-ui-stub/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "lib": ["ESNext"],
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "declaration": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "types": ["node"],
+    "rootDir": "./src"
+  },
+  "include": ["src"]
+}

--- a/packages/ag-ui-stub/tsdown.config.ts
+++ b/packages/ag-ui-stub/tsdown.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+  entry: {
+    index: "src/index.ts",
+    scenarios: "src/scenarios/index.ts",
+  },
+  format: ["esm", "cjs"],
+  dts: true,
+  target: "esnext",
+  clean: true,
+});

--- a/packages/ag-ui-stub/vitest.config.ts
+++ b/packages/ag-ui-stub/vitest.config.ts
@@ -1,0 +1,23 @@
+/// <reference types="vitest/config" />
+import { defineConfig } from "vitest/config";
+
+// Single Node unit layer (no browser specs). Coverage is uploaded to Codecov
+// under the `ag-ui-stub` flag.
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      // Pin the source set explicitly so untested modules count at 0% rather
+      // than vanishing from the denominator (Vitest 4 + v8 behavior).
+      include: ["src/**/*.{ts,tsx}"],
+      exclude: [
+        "src/**/*.spec.{ts,tsx}",
+        "src/index.ts", // re-export barrel
+        "src/test-support.ts", // test helpers
+        "src/server.ts", // Hono entrypoint — exercised at runtime, not in unit specs
+      ],
+      reporter: ["text", "html", "lcov"],
+      reportsDirectory: "coverage",
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,61 @@ importers:
         specifier: ~6.0.3
         version: 6.0.3
 
+  packages/ag-ui-stub:
+    dependencies:
+      '@ag-ui/core':
+        specifier: 0.0.57
+        version: 0.0.57
+      '@ag-ui/encoder':
+        specifier: 0.0.57
+        version: 0.0.57
+      '@hono/node-server':
+        specifier: ^2.0.4
+        version: 2.0.4(hono@4.12.26)
+      consola:
+        specifier: ^3.4.2
+        version: 3.4.2
+      hono:
+        specifier: ^4.12.25
+        version: 4.12.26
+    devDependencies:
+      '@eslint/js':
+        specifier: latest
+        version: 10.0.1(eslint@10.5.0(jiti@2.4.2))
+      '@types/node':
+        specifier: 25.7.0
+        version: 25.7.0
+      '@vitest/coverage-v8':
+        specifier: ^4.1.9
+        version: 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.8)
+      concurrently:
+        specifier: ^10.0.3
+        version: 10.0.3
+      eslint:
+        specifier: ^10.5.0
+        version: 10.5.0(jiti@2.4.2)
+      globals:
+        specifier: ^17.6.0
+        version: 17.6.0
+      prettier:
+        specifier: 3.8.4
+        version: 3.8.4
+      tsdown:
+        specifier: ^0.22.3
+        version: 0.22.3(oxc-resolver@11.20.0)(tsx@4.22.4)(typescript@5.9.3)(vue-tsc@3.3.4(typescript@5.9.3))
+      tsx:
+        specifier: ^4.22.4
+        version: 4.22.4
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      typescript-eslint:
+        specifier: ^8.61.1
+        version: 8.61.1(eslint@10.5.0(jiti@2.4.2))(typescript@5.9.3)
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.7.0)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-istanbul@4.1.8)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.8)(happy-dom@20.10.6)(vite@8.0.7(@types/node@25.7.0)(esbuild@0.28.1)(jiti@2.4.2)(sass@1.101.0)(terser@5.39.0)(tsx@4.22.4)(yaml@2.8.3))
+
   packages/copilotkit:
     dependencies:
       '@ag-ui/mastra':
@@ -9394,10 +9449,6 @@ snapshots:
       '@repeaterjs/repeater': 3.1.0
       tslib: 2.8.1
 
-  '@hono/node-server@1.19.14(hono@4.12.25)':
-    dependencies:
-      hono: 4.12.25
-
   '@hono/node-server@1.19.14(hono@4.12.26)':
     dependencies:
       hono: 4.12.26
@@ -9405,6 +9456,10 @@ snapshots:
   '@hono/node-server@2.0.4(hono@4.12.25)':
     dependencies:
       hono: 4.12.25
+
+  '@hono/node-server@2.0.4(hono@4.12.26)':
+    dependencies:
+      hono: 4.12.26
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -9913,7 +9968,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.25)
+      '@hono/node-server': 1.19.14(hono@4.12.26)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -9923,7 +9978,7 @@ snapshots:
       eventsource-parser: 3.0.8
       express: 5.2.1
       express-rate-limit: 8.5.1(express@5.2.1)
-      hono: 4.12.25
+      hono: 4.12.26
       jose: 6.2.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,5 @@
 packages:
+  - "packages/ag-ui-stub"
   - "packages/copilotkit"
   - "packages/core"
   - "packages/mcp-server"


### PR DESCRIPTION
## Summary

Adds a new private package **`@elmethis/ag-ui-stub`** — a deterministic,
**LLM-free** AG-UI test double. It speaks the same wire contract as a real
agent backend (POST `RunAgentInput` → SSE stream of `BaseEvent`s) but replays
canned, scripted scenarios, so Storybook and the `ag-ui-client` component
tests can exercise every event branch with no API key, network, cost, or
flakiness. Replaces reliance on the live `copilotkit` backend (`:19101`) for
component dev/tests.

## Two layers

- **`agUiResponse(scenario, input)`** — a framework-agnostic Web-standard
  `Response`/SSE primitive built on `@ag-ui/encoder` (pull-based for real
  backpressure). `runFrame` auto-wraps `RUN_STARTED`/`RUN_FINISHED`, echoes
  `threadId`/`runId`, and honors `resume`. Usable **server-less** in tests via
  `createStubFetch()` — `HttpAgent` accepts an injected `fetch`.
- **Hono server** on `:19103` (`POST /stub/agent/:scenario/run`, `?delay=<ms>`)
  that prints **consola** endpoint hints on startup; mirrors
  `packages/mcp-server`.

## Scenarios (the renderer test matrix)

`full` (end-to-end reason → act → state → answer, with `STEP_*` delimiters),
`text-stream`, `tool-call`, `state`, `reasoning`, `interrupt` (HITL/`resume`),
`messages-snapshot`, `error`, `long-stream`.

## Conventions

- Built with **tsdown** (dual ESM/CJS + dts, two entries) mirroring
  `@elmethis/core`; `check` / `check.ci` parity.
- `@ag-ui/*` pinned to **0.0.57** to match `@ag-ui/client` in qwik — not the
  `@ag-ui/mastra` 1.x line `copilotkit` uses.
- CI workflow (`.github/workflows/ag-ui-stub.yml`) mirrors `core.yml`: lint,
  format-check, type-check, build, unit tests + v8 coverage to Codecov.

## Verification

- `pnpm check.ci` green: fmt.check + lint + `tsc --noEmit` + tsdown build +
  **20 unit tests**.
- Coverage ~97.5% statements; live server smoke tests confirmed correct SSE
  sequences (incl. the `full` run and 404 on unknown scenarios).

## Notes

- This package is independent of the other workspace packages (no
  `@elmethis/core` dependency), so its CI is self-contained.
- Follow-up (not in this PR): wire qwik/react/vue `ag-ui-client` stories +
  browser specs to the stub, replacing the `localhost:19101/copilotkit/...`
  URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)