### PR TITLE
fix(qwik/media): preserve scoped progress var when style prop is passed

### DIFF
--- a/packages/qwik/package.json
+++ b/packages/qwik/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elmethis/qwik",
-  "version": "1.0.0-alpha.33",
+  "version": "1.0.0-alpha.34",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/qwik/src/components/media/elm-audio-player.tsx
+++ b/packages/qwik/src/components/media/elm-audio-player.tsx
@@ -1,6 +1,7 @@
 import {
   $,
   component$,
+  type CSSProperties,
   PropsOf,
   useComputed$,
   useSignal,
@@ -88,6 +89,7 @@ const fileNameFromSrc = (src: string): string => {
 export const ElmAudioPlayer = component$<ElmAudioPlayerProps>((props) => {
   const {
     class: className,
+    style,
     src,
     title,
     artist,
@@ -201,6 +203,7 @@ export const ElmAudioPlayer = component$<ElmAudioPlayerProps>((props) => {
       style={{
         "--elmethis-scoped-progress": progress.value,
         "--elmethis-scoped-hover": hoverRatio.value ?? 0,
+        ...(style as CSSProperties),
       }}
       {...rest}
     >


### PR DESCRIPTION
## Problem

The A2UI `Audio` block-catalog story plays audio, but the seek bar never moves.

`ElmAudioPlayer` works when used standalone, but the catalog renderer passes `style={firstChildMargin(index)}` to it. Since the player is the root component (`index === 0`), it receives `style={{ marginBlockStart: 0 }}`.

Inside the component, `style` was **not** destructured, so it stayed in `...rest`. The root `<div>` placed `{...rest}` **after** the inline `style={{ "--elmethis-scoped-progress": ... }}`, so the incoming `style` clobbered the entire inline style — including `--elmethis-scoped-progress`. The fill width (`calc(var(--elmethis-scoped-progress, 0) * 100%)`) then fell back to `0`, so the bar stayed put.

The standalone story passes no `style`, which is why the bug never surfaced there.

## Fix

Destructure `style` and merge it into the inline style object, matching the convention already used in `elm-heading.tsx` / `elm-switch.tsx`:

```tsx
style={{
  "--elmethis-scoped-progress": progress.value,
  "--elmethis-scoped-hover": hoverRatio.value ?? 0,
  ...(style as CSSProperties),
}}
{...rest}
```

The catalog's `marginBlockStart: 0` still applies, and the scoped progress variable survives.

## Verification

- `pnpm build.types` ✅
- `pnpm lint` ✅
- pre-commit `check` (fmt / lint / lint.css / build.types across all packages) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)