### PR TITLE
feat(qwik/ag-ui): toggleable tool-call/reasoning display, inline status reel

### DIFF
--- a/packages/qwik/package.json
+++ b/packages/qwik/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elmethis/qwik",
-  "version": "1.0.0-alpha.32",
+  "version": "1.0.0-alpha.33",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/qwik/src/components/ag-ui-client/elm-ag-ui-agent.module.css
+++ b/packages/qwik/src/components/ag-ui-client/elm-ag-ui-agent.module.css
@@ -49,10 +49,6 @@
       height: min-content;
       margin: 0 auto;
 
-      .status {
-        padding-block: 0.5rem;
-      }
-
       .queue-container {
         width: 100%;
         display: flex;

--- a/packages/qwik/src/components/ag-ui-client/elm-ag-ui-agent.tsx
+++ b/packages/qwik/src/components/ag-ui-client/elm-ag-ui-agent.tsx
@@ -38,6 +38,16 @@ export interface ElmAgUiAgentProps {
    */
   width?: CSSProperties["width"];
   enableAutoScroll?: boolean;
+  /**
+   * Render assistant tool calls (and their results) inline.
+   * @default true
+   */
+  enableToolCalls?: boolean;
+  /**
+   * Render `reasoning` (thinking) messages.
+   * @default true
+   */
+  enableReasoning?: boolean;
   class?: ClassList;
   style?: CSSProperties;
   /**
@@ -78,6 +88,8 @@ export const ElmAgUiAgent = component$<ElmAgUiAgentProps>((props) => {
     abort$,
     dequeue$,
     width = "clamp(300px, 100%, 600px)",
+    enableToolCalls = true,
+    enableReasoning = true,
     class: className,
     style,
     prompts,
@@ -159,6 +171,8 @@ export const ElmAgUiAgent = component$<ElmAgUiAgentProps>((props) => {
             isRunning={state.isRunning}
             messages={state.messages}
             handleRetry$={retry$}
+            enableToolCalls={enableToolCalls}
+            enableReasoning={enableReasoning}
           />
 
           {state.error && (

--- a/packages/qwik/src/components/ag-ui-client/elm-ag-ui-agent.tsx
+++ b/packages/qwik/src/components/ag-ui-client/elm-ag-ui-agent.tsx
@@ -19,7 +19,6 @@ import type { InputContent } from "@ag-ui/client";
 import styles from "./elm-ag-ui-agent.module.css";
 
 import { ElmAgUiMessageRenderer } from "./elm-ag-ui-message-renderer";
-import { ElmAgUiStatus } from "./elm-ag-ui-status";
 import { ElmAgUiInput } from "./elm-ag-ui-input";
 import type { ElmAgUiPromptDescriptor } from "./elm-ag-ui-prompt-picker";
 import { ElmInlineText } from "../typography/elm-inline-text";
@@ -198,15 +197,6 @@ export const ElmAgUiAgent = component$<ElmAgUiAgentProps>((props) => {
 
       <div class={styles["agent-input-container"]}>
         <div class={styles["agent-input"]}>
-          {(state.status === "running" ||
-            state.status === "awaiting_input") && (
-            <ElmAgUiStatus
-              class={styles["status"]}
-              status={state.status}
-              activity={state.activity}
-            />
-          )}
-
           {state.queue.length > 0 && (
             <div class={styles["queue-container"]}>
               {state.queue.map((queued) => (
@@ -258,6 +248,8 @@ export const ElmAgUiAgent = component$<ElmAgUiAgentProps>((props) => {
             onSubmit$={onSubmit$}
             onAbort$={abort$}
             isRunning={state.isRunning}
+            status={state.status}
+            activity={state.activity}
             prompts={prompts}
             resolvePrompt$={resolvePrompt$}
           />

--- a/packages/qwik/src/components/ag-ui-client/elm-ag-ui-input.module.css
+++ b/packages/qwik/src/components/ag-ui-client/elm-ag-ui-input.module.css
@@ -61,6 +61,16 @@
     align-items: center;
   }
 
+  /* Sits in the `spacer` track between the plus and stop/send buttons.
+     `min-width: 0` lets the track shrink and clip a long label instead
+     of pushing the stop/send buttons out of the row. */
+  .status {
+    grid-area: spacer;
+    min-width: 0;
+    overflow: hidden;
+    white-space: nowrap;
+  }
+
   .plus-button {
     grid-area: plus;
     width: 1.5rem;

--- a/packages/qwik/src/components/ag-ui-client/elm-ag-ui-input.tsx
+++ b/packages/qwik/src/components/ag-ui-client/elm-ag-ui-input.tsx
@@ -17,6 +17,8 @@ import {
   type ElmAgUiPromptDescriptor,
 } from "./elm-ag-ui-prompt-picker";
 import { ElmCollapse } from "../containments/elm-collapse";
+import { ElmAgUiStatus } from "./elm-ag-ui-status";
+import type { AgentActivity, AgentRunStatus } from "./create-agent-subscriber";
 
 export interface ElmAgUiInputProps {
   class?: string;
@@ -24,6 +26,12 @@ export interface ElmAgUiInputProps {
   style?: CSSProperties;
 
   isRunning: boolean;
+
+  /** Coarse run lifecycle; drives the inline status shown in the button row. */
+  status?: AgentRunStatus;
+
+  /** Live in-run activity; only read while running. */
+  activity?: AgentActivity;
 
   onInput$: QRL<(event: InputEvent, element: HTMLTextAreaElement) => void>;
 
@@ -67,6 +75,8 @@ export const ElmAgUiInput = component$<ElmAgUiInputProps>(
     class: className,
     style,
     isRunning,
+    status,
+    activity,
     onInput$,
     onSubmit$,
     onAbort$,
@@ -306,6 +316,14 @@ export const ElmAgUiInput = component$<ElmAgUiInputProps>(
                   color="white"
                 />
               </div>
+            )}
+
+            {(status === "running" || status === "awaiting_input") && (
+              <ElmAgUiStatus
+                class={styles["status"]}
+                status={status}
+                activity={activity}
+              />
             )}
 
             {/*

--- a/packages/qwik/src/components/ag-ui-client/elm-ag-ui-message-renderer.spec.tsx
+++ b/packages/qwik/src/components/ag-ui-client/elm-ag-ui-message-renderer.spec.tsx
@@ -77,6 +77,77 @@ describe("[CSR] ElmAgUiMessageRenderer — role dispatch", () => {
     expect(screen.outerHTML).toContain("lookup_user");
   });
 
+  test("enableToolCalls={false} suppresses tool execution rendering", async () => {
+    const messages: Message[] = [
+      {
+        id: "1",
+        role: "assistant",
+        content: null,
+        toolCalls: [
+          {
+            id: "tc1",
+            type: "function",
+            function: { name: "lookup_user", arguments: '{"id":1}' },
+          },
+        ],
+      },
+    ] as unknown as Message[];
+    const { screen, render } = await createDOM();
+    await render(
+      <ElmAgUiMessageRenderer
+        isRunning={true}
+        handleRetry$={$(() => {})}
+        messages={messages}
+        enableToolCalls={false}
+      />,
+    );
+    expect(screen.outerHTML).not.toContain("lookup_user");
+  });
+
+  test("enableToolCalls={false} still renders the assistant's text content", async () => {
+    const messages: Message[] = [
+      {
+        id: "1",
+        role: "assistant",
+        content: "answer text",
+        toolCalls: [
+          {
+            id: "tc1",
+            type: "function",
+            function: { name: "lookup_user", arguments: '{"id":1}' },
+          },
+        ],
+      },
+    ] as unknown as Message[];
+    const { screen, render } = await createDOM();
+    await render(
+      <ElmAgUiMessageRenderer
+        isRunning={false}
+        handleRetry$={$(() => {})}
+        messages={messages}
+        enableToolCalls={false}
+      />,
+    );
+    expect(screen.outerHTML).not.toContain("lookup_user");
+    expect(screen.outerHTML).toContain("answer text");
+  });
+
+  test("enableReasoning={false} suppresses reasoning messages", async () => {
+    const messages: Message[] = [
+      { id: "1", role: "reasoning", content: "internal thinking trace" },
+    ] as Message[];
+    const { screen, render } = await createDOM();
+    await render(
+      <ElmAgUiMessageRenderer
+        isRunning={false}
+        handleRetry$={$(() => {})}
+        messages={messages}
+        enableReasoning={false}
+      />,
+    );
+    expect(screen.outerHTML).not.toContain("internal thinking trace");
+  });
+
   test("system / developer / tool roles produce no visible content", async () => {
     const messages: Message[] = [
       { id: "1", role: "system", content: "secret system prompt" },

--- a/packages/qwik/src/components/ag-ui-client/elm-ag-ui-message-renderer.stories.tsx
+++ b/packages/qwik/src/components/ag-ui-client/elm-ag-ui-message-renderer.stories.tsx
@@ -18,6 +18,8 @@ const meta: Meta<ElmAgUiMessageRendererProps> = {
   tags: ["autodocs"],
   args: {
     isRunning: false,
+    enableToolCalls: true,
+    enableReasoning: true,
   },
 };
 

--- a/packages/qwik/src/components/ag-ui-client/elm-ag-ui-message-renderer.tsx
+++ b/packages/qwik/src/components/ag-ui-client/elm-ag-ui-message-renderer.tsx
@@ -36,10 +36,30 @@ export interface ElmAgUiMessageRendererProps {
   isRunning: boolean;
 
   messages: Message[];
+
+  /**
+   * Render assistant tool calls (and their results) inline.
+   * @default true
+   */
+  enableToolCalls?: boolean;
+
+  /**
+   * Render `reasoning` (thinking) messages.
+   * @default true
+   */
+  enableReasoning?: boolean;
 }
 
 export const ElmAgUiMessageRenderer = component$<ElmAgUiMessageRendererProps>(
-  ({ class: className, style, messages, isRunning, handleRetry$ }) => {
+  ({
+    class: className,
+    style,
+    messages,
+    isRunning,
+    handleRetry$,
+    enableToolCalls = true,
+    enableReasoning = true,
+  }) => {
     const renderTool = (toolCall: ToolCall, messages: Message[]) => {
       let toolEventType = EventType.TOOL_CALL_START;
 
@@ -78,12 +98,11 @@ export const ElmAgUiMessageRenderer = component$<ElmAgUiMessageRendererProps>(
         }
 
         case "assistant": {
-          if (message.content != null || message.toolCalls?.length) {
+          const toolCalls = enableToolCalls ? message.toolCalls : undefined;
+          if (message.content != null || toolCalls?.length) {
             return (
               <>
-                {message.toolCalls?.map((toolCall) =>
-                  renderTool(toolCall, messages),
-                )}
+                {toolCalls?.map((toolCall) => renderTool(toolCall, messages))}
 
                 {message.content != null && (
                   <div class={styles["message-content-assistant-wrapper"]}>
@@ -130,6 +149,8 @@ export const ElmAgUiMessageRenderer = component$<ElmAgUiMessageRendererProps>(
         }
 
         case "reasoning": {
+          if (!enableReasoning) return null;
+
           const Reasoning = component$<{
             isReasoningRunning: boolean;
             markdown: string;

--- a/packages/qwik/src/components/ag-ui-client/elm-ag-ui-status.module.css
+++ b/packages/qwik/src/components/ag-ui-client/elm-ag-ui-status.module.css
@@ -1,9 +1,32 @@
+/* Clipping host: hides an incoming reel cell until it rolls up. */
 .elm-ag-ui-status {
+  display: flex;
+  align-items: center;
+  overflow: hidden;
+  user-select: none;
+}
+
+/* The animated cell: holds the icon + label and rolls up on each
+   state change. Keeping the flex row here (not on the clipping host)
+   lets the whole cell translate as one unit. */
+.reel {
   display: flex;
   flex-direction: row;
   align-items: center;
   gap: 0.5rem;
-  user-select: none;
+  animation: elm-ag-ui-status-reel 320ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+@keyframes elm-ag-ui-status-reel {
+  from {
+    transform: translateY(110%);
+    opacity: 0;
+  }
+
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
 }
 
 @keyframes elm-ag-ui-status-pulse {
@@ -22,6 +45,7 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .reel,
   .pulse {
     animation: none;
   }

--- a/packages/qwik/src/components/ag-ui-client/elm-ag-ui-status.tsx
+++ b/packages/qwik/src/components/ag-ui-client/elm-ag-ui-status.tsx
@@ -108,6 +108,8 @@ export const ElmAgUiStatus = component$<ElmAgUiStatusProps>(
     const view = resolveView(status, activity);
     if (!view) return null;
 
+    const displayLabel = label ?? view.label;
+
     return (
       <div
         class={[styles["elm-ag-ui-status"], className]}
@@ -115,13 +117,24 @@ export const ElmAgUiStatus = component$<ElmAgUiStatusProps>(
         role="status"
         aria-live="polite"
       >
-        <ElmMdiIcon
-          d={view.d}
-          size="1rem"
-          color={view.color}
-          class={view.pulse ? styles.pulse : undefined}
-        />
-        <ElmInlineText color={view.color}>{label ?? view.label}</ElmInlineText>
+        {/*
+          Reel: the `key` changes whenever the rendered (status, activity,
+          label) tuple does, so Qwik swaps in a fresh node and the CSS
+          roll-in animation replays. The host clips overflow, so the new
+          cell appears to roll up into place — like a slot/odometer.
+        */}
+        <div
+          key={`${status}:${activity}:${displayLabel}`}
+          class={styles["reel"]}
+        >
+          <ElmMdiIcon
+            d={view.d}
+            size="1rem"
+            color={view.color}
+            class={view.pulse ? styles.pulse : undefined}
+          />
+          <ElmInlineText color={view.color}>{displayLabel}</ElmInlineText>
+        </div>
       </div>
     );
   },

--- a/packages/qwik/src/components/ag-ui-client/use-agent.stories.tsx
+++ b/packages/qwik/src/components/ag-ui-client/use-agent.stories.tsx
@@ -32,6 +32,12 @@ const UseAgent = component$<UseAgentProps>(
   ({ class: className, style, url, mcpUrl }) => {
     const context = useStore<Array<{ description: string; value: string }>>([]);
 
+    // Demo toggles for the renderer's display options. Flipping these
+    // re-renders <ElmAgUiAgent> with new props while the agent store
+    // (from useAgent) stays put, so the conversation is preserved.
+    const enableToolCalls = useSignal(true);
+    const enableReasoning = useSignal(true);
+
     // Weather MCP server: tools are listed asynchronously after
     // connect. The returned signal grows as the server becomes ready.
     const { tools: mcpTools } = useMcpTools({
@@ -191,17 +197,71 @@ const UseAgent = component$<UseAgentProps>(
     });
 
     return (
-      <ElmAgUiAgent
-        state={state}
-        send$={send$}
-        retry$={retry$}
-        abort$={abort$}
-        dequeue$={dequeue$}
-        class={className}
-        style={style}
-        prompts={pickerPrompts.value}
-        resolvePrompt$={resolvePrompt$}
-      />
+      <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
+        <div
+          style={{
+            flexShrink: 0,
+            display: "flex",
+            gap: "1rem",
+            alignItems: "center",
+            padding: "0.5rem 0.75rem",
+            borderBottom: "1px solid #ccc",
+            fontSize: "0.875rem",
+          }}
+        >
+          <label
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: "0.375rem",
+              cursor: "pointer",
+            }}
+          >
+            <input
+              type="checkbox"
+              checked={enableToolCalls.value}
+              onChange$={(_event, el) => {
+                enableToolCalls.value = el.checked;
+              }}
+            />
+            Tool calls
+          </label>
+
+          <label
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: "0.375rem",
+              cursor: "pointer",
+            }}
+          >
+            <input
+              type="checkbox"
+              checked={enableReasoning.value}
+              onChange$={(_event, el) => {
+                enableReasoning.value = el.checked;
+              }}
+            />
+            Reasoning
+          </label>
+        </div>
+
+        <div style={{ flex: 1, minHeight: 0 }}>
+          <ElmAgUiAgent
+            state={state}
+            send$={send$}
+            retry$={retry$}
+            abort$={abort$}
+            dequeue$={dequeue$}
+            class={className}
+            style={style}
+            prompts={pickerPrompts.value}
+            resolvePrompt$={resolvePrompt$}
+            enableToolCalls={enableToolCalls.value}
+            enableReasoning={enableReasoning.value}
+          />
+        </div>
+      </div>
     );
   },
 );


### PR DESCRIPTION
## Summary

Three related improvements to the `@elmethis/qwik` AG-UI client, plus a version bump.

### 1. Toggleable tool-call & reasoning display
`ElmAgUiMessageRenderer` gains two optional config props, forwarded through `ElmAgUiAgent`:

- `enableToolCalls?: boolean` — render assistant tool calls (and their results) inline.
- `enableReasoning?: boolean` — render `reasoning` (thinking) messages.

Both default to `true`, so existing behavior is unchanged. Naming follows the repo's `enable*` config-flag convention (matching `enableAutoScroll`). When tool calls are off, an assistant message's text content still renders. The `useAgent` story gains a simple checkbox panel to flip them live (state is preserved across toggles).

### 2. Status indicator moved into the input button row
`ElmAgUiStatus` no longer floats above the textarea — it now sits in the input card's button row, in the `spacer` grid track between the attachment (`+`) button and the stop/send buttons. `ElmAgUiInput` takes `status`/`activity` props and the agent forwards `state.status`/`state.activity`. A long label clips rather than pushing the buttons out of the row.

### 3. Roll-in reel animation on status changes
The status icon + label are wrapped in a keyed `.reel` cell; each `(status, activity, label)` change remounts the node and replays a CSS roll-in, so the new cell appears to roll up into place (slot/odometer feel) as the agent moves through Thinking → Writing → Calling a tool. Gated by `prefers-reduced-motion` alongside the existing icon pulse.

### 4. Version bump
`@elmethis/qwik` → `1.0.0-alpha.33`.

## Testing

- Added unit tests for the toggle behavior (tool calls suppressed / text still shown / reasoning suppressed).
- `build.types` (tsc), eslint, and stylelint clean; status + renderer unit specs pass.
- Animation is CSS-only — a visual check in Storybook (**Components/AG-UI/hooks/useAgent** against the stub `reasoning`/`tool-call` endpoints) is recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)