### PR TITLE
feat: add ElmButtonDropdown split button-dropdown (react, qwik, vue)

### DIFF
--- a/packages/qwik/package.json
+++ b/packages/qwik/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elmethis/qwik",
-  "version": "1.0.0-alpha.34",
+  "version": "1.0.0-alpha.35",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/qwik/src/components/form/elm-button-dropdown.browser.spec.tsx
+++ b/packages/qwik/src/components/form/elm-button-dropdown.browser.spec.tsx
@@ -1,0 +1,57 @@
+import { component$, useSignal } from "@qwik.dev/core";
+import { render } from "vitest-browser-qwik";
+import { describe, expect, test, vi } from "vitest";
+
+import { ElmButtonDropdown } from "./elm-button-dropdown";
+
+// ElmButtonDropdown renders its menu items with a per-iteration inline
+// `onClick$` inside `items.map(...)` — the same QRL-in-iteration shape that
+// failed to resolve elsewhere (see [[feedback_qwik_qrl_in_jsx_iteration]]).
+// createDOM can't catch it because it doesn't run the real optimizer, so this
+// real-browser spec drives an actual item click: a broken handler surfaces as
+// "selection never changes". See [[project_qwik_browser_testing]].
+
+// `items` is created inside the component (NOT a captured module const) so the
+// lazy segment doesn't re-import this spec module mid-test.
+const Harness = component$(() => {
+  const selected = useSignal<string | null>(null);
+  return (
+    <div>
+      <output data-testid="selected">{String(selected.value)}</output>
+      <ElmButtonDropdown
+        label="Run"
+        selectedOptionId={selected}
+        items={[
+          { id: "edit", label: "Edit" },
+          { id: "remove", label: "Remove" },
+        ]}
+      />
+    </div>
+  );
+});
+
+// The main button reflects the selection; scope to it so the same label still
+// present in the collapsed menu row doesn't match.
+const mainButtonText = () =>
+  document.querySelector('[class*="main"]')?.textContent ?? "";
+
+describe("[CSR] ElmButtonDropdown selection", () => {
+  test("the caret opens the menu and an item click updates the binding + display", async () => {
+    const screen = await render(<Harness />);
+
+    // The caret toggles the menu open.
+    await screen.getByRole("button", { name: "Toggle dropdown" }).click();
+
+    // Click an item — this is the QRL-in-iteration handler under test. If it
+    // failed to resolve, the binding would never change.
+    await screen.getByText("Remove").click();
+
+    await vi.waitFor(() =>
+      expect(screen.getByTestId("selected").element().textContent).toBe(
+        "remove",
+      ),
+    );
+    // The main action button now reflects the chosen option.
+    await vi.waitFor(() => expect(mainButtonText()).toContain("Remove"));
+  });
+});

--- a/packages/qwik/src/components/form/elm-button-dropdown.module.css
+++ b/packages/qwik/src/components/form/elm-button-dropdown.module.css
@@ -1,0 +1,86 @@
+.elm-button-dropdown {
+  position: relative;
+  box-sizing: border-box;
+  display: inline-flex;
+  align-items: stretch;
+
+  &.block {
+    display: flex;
+    width: 100%;
+
+    .main {
+      flex: 1 1 auto;
+    }
+  }
+
+  /* The two ElmButton segments are joined into one control. Descendant
+     selectors here outrank ElmButton's own single-class rules, so corners,
+     padding, and the hover transform retune without `!important`. */
+  .main {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+
+  .caret {
+    box-sizing: border-box;
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+    padding-left: 0.75rem;
+    padding-right: 0.75rem;
+    border-left: 1px solid light-dark(rgb(0 0 0 / 15%), rgb(255 255 255 / 20%));
+  }
+
+  /* Keep the joined control from shifting per-segment on hover/active. */
+  .segment:hover,
+  .segment:active {
+    transform: none;
+  }
+
+  .menu {
+    position: absolute;
+    top: calc(100% + 0.25rem);
+    left: 0;
+    z-index: 100;
+    box-sizing: border-box;
+    width: max-content;
+    min-width: 100%;
+    border-radius: 0.25rem;
+    background-color: light-dark(rgb(255 255 255 / 95%), rgb(51 51 51 / 95%));
+    box-shadow: 0 0 0.125rem light-dark(rgb(0 0 0 / 15%), rgb(0 0 0 / 75%));
+
+    .item {
+      overflow: hidden;
+      width: 100%;
+      padding: 0.5rem;
+      box-sizing: border-box;
+      border-radius: 0.25rem;
+      display: flex;
+      justify-content: flex-start;
+      align-items: center;
+      gap: 0.25rem;
+      transition: background-color 100ms;
+      cursor: pointer;
+
+      &:hover {
+        background-color: light-dark(
+          rgb(190 194 202 / 30%),
+          rgb(190 194 202 / 20%)
+        );
+      }
+
+      &.selected {
+        background-color: light-dark(
+          rgb(190 194 202 / 25%),
+          rgb(190 194 202 / 15%)
+        );
+        color: var(--elmethis-color-primary-weak);
+      }
+
+      &.item-disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+        pointer-events: none;
+      }
+    }
+  }
+}

--- a/packages/qwik/src/components/form/elm-button-dropdown.spec.tsx
+++ b/packages/qwik/src/components/form/elm-button-dropdown.spec.tsx
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "vitest";
+import { component$, useSignal } from "@qwik.dev/core";
+import { renderToString } from "@qwik.dev/core/server";
+
+import {
+  ElmButtonDropdown,
+  type ElmButtonDropdownItem,
+} from "./elm-button-dropdown";
+
+// Option-click selection (clipped collapse list, per-item QRL handlers, real
+// `useVisibleTask$`) lives in elm-button-dropdown.browser.spec.tsx — createDOM
+// can't run the visible task. The unit layer covers the SSR shell: the two
+// button segments, the placeholder, and the selected option's label.
+
+const ITEMS: ElmButtonDropdownItem[] = [
+  { id: "edit", label: "Edit" },
+  { id: "remove", label: "Remove", disabled: true },
+];
+
+const countButtons = (html: string) => html.split("<button").length - 1;
+
+describe("[SSR] ElmButtonDropdown", () => {
+  test("renders two buttons: the main action and the caret toggle", async () => {
+    const Harness = component$(() => {
+      const selected = useSignal<string | null>(null);
+      return (
+        <ElmButtonDropdown
+          label="Choose"
+          items={ITEMS}
+          selectedOptionId={selected}
+        />
+      );
+    });
+
+    const { html } = await renderToString(<Harness />, {
+      containerTagName: "div",
+    });
+    expect(countButtons(html)).toBe(2);
+  });
+
+  test("shows the placeholder when nothing is selected", async () => {
+    const Harness = component$(() => {
+      const selected = useSignal<string | null>(null);
+      return (
+        <ElmButtonDropdown
+          label="Choose an action"
+          items={ITEMS}
+          selectedOptionId={selected}
+        />
+      );
+    });
+
+    const { html } = await renderToString(<Harness />, {
+      containerTagName: "div",
+    });
+    expect(html).toContain("Choose an action");
+  });
+
+  test("displays the selected option's label on the main button", async () => {
+    const Harness = component$(() => {
+      const selected = useSignal<string | null>("edit");
+      return (
+        <ElmButtonDropdown
+          label="Choose an action"
+          items={ITEMS}
+          selectedOptionId={selected}
+        />
+      );
+    });
+
+    const { html } = await renderToString(<Harness />, {
+      containerTagName: "div",
+    });
+    // Scope to the main button's visible text — qwik serializes the unused
+    // `label` prop into its resumability state, so a global search would still
+    // find the placeholder string there. The first `_flex` span after `_main_`
+    // is the main button's content.
+    const fromMain = html.slice(html.indexOf("_main_"));
+    const mainText =
+      fromMain.match(/_flex[^"]*">([\s\S]*?)<\/span>/)?.[1] ?? "";
+    expect(mainText).toContain("Edit");
+    expect(mainText).not.toContain("Choose an action");
+  });
+
+  test("disabled forwards the native attribute onto both buttons", async () => {
+    const Harness = component$(() => {
+      const selected = useSignal<string | null>(null);
+      return (
+        <ElmButtonDropdown
+          label="Choose"
+          items={ITEMS}
+          selectedOptionId={selected}
+          disabled
+        />
+      );
+    });
+
+    const { html } = await renderToString(<Harness />, {
+      containerTagName: "div",
+    });
+    const disabledButtons = html.match(/<button[^>]*\bdisabled\b/g) ?? [];
+    expect(disabledButtons.length).toBe(2);
+  });
+});

--- a/packages/qwik/src/components/form/elm-button-dropdown.stories.tsx
+++ b/packages/qwik/src/components/form/elm-button-dropdown.stories.tsx
@@ -1,0 +1,141 @@
+import { component$, useSignal } from "@qwik.dev/core";
+import type { Meta, StoryObj } from "storybook-framework-qwik";
+
+import {
+  ElmButtonDropdown,
+  type ElmButtonDropdownItem,
+  type ElmButtonDropdownProps,
+} from "./elm-button-dropdown";
+
+import MiniMax from "../../assets/images/minimax.svg?url";
+import OpenAI from "../../assets/images/openai.svg?url";
+import Claude from "../../assets/images/claude.svg?url";
+
+const MODELS: ElmButtonDropdownItem[] = [
+  { id: "claude", label: "Claude Opus 4.7", icon: Claude },
+  { id: "gpt", label: "GPT-5.4 Mini", icon: OpenAI },
+  { id: "minimax", label: "MiniMax M2.5", icon: MiniMax },
+];
+
+const meta: Meta<ElmButtonDropdownProps> = {
+  title: "Components/Form/elm-button-dropdown",
+  component: ElmButtonDropdown,
+  tags: ["autodocs"],
+  args: {
+    label: "Select a model",
+  },
+};
+
+export default meta;
+type Story = StoryObj<ElmButtonDropdownProps>;
+
+const PrimaryDropdown = component$(() => {
+  const selectedOptionId = useSignal<string | null>(null);
+  return (
+    <ElmButtonDropdown
+      label="Select a model"
+      items={MODELS}
+      selectedOptionId={selectedOptionId}
+    />
+  );
+});
+
+export const Primary: Story = {
+  render: () => <PrimaryDropdown />,
+};
+
+const PreselectedDropdown = component$(() => {
+  const selectedOptionId = useSignal<string | null>("claude");
+  return (
+    <ElmButtonDropdown
+      label="Select a model"
+      items={MODELS}
+      selectedOptionId={selectedOptionId}
+    />
+  );
+});
+
+export const Preselected: Story = {
+  render: () => <PreselectedDropdown />,
+};
+
+const BlockDropdown = component$(() => {
+  const selectedOptionId = useSignal<string | null>(null);
+  return (
+    <ElmButtonDropdown
+      label="Select a model"
+      items={MODELS}
+      selectedOptionId={selectedOptionId}
+      block
+    />
+  );
+});
+
+export const Block: Story = {
+  render: () => <BlockDropdown />,
+};
+
+const DisabledDropdown = component$(() => {
+  const selectedOptionId = useSignal<string | null>(null);
+  return (
+    <ElmButtonDropdown
+      label="Select a model"
+      items={MODELS}
+      selectedOptionId={selectedOptionId}
+      disabled
+    />
+  );
+});
+
+export const Disabled: Story = {
+  render: () => <DisabledDropdown />,
+};
+
+const LoadingDropdown = component$(() => {
+  const selectedOptionId = useSignal<string | null>(null);
+  return (
+    <ElmButtonDropdown
+      label="Select a model"
+      items={MODELS}
+      selectedOptionId={selectedOptionId}
+      isLoading
+    />
+  );
+});
+
+export const Loading: Story = {
+  render: () => <LoadingDropdown />,
+};
+
+const ControlledDropdown = component$(() => {
+  const selectedOptionId = useSignal<string | null>(null);
+  const log = useSignal<string>("none");
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+      <ElmButtonDropdown
+        label="Select a model"
+        items={MODELS}
+        selectedOptionId={selectedOptionId}
+        onClick$={(item) => {
+          log.value = `run: ${item?.id ?? "none"}`;
+        }}
+      />
+      <div style={{ fontFamily: "monospace", fontSize: "0.85rem" }}>
+        <div>selected: {selectedOptionId.value ?? "none"}</div>
+        <div>last run: {log.value}</div>
+      </div>
+      <button
+        onClick$={() => {
+          selectedOptionId.value = null;
+        }}
+      >
+        Clear selection
+      </button>
+    </div>
+  );
+});
+
+export const Controlled: Story = {
+  render: () => <ControlledDropdown />,
+};

--- a/packages/qwik/src/components/form/elm-button-dropdown.tsx
+++ b/packages/qwik/src/components/form/elm-button-dropdown.tsx
@@ -1,0 +1,254 @@
+import {
+  $,
+  component$,
+  PropsOf,
+  QRL,
+  Signal,
+  useComputed$,
+  useSignal,
+  useVisibleTask$,
+} from "@qwik.dev/core";
+import { mdiChevronRight, mdiMenuDown } from "@mdi/js";
+
+import { ElmButton } from "./elm-button";
+import { ElmMdiIcon } from "../icon/elm-mdi-icon";
+import { ElmInlineIcon } from "../icon/elm-inline-icon";
+import { ElmInlineText } from "../typography/elm-inline-text";
+import { ElmCollapse } from "../containments/elm-collapse";
+import styles from "./elm-button-dropdown.module.css";
+import textStyles from "../../styles/text.module.css";
+
+export interface ElmButtonDropdownItem {
+  id: string;
+  label: string;
+  /**
+   * Optional icon URL displayed alongside the item label.
+   */
+  icon?: string;
+  /**
+   * Whether the item is disabled and cannot be clicked.
+   */
+  disabled?: boolean;
+  /**
+   * Called when this item is clicked.
+   */
+  onClick$?: QRL<() => void>;
+}
+
+// Display/form dual-use component: like ElmSelect, it binds a
+// `selectedOptionId: Signal<string | null>` directly rather than adopting
+// `useBindableSignal`'s controlled/uncontrolled split.
+export interface ElmButtonDropdownProps extends Omit<
+  PropsOf<"div">,
+  "onClick$"
+> {
+  /**
+   * Main button content shown when no option is selected (placeholder).
+   */
+  label?: string;
+
+  /**
+   * Entries shown in the dropdown menu.
+   */
+  items: ElmButtonDropdownItem[];
+
+  /**
+   * Currently selected option id. The main button displays the matching item.
+   */
+  selectedOptionId: Signal<string | null>;
+
+  /**
+   * Whether the button uses the primary style. Defaults to `true`.
+   */
+  primary?: boolean;
+
+  /**
+   * Custom button color. Overrides `primary` when set.
+   */
+  color?: string;
+
+  /**
+   * Whether the control fills the width of its container.
+   */
+  block?: boolean;
+
+  /**
+   * Whether the whole control is disabled.
+   */
+  disabled?: boolean;
+
+  /**
+   * Whether only the main button is disabled. The dropdown caret stays
+   * interactive.
+   */
+  disableMainButton?: boolean;
+
+  /**
+   * Whether only the dropdown caret is disabled. The main button stays
+   * interactive.
+   */
+  disableDropdown?: boolean;
+
+  /**
+   * Whether the main button is in a loading state.
+   */
+  isLoading?: boolean;
+
+  /**
+   * Whether the menu closes automatically after an item is clicked. Defaults
+   * to `true`.
+   */
+  autoClose?: boolean;
+
+  /**
+   * mdi path for the caret icon. Defaults to `mdiMenuDown`.
+   */
+  dropdownIcon?: string;
+
+  /**
+   * Main button click handler. Receives the currently selected item, or
+   * `null` when nothing is selected.
+   */
+  onClick$?: QRL<(selectedItem: ElmButtonDropdownItem | null) => void>;
+
+  /**
+   * Called with the clicked dropdown item.
+   */
+  onItemClick$?: QRL<(item: ElmButtonDropdownItem) => void>;
+
+  /**
+   * Called whenever the dropdown opens or closes.
+   */
+  onOpenChange$?: QRL<(isOpen: boolean) => void>;
+}
+
+export const ElmButtonDropdown = component$<ElmButtonDropdownProps>((props) => {
+  const {
+    class: className,
+    style,
+    label,
+    items,
+    selectedOptionId,
+    primary = true,
+    color,
+    block,
+    disabled,
+    disableMainButton,
+    disableDropdown,
+    isLoading,
+    dropdownIcon = mdiMenuDown,
+    onClick$,
+    onItemClick$,
+    onOpenChange$,
+    ...rest
+  } = props;
+
+  const selectedOption = useComputed$(
+    () => items.find((item) => item.id === selectedOptionId.value) ?? null,
+  );
+
+  const isOpen = useSignal(false);
+  const containerRef = useSignal<Element>();
+
+  // Single source for open/close so the open-change callback fires from every
+  // path (caret, item select, outside click).
+  const setOpen$ = $((next: boolean) => {
+    if (isOpen.value === next) return;
+    isOpen.value = next;
+    void onOpenChange$?.(next);
+  });
+
+  // eslint-disable-next-line qwik/no-use-visible-task
+  useVisibleTask$(({ cleanup }) => {
+    const handler = (event: MouseEvent) => {
+      if (!isOpen.value || !containerRef.value) return;
+      const target = event.target as Node;
+      if (!containerRef.value.contains(target)) {
+        void setOpen$(false);
+      }
+    };
+    document.addEventListener("click", handler);
+    cleanup(() => document.removeEventListener("click", handler));
+  });
+
+  const dropdownDisabled = disabled || disableDropdown || isLoading;
+  const mainDisabled = disabled || disableMainButton;
+
+  return (
+    <div
+      ref={containerRef}
+      class={[styles["elm-button-dropdown"], block && styles.block, className]}
+      style={style}
+      {...rest}
+    >
+      <ElmButton
+        class={[styles.main, styles.segment]}
+        primary={primary}
+        color={color}
+        isLoading={isLoading}
+        disabled={mainDisabled}
+        onClick$={$(() => {
+          void onClick$?.(selectedOption.value);
+        })}
+      >
+        {selectedOption.value ? (
+          <>
+            {selectedOption.value.icon && (
+              <ElmInlineIcon src={selectedOption.value.icon} />
+            )}
+            {selectedOption.value.label}
+          </>
+        ) : (
+          label
+        )}
+      </ElmButton>
+
+      <ElmButton
+        class={[styles.caret, styles.segment]}
+        primary={primary}
+        color={color}
+        disabled={dropdownDisabled}
+        aria-label="Toggle dropdown"
+        aria-expanded={isOpen.value}
+        onClick$={$(() => {
+          void setOpen$(!isOpen.value);
+        })}
+      >
+        <ElmMdiIcon d={dropdownIcon} size="1.25rem" />
+      </ElmButton>
+
+      <ElmCollapse isOpen={isOpen.value} class={styles.menu}>
+        {items.map((item) => (
+          <div
+            key={item.id}
+            class={[
+              styles.item,
+              textStyles.text,
+              item.id === selectedOptionId.value && styles.selected,
+              item.disabled && styles["item-disabled"],
+            ]}
+            aria-selected={item.id === selectedOptionId.value}
+            onClick$={(event) => {
+              event.stopPropagation();
+              if (item.disabled) return;
+              selectedOptionId.value = item.id;
+              void item.onClick$?.();
+              void onItemClick$?.(item);
+              if (props.autoClose !== false) {
+                void setOpen$(false);
+              }
+            }}
+          >
+            <ElmMdiIcon
+              d={mdiChevronRight}
+              color="var(--elmethis-color-primary-weak)"
+              size="0.75em"
+            />
+            {item.icon && <ElmInlineIcon src={item.icon} />}
+            <ElmInlineText>{item.label}</ElmInlineText>
+          </div>
+        ))}
+      </ElmCollapse>
+    </div>
+  );
+});

--- a/packages/qwik/src/index.ts
+++ b/packages/qwik/src/index.ts
@@ -180,6 +180,11 @@ export {
 // | Form |
 export { ElmButton, type ElmButtonProps } from "./components/form/elm-button";
 export {
+  ElmButtonDropdown,
+  type ElmButtonDropdownItem,
+  type ElmButtonDropdownProps,
+} from "./components/form/elm-button-dropdown";
+export {
   ElmCheckbox,
   type ElmCheckboxProps,
 } from "./components/form/elm-checkbox";

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elmethis/react",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "React component library for elmethis.",
   "publishConfig": {
     "access": "public"

--- a/packages/react/src/components/form/elm-button-dropdown.browser.spec.tsx
+++ b/packages/react/src/components/form/elm-button-dropdown.browser.spec.tsx
@@ -1,0 +1,84 @@
+import { render } from "vitest-browser-react";
+import { describe, expect, test, vi } from "vitest";
+
+import {
+  ElmButtonDropdown,
+  type ElmButtonDropdownItem,
+} from "./elm-button-dropdown";
+
+// ElmButtonDropdown's menu is rendered by ElmCollapse, which clips its content
+// (grid-template-rows: 0fr + overflow: hidden) instead of removing it — so the
+// items always report "visible". Open/closed is observed via the caret's
+// `aria-expanded`. The per-item inline `onClick`, the two-segment split (main
+// fires `onClick`, caret toggles), and the outside-click close all need a real
+// browser, so they are exercised here rather than in the SSR layer.
+
+const ITEMS: ElmButtonDropdownItem[] = [
+  { id: "edit", label: "Edit" },
+  { id: "remove", label: "Remove" },
+];
+
+const Harness = (props: {
+  onClick?: () => void;
+  onItemClick?: (item: ElmButtonDropdownItem) => void;
+}) => (
+  <div>
+    <button>outside</button>
+    <ElmButtonDropdown
+      label="Run"
+      items={ITEMS}
+      onClick={props.onClick}
+      onItemClick={props.onItemClick}
+    />
+  </div>
+);
+
+const expanded = (el: Element) => el.getAttribute("aria-expanded") === "true";
+
+describe("[CSR] ElmButtonDropdown", () => {
+  test("the caret opens the menu and an item click fires its handler then closes it", async () => {
+    const onItemClick = vi.fn();
+    const screen = await render(<Harness onItemClick={onItemClick} />);
+
+    const caret = screen.getByRole("button", { name: "Toggle dropdown" });
+    expect(expanded(caret.element())).toBe(false);
+
+    await caret.click();
+    await vi.waitFor(() => expect(expanded(caret.element())).toBe(true));
+
+    await screen.getByText("Remove").click();
+    await vi.waitFor(() =>
+      expect(onItemClick).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "remove" }),
+      ),
+    );
+    // autoClose defaults to true, so selecting an item closes the menu.
+    await vi.waitFor(() => expect(expanded(caret.element())).toBe(false));
+  });
+
+  test("the main button fires onClick without opening the menu", async () => {
+    const onClick = vi.fn();
+    const onItemClick = vi.fn();
+    const screen = await render(
+      <Harness onClick={onClick} onItemClick={onItemClick} />,
+    );
+
+    await screen.getByRole("button", { name: "Run" }).click();
+    expect(onClick).toHaveBeenCalledTimes(1);
+
+    const caret = screen.getByRole("button", { name: "Toggle dropdown" });
+    expect(expanded(caret.element())).toBe(false);
+    expect(onItemClick).not.toHaveBeenCalled();
+  });
+
+  test("clicking outside closes the open menu", async () => {
+    const screen = await render(<Harness />);
+
+    const caret = screen.getByRole("button", { name: "Toggle dropdown" });
+    await caret.click();
+    await vi.waitFor(() => expect(expanded(caret.element())).toBe(true));
+
+    await screen.getByText("outside").click();
+    await vi.waitFor(() => expect(expanded(caret.element())).toBe(false));
+  });
+});

--- a/packages/react/src/components/form/elm-button-dropdown.browser.spec.tsx
+++ b/packages/react/src/components/form/elm-button-dropdown.browser.spec.tsx
@@ -56,6 +56,25 @@ describe("[CSR] ElmButtonDropdown", () => {
     await vi.waitFor(() => expect(expanded(caret.element())).toBe(false));
   });
 
+  test("selecting an item updates the displayed main button label", async () => {
+    const screen = await render(<Harness />);
+
+    // The main button starts on the placeholder label.
+    expect(screen.getByRole("button", { name: "Run" }).element()).toBeTruthy();
+
+    const caret = screen.getByRole("button", { name: "Toggle dropdown" });
+    await caret.click();
+    await screen.getByText("Remove").click();
+
+    // The main action button now reflects the chosen option. It is the only
+    // <button> carrying that name — menu rows are <div>s.
+    await vi.waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Remove" }).element(),
+      ).toBeTruthy(),
+    );
+  });
+
   test("the main button fires onClick without opening the menu", async () => {
     const onClick = vi.fn();
     const onItemClick = vi.fn();

--- a/packages/react/src/components/form/elm-button-dropdown.module.css
+++ b/packages/react/src/components/form/elm-button-dropdown.module.css
@@ -68,6 +68,14 @@
         );
       }
 
+      &.selected {
+        background-color: light-dark(
+          rgb(190 194 202 / 25%),
+          rgb(190 194 202 / 15%)
+        );
+        color: var(--elmethis-color-primary-weak);
+      }
+
       &.item-disabled {
         opacity: 0.5;
         cursor: not-allowed;

--- a/packages/react/src/components/form/elm-button-dropdown.module.css
+++ b/packages/react/src/components/form/elm-button-dropdown.module.css
@@ -1,0 +1,78 @@
+.elm-button-dropdown {
+  position: relative;
+  box-sizing: border-box;
+  display: inline-flex;
+  align-items: stretch;
+
+  &.block {
+    display: flex;
+    width: 100%;
+
+    .main {
+      flex: 1 1 auto;
+    }
+  }
+
+  /* The two ElmButton segments are joined into one control. Descendant
+     selectors here outrank ElmButton's own single-class rules, so corners,
+     padding, and the hover transform retune without `!important`. */
+  .main {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+
+  .caret {
+    box-sizing: border-box;
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+    padding-left: 0.75rem;
+    padding-right: 0.75rem;
+    border-left: 1px solid light-dark(rgb(0 0 0 / 15%), rgb(255 255 255 / 20%));
+  }
+
+  /* Keep the joined control from shifting per-segment on hover/active. */
+  .segment:hover,
+  .segment:active {
+    transform: none;
+  }
+
+  .menu {
+    position: absolute;
+    top: calc(100% + 0.25rem);
+    left: 0;
+    z-index: 100;
+    box-sizing: border-box;
+    width: max-content;
+    min-width: 100%;
+    border-radius: 0.25rem;
+    background-color: light-dark(rgb(255 255 255 / 95%), rgb(51 51 51 / 95%));
+    box-shadow: 0 0 0.125rem light-dark(rgb(0 0 0 / 15%), rgb(0 0 0 / 75%));
+
+    .item {
+      overflow: hidden;
+      width: 100%;
+      padding: 0.5rem;
+      box-sizing: border-box;
+      border-radius: 0.25rem;
+      display: flex;
+      justify-content: flex-start;
+      align-items: center;
+      gap: 0.25rem;
+      transition: background-color 100ms;
+      cursor: pointer;
+
+      &:hover {
+        background-color: light-dark(
+          rgb(190 194 202 / 30%),
+          rgb(190 194 202 / 20%)
+        );
+      }
+
+      &.item-disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+        pointer-events: none;
+      }
+    }
+  }
+}

--- a/packages/react/src/components/form/elm-button-dropdown.spec.tsx
+++ b/packages/react/src/components/form/elm-button-dropdown.spec.tsx
@@ -21,6 +21,25 @@ describe("[SSR] ElmButtonDropdown", () => {
     expect(html).toContain("Delete");
   });
 
+  it("shows the placeholder when nothing is selected and the option once selected", () => {
+    const placeholder = renderToStaticMarkup(
+      <ElmButtonDropdown label="Pick an action" items={ITEMS} />,
+    );
+    expect(placeholder).toContain("Pick an action");
+
+    const selected = renderToStaticMarkup(
+      <ElmButtonDropdown
+        label="Pick an action"
+        selectedOptionId="save"
+        items={ITEMS}
+      />,
+    );
+    // The main button now reflects the selected option, so the placeholder is
+    // gone and "Save" appears for both the main button and the menu row.
+    expect(selected).not.toContain("Pick an action");
+    expect(selected.split("Save").length - 1).toBe(2);
+  });
+
   it("renders two buttons: the main action and the caret toggle", () => {
     const html = renderToStaticMarkup(
       <ElmButtonDropdown label="Save" items={ITEMS} />,

--- a/packages/react/src/components/form/elm-button-dropdown.spec.tsx
+++ b/packages/react/src/components/form/elm-button-dropdown.spec.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import {
+  ElmButtonDropdown,
+  type ElmButtonDropdownItem,
+} from "./elm-button-dropdown";
+
+const ITEMS: ElmButtonDropdownItem[] = [
+  { id: "save", label: "Save" },
+  { id: "delete", label: "Delete", disabled: true },
+];
+
+describe("[SSR] ElmButtonDropdown", () => {
+  it("renders the main label and the menu items", () => {
+    const html = renderToStaticMarkup(
+      <ElmButtonDropdown label="Actions" items={ITEMS} />,
+    );
+    expect(html).toContain("Actions");
+    expect(html).toContain("Save");
+    expect(html).toContain("Delete");
+  });
+
+  it("renders two buttons: the main action and the caret toggle", () => {
+    const html = renderToStaticMarkup(
+      <ElmButtonDropdown label="Save" items={ITEMS} />,
+    );
+    const count = html.split("<button").length - 1;
+    expect(count).toBe(2);
+  });
+
+  it("disables both buttons when the whole control is disabled", () => {
+    const html = renderToStaticMarkup(
+      <ElmButtonDropdown label="Save" disabled items={ITEMS} />,
+    );
+    // Both the main button and the caret button carry the disabled attribute.
+    expect(html.match(/<button disabled/g)?.length).toBe(2);
+  });
+
+  it("disables only the caret when disableDropdown is set", () => {
+    const html = renderToStaticMarkup(
+      <ElmButtonDropdown label="Save" disableDropdown items={ITEMS} />,
+    );
+    expect(html.match(/<button disabled/g)?.length).toBe(1);
+  });
+
+  it("disables only the main button when disableMainButton is set", () => {
+    const html = renderToStaticMarkup(
+      <ElmButtonDropdown label="Save" disableMainButton items={ITEMS} />,
+    );
+    expect(html.match(/<button disabled/g)?.length).toBe(1);
+  });
+});

--- a/packages/react/src/components/form/elm-button-dropdown.stories.tsx
+++ b/packages/react/src/components/form/elm-button-dropdown.stories.tsx
@@ -1,28 +1,22 @@
 import { useState, type ComponentProps } from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { mdiContentSave } from "@mdi/js";
 
 import {
   ElmButtonDropdown,
   type ElmButtonDropdownItem,
 } from "./elm-button-dropdown";
-import { ElmMdiIcon } from "../icon/elm-mdi-icon";
 
-const Claude =
-  "https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/claude-color.svg";
+const MiniMax =
+  "https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/minimax-color.svg";
 const OpenAI =
   "https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/openai.svg";
-
-const ITEMS: ElmButtonDropdownItem[] = [
-  { id: "save", label: "Save" },
-  { id: "save-as", label: "Save as…" },
-  { id: "duplicate", label: "Duplicate" },
-  { id: "delete", label: "Delete", disabled: true },
-];
+const Claude =
+  "https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/claude-color.svg";
 
 const MODELS: ElmButtonDropdownItem[] = [
   { id: "claude", label: "Claude Opus 4.7", icon: Claude },
   { id: "gpt", label: "GPT-5.4 Mini", icon: OpenAI },
+  { id: "minimax", label: "MiniMax M2.5", icon: MiniMax },
 ];
 
 const meta = {
@@ -30,9 +24,8 @@ const meta = {
   component: ElmButtonDropdown,
   tags: ["autodocs"],
   args: {
-    label: "Save",
-    icon: <ElmMdiIcon d={mdiContentSave} />,
-    items: ITEMS,
+    label: "Select a model",
+    items: MODELS,
   },
 } satisfies Meta<typeof ElmButtonDropdown>;
 
@@ -41,11 +34,9 @@ type Story = StoryObj<typeof meta>;
 
 export const Primary: Story = {};
 
-export const WithItemIcons: Story = {
+export const Preselected: Story = {
   args: {
-    label: "Model",
-    icon: undefined,
-    items: MODELS,
+    defaultSelectedOptionId: "claude",
   },
 };
 
@@ -79,23 +70,27 @@ export const Loading: Story = {
   },
 };
 
-const InteractiveStory = (args: ComponentProps<typeof ElmButtonDropdown>) => {
+const ControlledStory = (args: ComponentProps<typeof ElmButtonDropdown>) => {
+  const [selectedOptionId, setSelectedOptionId] = useState<string | null>(null);
   const [log, setLog] = useState<string>("none");
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
       <ElmButtonDropdown
         {...args}
-        onClick={() => setLog("main button clicked")}
-        onItemClick={(item) => setLog(`item clicked: ${item.id}`)}
+        selectedOptionId={selectedOptionId}
+        onSelectedOptionIdChange={setSelectedOptionId}
+        onClick={(item) => setLog(`run: ${item?.id ?? "none"}`)}
       />
       <div style={{ fontFamily: "monospace", fontSize: "0.85rem" }}>
-        last action: {log}
+        <div>selected: {selectedOptionId ?? "none"}</div>
+        <div>last run: {log}</div>
       </div>
+      <button onClick={() => setSelectedOptionId(null)}>Clear selection</button>
     </div>
   );
 };
 
-export const Interactive: Story = {
-  render: (args) => <InteractiveStory {...args} />,
+export const Controlled: Story = {
+  render: (args) => <ControlledStory {...args} />,
 };

--- a/packages/react/src/components/form/elm-button-dropdown.stories.tsx
+++ b/packages/react/src/components/form/elm-button-dropdown.stories.tsx
@@ -1,0 +1,101 @@
+import { useState, type ComponentProps } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { mdiContentSave } from "@mdi/js";
+
+import {
+  ElmButtonDropdown,
+  type ElmButtonDropdownItem,
+} from "./elm-button-dropdown";
+import { ElmMdiIcon } from "../icon/elm-mdi-icon";
+
+const Claude =
+  "https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/claude-color.svg";
+const OpenAI =
+  "https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/openai.svg";
+
+const ITEMS: ElmButtonDropdownItem[] = [
+  { id: "save", label: "Save" },
+  { id: "save-as", label: "Save as…" },
+  { id: "duplicate", label: "Duplicate" },
+  { id: "delete", label: "Delete", disabled: true },
+];
+
+const MODELS: ElmButtonDropdownItem[] = [
+  { id: "claude", label: "Claude Opus 4.7", icon: Claude },
+  { id: "gpt", label: "GPT-5.4 Mini", icon: OpenAI },
+];
+
+const meta = {
+  title: "Components/Form/elm-button-dropdown",
+  component: ElmButtonDropdown,
+  tags: ["autodocs"],
+  args: {
+    label: "Save",
+    icon: <ElmMdiIcon d={mdiContentSave} />,
+    items: ITEMS,
+  },
+} satisfies Meta<typeof ElmButtonDropdown>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {};
+
+export const WithItemIcons: Story = {
+  args: {
+    label: "Model",
+    icon: undefined,
+    items: MODELS,
+  },
+};
+
+export const Block: Story = {
+  args: {
+    block: true,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
+};
+
+export const DisableMainButton: Story = {
+  args: {
+    disableMainButton: true,
+  },
+};
+
+export const DisableDropdown: Story = {
+  args: {
+    disableDropdown: true,
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    isLoading: true,
+  },
+};
+
+const InteractiveStory = (args: ComponentProps<typeof ElmButtonDropdown>) => {
+  const [log, setLog] = useState<string>("none");
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+      <ElmButtonDropdown
+        {...args}
+        onClick={() => setLog("main button clicked")}
+        onItemClick={(item) => setLog(`item clicked: ${item.id}`)}
+      />
+      <div style={{ fontFamily: "monospace", fontSize: "0.85rem" }}>
+        last action: {log}
+      </div>
+    </div>
+  );
+};
+
+export const Interactive: Story = {
+  render: (args) => <InteractiveStory {...args} />,
+};

--- a/packages/react/src/components/form/elm-button-dropdown.tsx
+++ b/packages/react/src/components/form/elm-button-dropdown.tsx
@@ -1,0 +1,248 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ComponentPropsWithoutRef,
+  type CSSProperties,
+  type ReactNode,
+} from "react";
+import { clsx } from "clsx";
+import { mdiChevronRight, mdiMenuDown } from "@mdi/js";
+
+import { ElmButton } from "./elm-button";
+import { ElmMdiIcon } from "../icon/elm-mdi-icon";
+import { ElmInlineIcon } from "../icon/elm-inline-icon";
+import { ElmInlineText } from "../typography/elm-inline-text";
+import { ElmCollapse } from "../containments/elm-collapse";
+
+import styles from "./elm-button-dropdown.module.css";
+import textStyles from "../../styles/text.module.css";
+
+export interface ElmButtonDropdownItem {
+  id: string;
+  label: string;
+  /**
+   * Optional icon URL displayed alongside the item label.
+   */
+  icon?: string;
+  /**
+   * Whether the item is disabled and cannot be clicked.
+   */
+  disabled?: boolean;
+  /**
+   * Called when this item is clicked.
+   */
+  onClick?: () => void;
+}
+
+export interface ElmButtonDropdownProps extends Omit<
+  ComponentPropsWithoutRef<"div">,
+  "onClick"
+> {
+  /**
+   * Content of the main button.
+   */
+  label?: ReactNode;
+
+  /**
+   * Optional icon rendered before the main button label.
+   */
+  icon?: ReactNode;
+
+  /**
+   * Entries shown in the dropdown menu.
+   */
+  items: ElmButtonDropdownItem[];
+
+  /**
+   * Whether the button uses the primary style. Defaults to `true`.
+   */
+  primary?: boolean;
+
+  /**
+   * Custom button color. Overrides `primary` when set.
+   */
+  color?: string;
+
+  /**
+   * Whether the control fills the width of its container.
+   */
+  block?: boolean;
+
+  /**
+   * Whether the whole control is disabled.
+   */
+  disabled?: boolean;
+
+  /**
+   * Whether only the main button is disabled. The dropdown caret stays
+   * interactive.
+   */
+  disableMainButton?: boolean;
+
+  /**
+   * Whether only the dropdown caret is disabled. The main button stays
+   * interactive.
+   */
+  disableDropdown?: boolean;
+
+  /**
+   * Whether the main button is in a loading state.
+   */
+  isLoading?: boolean;
+
+  /**
+   * Whether the menu closes automatically after an item is clicked. Defaults
+   * to `true`.
+   */
+  autoClose?: boolean;
+
+  /**
+   * mdi path for the caret icon. Defaults to `mdiMenuDown`.
+   */
+  dropdownIcon?: string;
+
+  /**
+   * Main button click handler.
+   */
+  onClick?: () => void;
+
+  /**
+   * Called with the clicked dropdown item.
+   */
+  onItemClick?: (item: ElmButtonDropdownItem) => void;
+
+  /**
+   * Called whenever the dropdown opens or closes.
+   */
+  onOpenChange?: (isOpen: boolean) => void;
+}
+
+export const ElmButtonDropdown = ({
+  className,
+  style,
+  label,
+  icon,
+  items,
+  primary = true,
+  color,
+  block,
+  disabled,
+  disableMainButton,
+  disableDropdown,
+  isLoading,
+  autoClose = true,
+  dropdownIcon = mdiMenuDown,
+  onClick,
+  onItemClick,
+  onOpenChange,
+  ...rest
+}: ElmButtonDropdownProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  const setOpen = useCallback(
+    (next: boolean) => {
+      setIsOpen((prev) => {
+        if (prev !== next) onOpenChange?.(next);
+        return next;
+      });
+    },
+    [onOpenChange],
+  );
+
+  // Close on outside click, mirroring ElmSelect's dropdown.
+  useEffect(() => {
+    if (!isOpen) return;
+    const handler = (event: MouseEvent) => {
+      if (!rootRef.current) return;
+      if (!rootRef.current.contains(event.target as Node)) setOpen(false);
+    };
+    document.addEventListener("click", handler);
+    return () => document.removeEventListener("click", handler);
+  }, [isOpen, setOpen]);
+
+  const dropdownDisabled = disabled || disableDropdown || isLoading;
+  const mainDisabled = disabled || disableMainButton;
+
+  const handleToggle = useCallback(() => {
+    if (!dropdownDisabled) setOpen(!isOpen);
+  }, [dropdownDisabled, isOpen, setOpen]);
+
+  const handleItemClick = useCallback(
+    (item: ElmButtonDropdownItem) => {
+      if (item.disabled) return;
+      item.onClick?.();
+      onItemClick?.(item);
+      if (autoClose) setOpen(false);
+    },
+    [autoClose, onItemClick, setOpen],
+  );
+
+  const caret = <ElmMdiIcon d={dropdownIcon} size="1.25rem" />;
+
+  return (
+    <div
+      ref={rootRef}
+      className={clsx(
+        styles["elm-button-dropdown"],
+        block && styles["block"],
+        className,
+      )}
+      style={style as CSSProperties}
+      {...rest}
+    >
+      <ElmButton
+        className={clsx(styles["main"], styles["segment"])}
+        type="button"
+        primary={primary}
+        color={color}
+        isLoading={isLoading}
+        disabled={mainDisabled}
+        onClick={() => onClick?.()}
+      >
+        {icon}
+        {label}
+      </ElmButton>
+
+      <ElmButton
+        className={clsx(styles["caret"], styles["segment"])}
+        type="button"
+        primary={primary}
+        color={color}
+        disabled={dropdownDisabled}
+        onClick={handleToggle}
+        aria-label="Toggle dropdown"
+        aria-expanded={isOpen}
+      >
+        {caret}
+      </ElmButton>
+
+      <ElmCollapse isOpen={isOpen} className={styles["menu"]}>
+        {items.map((item) => (
+          <div
+            key={item.id}
+            className={clsx(
+              styles["item"],
+              textStyles.text,
+              item.disabled && styles["item-disabled"],
+            )}
+            onClick={(e) => {
+              e.stopPropagation();
+              handleItemClick(item);
+            }}
+          >
+            <ElmMdiIcon
+              d={mdiChevronRight}
+              color="var(--elmethis-color-primary-weak)"
+              size="0.75em"
+            />
+            {item.icon && <ElmInlineIcon src={item.icon} />}
+            <ElmInlineText>{item.label}</ElmInlineText>
+          </div>
+        ))}
+      </ElmCollapse>
+    </div>
+  );
+};

--- a/packages/react/src/components/form/elm-button-dropdown.tsx
+++ b/packages/react/src/components/form/elm-button-dropdown.tsx
@@ -15,6 +15,7 @@ import { ElmMdiIcon } from "../icon/elm-mdi-icon";
 import { ElmInlineIcon } from "../icon/elm-inline-icon";
 import { ElmInlineText } from "../typography/elm-inline-text";
 import { ElmCollapse } from "../containments/elm-collapse";
+import { useBindableSignal } from "../../hooks/use-bindable-signal";
 
 import styles from "./elm-button-dropdown.module.css";
 import textStyles from "../../styles/text.module.css";
@@ -41,12 +42,13 @@ export interface ElmButtonDropdownProps extends Omit<
   "onClick"
 > {
   /**
-   * Content of the main button.
+   * Main button content shown when no option is selected (placeholder).
    */
   label?: ReactNode;
 
   /**
-   * Optional icon rendered before the main button label.
+   * Optional icon rendered before the main button label in the placeholder
+   * (no selection) state.
    */
   icon?: ReactNode;
 
@@ -54,6 +56,22 @@ export interface ElmButtonDropdownProps extends Omit<
    * Entries shown in the dropdown menu.
    */
   items: ElmButtonDropdownItem[];
+
+  /**
+   * Currently selected option id (controlled). The main button displays the
+   * matching item.
+   */
+  selectedOptionId?: string | null;
+
+  /**
+   * Initial selected option id for the uncontrolled case.
+   */
+  defaultSelectedOptionId?: string | null;
+
+  /**
+   * Called whenever the selected option id changes.
+   */
+  onSelectedOptionIdChange?: (selectedOptionId: string | null) => void;
 
   /**
    * Whether the button uses the primary style. Defaults to `true`.
@@ -104,9 +122,10 @@ export interface ElmButtonDropdownProps extends Omit<
   dropdownIcon?: string;
 
   /**
-   * Main button click handler.
+   * Main button click handler. Receives the currently selected item, or
+   * `null` when nothing is selected.
    */
-  onClick?: () => void;
+  onClick?: (selectedItem: ElmButtonDropdownItem | null) => void;
 
   /**
    * Called with the clicked dropdown item.
@@ -125,6 +144,9 @@ export const ElmButtonDropdown = ({
   label,
   icon,
   items,
+  selectedOptionId,
+  defaultSelectedOptionId = null,
+  onSelectedOptionIdChange,
   primary = true,
   color,
   block,
@@ -141,6 +163,14 @@ export const ElmButtonDropdown = ({
 }: ElmButtonDropdownProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const rootRef = useRef<HTMLDivElement>(null);
+
+  const [selected, setSelected] = useBindableSignal<string | null>({
+    value: selectedOptionId,
+    defaultValue: defaultSelectedOptionId,
+    onChange: onSelectedOptionIdChange,
+  });
+
+  const selectedItem = items.find((item) => item.id === selected) ?? null;
 
   const setOpen = useCallback(
     (next: boolean) => {
@@ -173,11 +203,12 @@ export const ElmButtonDropdown = ({
   const handleItemClick = useCallback(
     (item: ElmButtonDropdownItem) => {
       if (item.disabled) return;
+      setSelected(item.id);
       item.onClick?.();
       onItemClick?.(item);
       if (autoClose) setOpen(false);
     },
-    [autoClose, onItemClick, setOpen],
+    [setSelected, autoClose, onItemClick, setOpen],
   );
 
   const caret = <ElmMdiIcon d={dropdownIcon} size="1.25rem" />;
@@ -200,10 +231,19 @@ export const ElmButtonDropdown = ({
         color={color}
         isLoading={isLoading}
         disabled={mainDisabled}
-        onClick={() => onClick?.()}
+        onClick={() => onClick?.(selectedItem)}
       >
-        {icon}
-        {label}
+        {selectedItem ? (
+          <>
+            {selectedItem.icon && <ElmInlineIcon src={selectedItem.icon} />}
+            {selectedItem.label}
+          </>
+        ) : (
+          <>
+            {icon}
+            {label}
+          </>
+        )}
       </ElmButton>
 
       <ElmButton
@@ -226,8 +266,10 @@ export const ElmButtonDropdown = ({
             className={clsx(
               styles["item"],
               textStyles.text,
+              item.id === selected && styles["selected"],
               item.disabled && styles["item-disabled"],
             )}
+            aria-selected={item.id === selected}
             onClick={(e) => {
               e.stopPropagation();
               handleItemClick(item);

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -74,6 +74,11 @@ export {
 // Form
 export { ElmButton, type ElmButtonProps } from "./components/form/elm-button";
 export {
+  ElmButtonDropdown,
+  type ElmButtonDropdownItem,
+  type ElmButtonDropdownProps,
+} from "./components/form/elm-button-dropdown";
+export {
   ElmCheckbox,
   type ElmCheckboxProps,
 } from "./components/form/elm-checkbox";

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elmethis/vue",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Vue 3 component library for elmethis.",
   "publishConfig": {
     "access": "public"

--- a/packages/vue/src/components/form/elm-button-dropdown.browser.spec.tsx
+++ b/packages/vue/src/components/form/elm-button-dropdown.browser.spec.tsx
@@ -1,0 +1,52 @@
+import { render } from "vitest-browser-vue";
+import { defineComponent, h, ref } from "vue";
+import { describe, expect, test, vi } from "vitest";
+
+import { ElmButtonDropdown } from "./elm-button-dropdown";
+
+// ElmButtonDropdown renders its menu items with per-iteration `onClick`
+// handlers, and the collapsed list is clipped (not `display:none`) by
+// ElmCollapse's `grid-template-rows: 0fr` + `overflow: hidden`. Real layout and
+// a genuine caret-open + item click are exercised here in a real browser.
+
+const Harness = defineComponent({
+  name: "Harness",
+  setup() {
+    const selected = ref<string | null>(null);
+    return () =>
+      h("div", [
+        h("output", { "data-testid": "selected" }, String(selected.value)),
+        h(ElmButtonDropdown, {
+          label: "Run",
+          selectedOptionId: selected.value,
+          "onUpdate:selectedOptionId": (v: string | null) =>
+            (selected.value = v),
+          items: [
+            { id: "edit", label: "Edit" },
+            { id: "remove", label: "Remove" },
+          ],
+        }),
+      ]);
+  },
+});
+
+// The main button reflects the selection; scope to it so the same label still
+// present in the collapsed menu row doesn't match.
+const mainButtonText = () =>
+  document.querySelector('[class*="main"]')?.textContent ?? "";
+
+describe("[browser] ElmButtonDropdown selection", () => {
+  test("the caret opens the menu and an item click updates the binding + display", async () => {
+    const screen = render(Harness);
+
+    await screen.getByRole("button", { name: "Toggle dropdown" }).click();
+    await screen.getByText("Remove").click();
+
+    await vi.waitFor(() =>
+      expect(screen.getByTestId("selected").element().textContent).toBe(
+        "remove",
+      ),
+    );
+    await vi.waitFor(() => expect(mainButtonText()).toContain("Remove"));
+  });
+});

--- a/packages/vue/src/components/form/elm-button-dropdown.module.css
+++ b/packages/vue/src/components/form/elm-button-dropdown.module.css
@@ -1,0 +1,86 @@
+.elm-button-dropdown {
+  position: relative;
+  box-sizing: border-box;
+  display: inline-flex;
+  align-items: stretch;
+
+  &.block {
+    display: flex;
+    width: 100%;
+
+    .main {
+      flex: 1 1 auto;
+    }
+  }
+
+  /* The two ElmButton segments are joined into one control. Descendant
+     selectors here outrank ElmButton's own single-class rules, so corners,
+     padding, and the hover transform retune without `!important`. */
+  .main {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+
+  .caret {
+    box-sizing: border-box;
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+    padding-left: 0.75rem;
+    padding-right: 0.75rem;
+    border-left: 1px solid light-dark(rgb(0 0 0 / 15%), rgb(255 255 255 / 20%));
+  }
+
+  /* Keep the joined control from shifting per-segment on hover/active. */
+  .segment:hover,
+  .segment:active {
+    transform: none;
+  }
+
+  .menu {
+    position: absolute;
+    top: calc(100% + 0.25rem);
+    left: 0;
+    z-index: 100;
+    box-sizing: border-box;
+    width: max-content;
+    min-width: 100%;
+    border-radius: 0.25rem;
+    background-color: light-dark(rgb(255 255 255 / 95%), rgb(51 51 51 / 95%));
+    box-shadow: 0 0 0.125rem light-dark(rgb(0 0 0 / 15%), rgb(0 0 0 / 75%));
+
+    .item {
+      overflow: hidden;
+      width: 100%;
+      padding: 0.5rem;
+      box-sizing: border-box;
+      border-radius: 0.25rem;
+      display: flex;
+      justify-content: flex-start;
+      align-items: center;
+      gap: 0.25rem;
+      transition: background-color 100ms;
+      cursor: pointer;
+
+      &:hover {
+        background-color: light-dark(
+          rgb(190 194 202 / 30%),
+          rgb(190 194 202 / 20%)
+        );
+      }
+
+      &.selected {
+        background-color: light-dark(
+          rgb(190 194 202 / 25%),
+          rgb(190 194 202 / 15%)
+        );
+        color: var(--elmethis-color-primary-weak);
+      }
+
+      &.item-disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+        pointer-events: none;
+      }
+    }
+  }
+}

--- a/packages/vue/src/components/form/elm-button-dropdown.spec.tsx
+++ b/packages/vue/src/components/form/elm-button-dropdown.spec.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { createSSRApp, h } from "vue";
+import { renderToString } from "vue/server-renderer";
+
+import {
+  ElmButtonDropdown,
+  type ElmButtonDropdownItem,
+} from "./elm-button-dropdown";
+
+// Item-click selection (clipped collapse list, per-item handlers, real layout
+// and outside-click) lives in elm-button-dropdown.browser.spec.tsx. The unit
+// layer covers the SSR shell: the two button segments, the placeholder, the
+// selected option's label, and the disable variants.
+
+const ITEMS: ElmButtonDropdownItem[] = [
+  { id: "edit", label: "Edit" },
+  { id: "remove", label: "Remove", disabled: true },
+];
+
+const render = (props: Record<string, unknown>) =>
+  renderToString(
+    createSSRApp({
+      render: () =>
+        h(ElmButtonDropdown, { label: "Choose", items: ITEMS, ...props }),
+    }),
+  );
+
+describe("[SSR] ElmButtonDropdown", () => {
+  it("renders two buttons: the main action and the caret toggle", async () => {
+    const html = await render({});
+    expect(html.split("<button").length - 1).toBe(2);
+  });
+
+  it("shows the placeholder when nothing is selected", async () => {
+    const html = await render({ label: "Choose an action" });
+    expect(html).toContain("Choose an action");
+  });
+
+  it("displays the selected option's label on the main button", async () => {
+    const html = await render({
+      label: "Choose an action",
+      selectedOptionId: "edit",
+    });
+    expect(html).toContain("Edit");
+    // The placeholder is replaced by the selection (SSR HTML has no serialized
+    // prop state to leak the placeholder string, unlike resumable frameworks).
+    expect(html).not.toContain("Choose an action");
+  });
+
+  it("disabled forwards the native attribute onto both buttons", async () => {
+    const html = await render({ disabled: true });
+    const disabledButtons = html.match(/<button[^>]*\bdisabled\b/g) ?? [];
+    expect(disabledButtons.length).toBe(2);
+  });
+
+  it("disables only the caret when disableDropdown is set", async () => {
+    const html = await render({ disableDropdown: true });
+    const disabledButtons = html.match(/<button[^>]*\bdisabled\b/g) ?? [];
+    expect(disabledButtons.length).toBe(1);
+  });
+});

--- a/packages/vue/src/components/form/elm-button-dropdown.stories.tsx
+++ b/packages/vue/src/components/form/elm-button-dropdown.stories.tsx
@@ -1,0 +1,95 @@
+import type { Meta, StoryObj } from "@storybook/vue3-vite";
+import { ref } from "vue";
+
+import {
+  ElmButtonDropdown,
+  type ElmButtonDropdownItem,
+} from "./elm-button-dropdown";
+
+const MiniMax =
+  "https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/minimax-color.svg";
+const OpenAI =
+  "https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/openai.svg";
+const Claude =
+  "https://registry.npmmirror.com/@lobehub/icons-static-svg/latest/files/icons/claude-color.svg";
+
+const MODELS: ElmButtonDropdownItem[] = [
+  { id: "claude", label: "Claude Opus 4.7", icon: Claude },
+  { id: "gpt", label: "GPT-5.4 Mini", icon: OpenAI },
+  { id: "minimax", label: "MiniMax M2.5", icon: MiniMax },
+];
+
+const meta = {
+  title: "Components/Form/elm-button-dropdown",
+  component: ElmButtonDropdown,
+  tags: ["autodocs"],
+  args: {
+    label: "Select a model",
+    items: MODELS,
+  },
+} satisfies Meta<typeof ElmButtonDropdown>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {};
+
+export const Preselected: Story = {
+  args: {
+    defaultSelectedOptionId: "claude",
+  },
+};
+
+export const Block: Story = {
+  args: {
+    block: true,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
+};
+
+export const DisableMainButton: Story = {
+  args: {
+    disableMainButton: true,
+  },
+};
+
+export const DisableDropdown: Story = {
+  args: {
+    disableDropdown: true,
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    isLoading: true,
+  },
+};
+
+export const Controlled: Story = {
+  render: (args) => ({
+    components: { ElmButtonDropdown },
+    setup() {
+      const selectedOptionId = ref<string | null>(null);
+      const log = ref<string>("none");
+      const onClick = (item: ElmButtonDropdownItem | null) => {
+        log.value = `run: ${item?.id ?? "none"}`;
+      };
+      return { args, selectedOptionId, log, onClick };
+    },
+    template: `
+      <div style="display: flex; flex-direction: column; gap: 1rem">
+        <ElmButtonDropdown v-bind="args" v-model:selected-option-id="selectedOptionId" @click="onClick" />
+        <div style="font-family: monospace; font-size: 0.85rem">
+          <div>selected: {{ selectedOptionId ?? "none" }}</div>
+          <div>last run: {{ log }}</div>
+        </div>
+        <button @click="selectedOptionId = null">Clear selection</button>
+      </div>
+    `,
+  }),
+};

--- a/packages/vue/src/components/form/elm-button-dropdown.tsx
+++ b/packages/vue/src/components/form/elm-button-dropdown.tsx
@@ -1,0 +1,259 @@
+import {
+  defineComponent,
+  onBeforeUnmount,
+  onMounted,
+  ref,
+  type HTMLAttributes,
+  type PropType,
+} from "vue";
+import { clsx } from "clsx";
+import { useVModel } from "@vueuse/core";
+import { mdiChevronRight, mdiMenuDown } from "@mdi/js";
+
+import { ElmButton } from "./elm-button";
+import { ElmMdiIcon } from "../icon/elm-mdi-icon";
+import { ElmInlineIcon } from "../icon/elm-inline-icon";
+import { ElmInlineText } from "../typography/elm-inline-text";
+import { ElmCollapse } from "../containments/elm-collapse";
+
+import styles from "./elm-button-dropdown.module.css";
+import textStyles from "../../styles/text.module.css";
+
+export interface ElmButtonDropdownItem {
+  id: string;
+  label: string;
+  /**
+   * Optional icon URL displayed alongside the item label.
+   */
+  icon?: string;
+  /**
+   * Whether the item is disabled and cannot be clicked.
+   */
+  disabled?: boolean;
+  /**
+   * Called when this item is clicked.
+   */
+  onClick?: () => void;
+}
+
+export interface ElmButtonDropdownProps extends Omit<
+  HTMLAttributes,
+  "onClick"
+> {
+  /**
+   * Main button content shown when no option is selected (placeholder).
+   */
+  label?: string;
+
+  /**
+   * Entries shown in the dropdown menu.
+   */
+  items: ElmButtonDropdownItem[];
+
+  /**
+   * Currently selected option id. Bind with `v-model:selected-option-id`
+   * (prop `selectedOptionId` + `update:selectedOptionId` event). The main
+   * button displays the matching item.
+   */
+  selectedOptionId?: string | null;
+
+  /**
+   * Initial selected option id for the uncontrolled case.
+   */
+  defaultSelectedOptionId?: string | null;
+
+  /**
+   * Whether the button uses the primary style. Defaults to `true`.
+   */
+  primary?: boolean;
+
+  /**
+   * Custom button color. Overrides `primary` when set.
+   */
+  color?: string;
+
+  /**
+   * Whether the control fills the width of its container.
+   */
+  block?: boolean;
+
+  /**
+   * Whether the whole control is disabled.
+   */
+  disabled?: boolean;
+
+  /**
+   * Whether only the main button is disabled. The dropdown caret stays
+   * interactive.
+   */
+  disableMainButton?: boolean;
+
+  /**
+   * Whether only the dropdown caret is disabled. The main button stays
+   * interactive.
+   */
+  disableDropdown?: boolean;
+
+  /**
+   * Whether the main button is in a loading state.
+   */
+  isLoading?: boolean;
+
+  /**
+   * Whether the menu closes automatically after an item is clicked. Defaults
+   * to `true`.
+   */
+  autoClose?: boolean;
+
+  /**
+   * mdi path for the caret icon. Defaults to `mdiMenuDown`.
+   */
+  dropdownIcon?: string;
+}
+
+export const ElmButtonDropdown = defineComponent({
+  name: "ElmButtonDropdown",
+  props: {
+    label: { type: String, default: undefined },
+    items: {
+      type: Array as PropType<ElmButtonDropdownItem[]>,
+      required: true,
+    },
+    selectedOptionId: {
+      type: String as PropType<string | null>,
+      default: undefined,
+    },
+    defaultSelectedOptionId: {
+      type: String as PropType<string | null>,
+      default: null,
+    },
+    primary: { type: Boolean, default: true },
+    color: { type: String, default: undefined },
+    block: { type: Boolean, default: false },
+    disabled: { type: Boolean, default: undefined },
+    disableMainButton: { type: Boolean, default: false },
+    disableDropdown: { type: Boolean, default: false },
+    isLoading: { type: Boolean, default: false },
+    autoClose: { type: Boolean, default: true },
+    dropdownIcon: { type: String, default: mdiMenuDown },
+  },
+  emits: ["update:selectedOptionId", "click", "itemClick", "openChange"],
+  setup(props, { emit, slots }) {
+    // `selectedOptionId` is nullable, so `useVModel` is used directly rather
+    // than `useBindableSignal` (whose `defaultValue` must be NonNullable).
+    const selected = useVModel(props, "selectedOptionId", emit, {
+      passive: true,
+      defaultValue: props.defaultSelectedOptionId ?? null,
+    });
+
+    const isOpen = ref(false);
+    const containerRef = ref<HTMLDivElement | null>(null);
+
+    // Single source for open/close so the open-change event fires from every
+    // path (caret, item select, outside click).
+    const setOpen = (next: boolean): void => {
+      if (isOpen.value === next) return;
+      isOpen.value = next;
+      emit("openChange", next);
+    };
+
+    const handleOutsideClick = (event: MouseEvent): void => {
+      if (!isOpen.value || !containerRef.value) return;
+      if (!containerRef.value.contains(event.target as Node)) setOpen(false);
+    };
+    onMounted(() => document.addEventListener("click", handleOutsideClick));
+    onBeforeUnmount(() =>
+      document.removeEventListener("click", handleOutsideClick),
+    );
+
+    // inheritAttrs default: passthrough class/style merge onto the root.
+    return () => {
+      const selectedItem =
+        props.items.find((item) => item.id === selected.value) ?? null;
+      const dropdownDisabled =
+        props.disabled || props.disableDropdown || props.isLoading;
+      const mainDisabled = props.disabled || props.disableMainButton;
+
+      // ElmButton intercepts `onClick` through attrs (inheritAttrs: false) but
+      // does not declare it as a prop, so it is spread from a variable — a
+      // non-literal spread carries the extra `onClick` / `aria-*` attrs through
+      // without tripping JSX prop-name checking.
+      const mainButtonProps = {
+        class: clsx(styles["main"], styles["segment"]),
+        primary: props.primary,
+        color: props.color,
+        isLoading: props.isLoading,
+        disabled: mainDisabled,
+        onClick: () => emit("click", selectedItem),
+      };
+      const caretButtonProps = {
+        class: clsx(styles["caret"], styles["segment"]),
+        primary: props.primary,
+        color: props.color,
+        disabled: dropdownDisabled,
+        "aria-label": "Toggle dropdown",
+        "aria-expanded": isOpen.value,
+        onClick: () => setOpen(!isOpen.value),
+      };
+
+      return (
+        <div
+          ref={containerRef}
+          class={clsx(
+            styles["elm-button-dropdown"],
+            props.block && styles["block"],
+          )}
+        >
+          <ElmButton {...mainButtonProps}>
+            {selectedItem ? (
+              <>
+                {selectedItem.icon && <ElmInlineIcon src={selectedItem.icon} />}
+                {selectedItem.label}
+              </>
+            ) : (
+              <>
+                {slots.icon?.()}
+                {props.label}
+              </>
+            )}
+          </ElmButton>
+
+          <ElmButton {...caretButtonProps}>
+            <ElmMdiIcon d={props.dropdownIcon} size="1.25rem" />
+          </ElmButton>
+
+          <ElmCollapse isOpen={isOpen.value} class={styles["menu"]}>
+            {props.items.map((item) => (
+              <div
+                key={item.id}
+                class={clsx(
+                  styles["item"],
+                  textStyles.text,
+                  item.id === selected.value && styles["selected"],
+                  item.disabled && styles["item-disabled"],
+                )}
+                aria-selected={item.id === selected.value}
+                onClick={(event: MouseEvent) => {
+                  event.stopPropagation();
+                  if (item.disabled) return;
+                  selected.value = item.id;
+                  item.onClick?.();
+                  emit("itemClick", item);
+                  if (props.autoClose) setOpen(false);
+                }}
+              >
+                <ElmMdiIcon
+                  d={mdiChevronRight}
+                  color="var(--elmethis-color-primary-weak)"
+                  size="0.75em"
+                />
+                {item.icon && <ElmInlineIcon src={item.icon} />}
+                <ElmInlineText>{item.label}</ElmInlineText>
+              </div>
+            ))}
+          </ElmCollapse>
+        </div>
+      );
+    };
+  },
+});

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -84,6 +84,11 @@ export {
 // Form
 export { ElmButton, type ElmButtonProps } from "./components/form/elm-button";
 export {
+  ElmButtonDropdown,
+  type ElmButtonDropdownItem,
+  type ElmButtonDropdownProps,
+} from "./components/form/elm-button-dropdown";
+export {
   ElmCheckbox,
   type ElmCheckboxProps,
 } from "./components/form/elm-checkbox";


### PR DESCRIPTION
## Summary

Adds **`ElmButtonDropdown`** — a Quasar `q-btn-dropdown`-style split button — to all three component packages. It is a main action button joined to a caret that toggles a dropdown menu; the main button reflects the currently selected option.

Piloted in **React** first (per request), then ported to **Qwik** (the lead implementation) and **Vue**.

```
[ icon  Selected option ] [ ▾ ]   ← main fires onClick(selectedItem) · caret toggles the menu
```

## Behavior

- **Split layout:** two joined `ElmButton` segments (main action + caret), shared corner rounding + divider, no per-segment hover shift.
- **Selection display:** picking a menu item updates the main button to show that option (icon + label); `label` is the placeholder shown only when nothing is selected. The selected row is highlighted (`aria-selected` + `.selected`).
- **Disable variants:** `disabled` (whole), `disableMainButton`, `disableDropdown` — mirroring Quasar.
- **Config:** `autoClose` (default `true`), `primary` / `color`, `block`, `isLoading`, custom `dropdownIcon`; outside-click closes the menu.
- **Events:** main click → selected item; item click; open/close change.

## Per-framework idiom

Same concept, each package's native controllable-state pattern:

| | Selection binding | Handlers |
|---|---|---|
| **react** | `selectedOptionId` / `defaultSelectedOptionId` / `onSelectedOptionIdChange` (`useBindableSignal`) | `onClick(item\|null)`, `onItemClick`, `onOpenChange` |
| **qwik** | `selectedOptionId: Signal<string\|null>` bound directly (dual-use, like `ElmSelect`) | `onClick$`, `onItemClick$`, `onOpenChange$` |
| **vue** | `v-model:selectedOptionId` (+ `defaultSelectedOptionId`) | emits `click` / `itemClick` / `openChange` |

Deliberate divergence: react/vue support uncontrolled selection; qwik requires a bound `Signal` to match `ElmSelect`.

The CSS module is byte-identical across all three packages. Each barrel exports `ElmButtonDropdown` + `ElmButtonDropdownItem` + `ElmButtonDropdownProps`.

## Tests

Each package gets an SSR/unit spec + a `*.browser.spec.tsx` (caret-open → item click → selection & display update). Qwik's unit layer uses `renderToString` because createDOM can't run `useVisibleTask$`.

Full suites pass with no regressions:

- **react:** unit + browser green
- **qwik:** 488 unit / 43 browser
- **vue:** 370 unit / 26 browser

Per-package typecheck, ESLint, Stylelint, and Prettier all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)