### PR TITLE
feat(qwik): add ag-ui-stub scenario endpoints to useAgent story

### DIFF
--- a/packages/qwik/src/components/ag-ui-client/use-agent.stories.tsx
+++ b/packages/qwik/src/components/ag-ui-client/use-agent.stories.tsx
@@ -225,6 +225,17 @@ const meta: Meta<UseAgentProps> = {
         "http://localhost:19101/copilotkit/mastra/agent/minimax-m2.5/run",
         "http://localhost:19101/copilotkit/mastra/agent/minimax-m2.5-free/run",
         "http://localhost:19101/copilotkit/mastra/agent/kimi-k2.6/run",
+        // @elmethis/ag-ui-stub — deterministic, LLM-free scenarios
+        // (packages/ag-ui-stub). Append `?delay=<ms>` to pace the stream.
+        "http://localhost:19103/stub/agent/full/run",
+        "http://localhost:19103/stub/agent/text-stream/run",
+        "http://localhost:19103/stub/agent/tool-call/run",
+        "http://localhost:19103/stub/agent/state/run",
+        "http://localhost:19103/stub/agent/reasoning/run",
+        "http://localhost:19103/stub/agent/interrupt/run",
+        "http://localhost:19103/stub/agent/messages-snapshot/run",
+        "http://localhost:19103/stub/agent/error/run",
+        "http://localhost:19103/stub/agent/long-stream/run",
       ],
     },
     mcpUrl: {


### PR DESCRIPTION
## Summary

Adds the deterministic, LLM-free `@elmethis/ag-ui-stub` scenario endpoints (port 19103, `packages/ag-ui-stub`) as selectable `url` radio options in the `useAgent` Storybook story, alongside the existing CopilotKit endpoints.

This lets the story drive each stub scenario directly against the qwik ag-ui-client renderers without a live LLM.

## Endpoints added

`POST http://localhost:19103/stub/agent/<scenario>/run` for each scenario (append `?delay=<ms>` to pace the stream):

- `full`
- `text-stream`
- `tool-call`
- `state`
- `reasoning`
- `interrupt`
- `messages-snapshot`
- `error`
- `long-stream`

These map 1:1 to the stub server's `scenarioNames` (`/stub/agent/:scenario/run` route in `packages/ag-ui-stub/src/server.ts`).

## Changes

- `packages/qwik/src/components/ag-ui-client/use-agent.stories.tsx`: append the 9 stub endpoints to `argTypes.url.options` (purely additive string literals).

## Notes

- Default `url` arg is unchanged (still the CopilotKit minimax endpoint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)