### PR TITLE
fix(ci): widen lint.css scope to catch stylelint errors outside src/

### DIFF
--- a/packages/qwik/.storybook/sb.css
+++ b/packages/qwik/.storybook/sb.css
@@ -5,6 +5,5 @@ html {
 body,
 .docs-story {
   transition: background-color 200ms;
-
   background-color: light-dark(#efecea, #393e46);
 }

--- a/packages/qwik/package.json
+++ b/packages/qwik/package.json
@@ -46,7 +46,7 @@
     "fmt": "prettier --write ./src",
     "fmt.check": "prettier --check ./src",
     "lint": "eslint \"src/**/*.ts*\"",
-    "lint.css": "stylelint \"src/**/*.css\"",
+    "lint.css": "stylelint \"{src,.storybook}/**/*.css\"",
     "prepublishOnly": "pnpm run build",
     "release": "np",
     "start": "vite --open --mode ssr",

--- a/packages/react/.storybook/sb.css
+++ b/packages/react/.storybook/sb.css
@@ -5,6 +5,5 @@ html {
 body,
 .docs-story {
   transition: background-color 200ms;
-
   background-color: light-dark(#efecea, #393e46);
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -46,7 +46,7 @@
     "fmt": "prettier --write ./src",
     "fmt.check": "prettier --check ./src",
     "lint": "eslint \"src/**/*.ts*\"",
-    "lint.css": "stylelint \"src/**/*.css\"",
+    "lint.css": "stylelint \"{src,.storybook}/**/*.css\"",
     "test": "pnpm run test.unit && pnpm run test.browser",
     "test.unit": "vitest --run",
     "test.coverage": "vitest --run --coverage",

--- a/packages/vue/.storybook/sb.css
+++ b/packages/vue/.storybook/sb.css
@@ -5,6 +5,5 @@ html {
 body,
 .docs-story {
   transition: background-color 200ms;
-
   background-color: light-dark(#efecea, #393e46);
 }

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -51,7 +51,7 @@
     "fmt": "prettier --write ./src",
     "fmt.check": "prettier --check ./src",
     "lint": "eslint \"src/**/*.ts*\"",
-    "lint.css": "stylelint \"src/**/*.css\"",
+    "lint.css": "stylelint \"{src,.storybook}/**/*.css\"",
     "test": "pnpm run test.unit && pnpm run test.browser",
     "test.unit": "vitest --run",
     "test.coverage": "vitest --run --coverage",


### PR DESCRIPTION
## Summary
- Each package's `lint.css` script only globbed `src/**/*.css`, so CI's `lint-css` job silently skipped `.storybook/sb.css` — even though lefthook's local pre-commit hook (which globs the whole package) already caught issues there. Widen the glob to `{src,.storybook}/**/*.css` in `packages/{react,vue,qwik}/package.json` so CI and the local hook cover the same scope.
- Fixes the 3 pre-existing `declaration-empty-line-before` stylelint errors this exposed in `packages/{react,vue,qwik}/.storybook/sb.css`, so CI passes clean with the widened scope instead of going red immediately.

## Test plan
- [x] `pnpm run lint.css` passes in each of `packages/react`, `packages/vue`, `packages/qwik`
- [x] Confirmed the widened glob actually catches errors (verified against a deliberately broken edit, then reverted)
- [x] `lefthook run check --all-files` — all jobs green, including the previously-failing `stylelint-{react,vue,qwik}` jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)