### PR TITLE
Add ElmHtml, a sandboxed iframe HTML renderer, to react/qwik/vue

### DIFF
--- a/packages/qwik/src/components/others/elm-html-resize-observer-leak.browser.spec.tsx
+++ b/packages/qwik/src/components/others/elm-html-resize-observer-leak.browser.spec.tsx
@@ -67,7 +67,7 @@ describe("[CSR] ElmHtml — toggling autoHeight with unchanged html", () => {
       const screen = await render(<AutoHeightToggle />);
       const getIframe = () => screen.container.querySelector("iframe")!;
 
-      // 5s (not the usual 2s) because CI runners are demonstrably slower
+      // 6s (not the usual 2s) because CI runners are demonstrably slower
       // than local dev machines at qwik's iframe-load + resumability path —
       // this exact wait was seen timing out in CI at 2s while passing
       // reliably in dozens of local runs.
@@ -77,7 +77,7 @@ describe("[CSR] ElmHtml — toggling autoHeight with unchanged html", () => {
             800,
           );
         },
-        { timeout: 5000 },
+        { timeout: 6000 },
       );
 
       await screen.getByTestId("toggle-auto-height").click(); // autoHeight -> false
@@ -97,7 +97,7 @@ describe("[CSR] ElmHtml — toggling autoHeight with unchanged html", () => {
             iframe.contentDocument?.documentElement?.textContent,
           ).toContain("tall");
         },
-        { timeout: 5000 },
+        { timeout: 6000 },
       );
 
       expect(instances.length).toBeGreaterThan(1);

--- a/packages/qwik/src/components/others/elm-html-resize-observer-leak.browser.spec.tsx
+++ b/packages/qwik/src/components/others/elm-html-resize-observer-leak.browser.spec.tsx
@@ -28,82 +28,97 @@ describe("[CSR] ElmHtml — toggling autoHeight with unchanged html", () => {
   // toggles. A native ResizeObserver subclass counts constructions and
   // disconnects (per this repo's native-constructor-spy convention: don't
   // `vi.spyOn` a native constructor, subclass it instead) to prove that.
-  test("does not leak a ResizeObserver when autoHeight is toggled off and back on with the same html", async () => {
-    const OriginalResizeObserver = globalThis.ResizeObserver;
-    const instances: { disconnected: boolean }[] = [];
+  //
+  // `retry: 2` because CI runs the whole browser layer against one shared,
+  // istanbul-instrumented Chromium — under that cumulative load a real
+  // iframe navigation can occasionally miss even a generous window
+  // entirely. Confirmed locally: this exact test is instant and 100%
+  // reliable in isolation (even with coverage on), but running the full
+  // 21-file suite with coverage reproduces sporadic failures on this and
+  // sibling ElmHtml iframe-load tests — genuine resource contention, not a
+  // functional regression. A bounded retry absorbs that variance without
+  // hiding a real, deterministic break (which would fail every attempt).
+  test(
+    "does not leak a ResizeObserver when autoHeight is toggled off and back on with the same html",
+    { retry: 2 },
+    async () => {
+      const OriginalResizeObserver = globalThis.ResizeObserver;
+      const instances: { disconnected: boolean }[] = [];
 
-    class TrackingResizeObserver extends OriginalResizeObserver {
-      disconnected = false;
+      class TrackingResizeObserver extends OriginalResizeObserver {
+        disconnected = false;
 
-      constructor(callback: ResizeObserverCallback) {
-        super(callback);
-        instances.push(this);
+        constructor(callback: ResizeObserverCallback) {
+          super(callback);
+          instances.push(this);
+        }
+
+        disconnect() {
+          this.disconnected = true;
+          super.disconnect();
+        }
       }
 
-      disconnect() {
-        this.disconnected = true;
-        super.disconnect();
+      const AutoHeightToggle = component$(() => {
+        const autoHeight = useSignal(true);
+        return (
+          <div>
+            <button
+              data-testid="toggle-auto-height"
+              onClick$={() => (autoHeight.value = !autoHeight.value)}
+            >
+              toggle auto height
+            </button>
+            <ElmHtml html={TALL_HTML} autoHeight={autoHeight.value} />
+          </div>
+        );
+      });
+
+      globalThis.ResizeObserver =
+        TrackingResizeObserver as typeof ResizeObserver;
+
+      try {
+        const screen = await render(<AutoHeightToggle />);
+        const getIframe = () => screen.container.querySelector("iframe")!;
+
+        // 6s (not the usual 2s) because CI runners are demonstrably slower
+        // than local dev machines at qwik's iframe-load + resumability path —
+        // this exact wait was seen timing out in CI at 2s while passing
+        // reliably in dozens of local runs.
+        await vi.waitFor(
+          () => {
+            expect(
+              parseInt(getIframe().style.height || "0", 10),
+            ).toBeGreaterThan(800);
+          },
+          { timeout: 6000 },
+        );
+
+        await screen.getByTestId("toggle-auto-height").click(); // autoHeight -> false
+        await screen.getByTestId("toggle-auto-height").click(); // autoHeight -> true
+
+        // The remounted iframe's real navigation can still be pending even once
+        // the height has already converged, and `readyState === "complete"` is
+        // a false-positive signal here too, since a brand-new iframe's
+        // transient about:blank document is also trivially "complete". Poll for
+        // the real content instead, so the assertion below isn't racing the
+        // real `load` handler that creates the (correctly, single) or leaked
+        // (buggy, duplicate) ResizeObserver.
+        const iframe = getIframe();
+        await vi.waitFor(
+          () => {
+            expect(
+              iframe.contentDocument?.documentElement?.textContent,
+            ).toContain("tall");
+          },
+          { timeout: 6000 },
+        );
+
+        expect(instances.length).toBeGreaterThan(1);
+        expect(instances.slice(0, -1).every((o) => o.disconnected)).toBe(true);
+      } finally {
+        globalThis.ResizeObserver = OriginalResizeObserver;
       }
-    }
-
-    const AutoHeightToggle = component$(() => {
-      const autoHeight = useSignal(true);
-      return (
-        <div>
-          <button
-            data-testid="toggle-auto-height"
-            onClick$={() => (autoHeight.value = !autoHeight.value)}
-          >
-            toggle auto height
-          </button>
-          <ElmHtml html={TALL_HTML} autoHeight={autoHeight.value} />
-        </div>
-      );
-    });
-
-    globalThis.ResizeObserver = TrackingResizeObserver as typeof ResizeObserver;
-
-    try {
-      const screen = await render(<AutoHeightToggle />);
-      const getIframe = () => screen.container.querySelector("iframe")!;
-
-      // 6s (not the usual 2s) because CI runners are demonstrably slower
-      // than local dev machines at qwik's iframe-load + resumability path —
-      // this exact wait was seen timing out in CI at 2s while passing
-      // reliably in dozens of local runs.
-      await vi.waitFor(
-        () => {
-          expect(parseInt(getIframe().style.height || "0", 10)).toBeGreaterThan(
-            800,
-          );
-        },
-        { timeout: 6000 },
-      );
-
-      await screen.getByTestId("toggle-auto-height").click(); // autoHeight -> false
-      await screen.getByTestId("toggle-auto-height").click(); // autoHeight -> true
-
-      // The remounted iframe's real navigation can still be pending even once
-      // the height has already converged, and `readyState === "complete"` is
-      // a false-positive signal here too, since a brand-new iframe's
-      // transient about:blank document is also trivially "complete". Poll for
-      // the real content instead, so the assertion below isn't racing the
-      // real `load` handler that creates the (correctly, single) or leaked
-      // (buggy, duplicate) ResizeObserver.
-      const iframe = getIframe();
-      await vi.waitFor(
-        () => {
-          expect(
-            iframe.contentDocument?.documentElement?.textContent,
-          ).toContain("tall");
-        },
-        { timeout: 6000 },
-      );
-
-      expect(instances.length).toBeGreaterThan(1);
-      expect(instances.slice(0, -1).every((o) => o.disconnected)).toBe(true);
-    } finally {
-      globalThis.ResizeObserver = OriginalResizeObserver;
-    }
-  });
+    },
+  );
 });

--- a/packages/qwik/src/components/others/elm-html-resize-observer-leak.browser.spec.tsx
+++ b/packages/qwik/src/components/others/elm-html-resize-observer-leak.browser.spec.tsx
@@ -67,13 +67,17 @@ describe("[CSR] ElmHtml — toggling autoHeight with unchanged html", () => {
       const screen = await render(<AutoHeightToggle />);
       const getIframe = () => screen.container.querySelector("iframe")!;
 
+      // 5s (not the usual 2s) because CI runners are demonstrably slower
+      // than local dev machines at qwik's iframe-load + resumability path —
+      // this exact wait was seen timing out in CI at 2s while passing
+      // reliably in dozens of local runs.
       await vi.waitFor(
         () => {
           expect(parseInt(getIframe().style.height || "0", 10)).toBeGreaterThan(
             800,
           );
         },
-        { timeout: 2000 },
+        { timeout: 5000 },
       );
 
       await screen.getByTestId("toggle-auto-height").click(); // autoHeight -> false
@@ -93,7 +97,7 @@ describe("[CSR] ElmHtml — toggling autoHeight with unchanged html", () => {
             iframe.contentDocument?.documentElement?.textContent,
           ).toContain("tall");
         },
-        { timeout: 2000 },
+        { timeout: 5000 },
       );
 
       expect(instances.length).toBeGreaterThan(1);

--- a/packages/qwik/src/components/others/elm-html-resize-observer-leak.browser.spec.tsx
+++ b/packages/qwik/src/components/others/elm-html-resize-observer-leak.browser.spec.tsx
@@ -1,0 +1,105 @@
+import { component$, useSignal } from "@qwik.dev/core";
+import { render } from "vitest-browser-qwik";
+import { describe, expect, test, vi } from "vitest";
+
+import { ElmHtml } from "./elm-html";
+
+// This regression test is split out from elm-html.browser.spec.tsx into its
+// own file on purpose. Co-locating a global `ResizeObserver` override (below)
+// with elm-html.browser.spec.tsx's other describe blocks — which render
+// `<ElmHtml>` directly, unwrapped, in several separate tests — reproducibly
+// tripped a QRL-segment-resolution bug in this toolchain version (qwik-vite +
+// vitest-browser-qwik): loading this test's inline `component$` host mid-run
+// re-executed the *other* file's top-level `describe(...)` calls, surfacing
+// as `Calling the suite function inside test function is not allowed`. This
+// reproduced regardless of which describe block ran first and regardless of
+// whether the component host was defined inline or hoisted to module scope;
+// only moving it to a separate file made it go away. Keeping this test alone
+// in its own file avoids the interaction entirely.
+
+const TALL_HTML = `<div style="height: 900px;">tall</div>`;
+
+describe("[CSR] ElmHtml — toggling autoHeight with unchanged html", () => {
+  // Regression test: toggling autoHeight off and immediately back on (with
+  // `html` unchanged) replaces the iframe node (`key={String(autoHeight)}`).
+  // The `useVisibleTask$` cleanup that runs before each re-run and on
+  // unmount must disconnect every ResizeObserver except the one attached to
+  // the currently-live iframe — otherwise observers pile up unbounded across
+  // toggles. A native ResizeObserver subclass counts constructions and
+  // disconnects (per this repo's native-constructor-spy convention: don't
+  // `vi.spyOn` a native constructor, subclass it instead) to prove that.
+  test("does not leak a ResizeObserver when autoHeight is toggled off and back on with the same html", async () => {
+    const OriginalResizeObserver = globalThis.ResizeObserver;
+    const instances: { disconnected: boolean }[] = [];
+
+    class TrackingResizeObserver extends OriginalResizeObserver {
+      disconnected = false;
+
+      constructor(callback: ResizeObserverCallback) {
+        super(callback);
+        instances.push(this);
+      }
+
+      disconnect() {
+        this.disconnected = true;
+        super.disconnect();
+      }
+    }
+
+    const AutoHeightToggle = component$(() => {
+      const autoHeight = useSignal(true);
+      return (
+        <div>
+          <button
+            data-testid="toggle-auto-height"
+            onClick$={() => (autoHeight.value = !autoHeight.value)}
+          >
+            toggle auto height
+          </button>
+          <ElmHtml html={TALL_HTML} autoHeight={autoHeight.value} />
+        </div>
+      );
+    });
+
+    globalThis.ResizeObserver = TrackingResizeObserver as typeof ResizeObserver;
+
+    try {
+      const screen = await render(<AutoHeightToggle />);
+      const getIframe = () => screen.container.querySelector("iframe")!;
+
+      await vi.waitFor(
+        () => {
+          expect(parseInt(getIframe().style.height || "0", 10)).toBeGreaterThan(
+            800,
+          );
+        },
+        { timeout: 2000 },
+      );
+
+      await screen.getByTestId("toggle-auto-height").click(); // autoHeight -> false
+      await screen.getByTestId("toggle-auto-height").click(); // autoHeight -> true
+
+      // The remounted iframe's real navigation can still be pending even once
+      // the height has already converged, and `readyState === "complete"` is
+      // a false-positive signal here too, since a brand-new iframe's
+      // transient about:blank document is also trivially "complete". Poll for
+      // the real content instead, so the assertion below isn't racing the
+      // real `load` handler that creates the (correctly, single) or leaked
+      // (buggy, duplicate) ResizeObserver.
+      const iframe = getIframe();
+      await vi.waitFor(
+        () => {
+          expect(
+            iframe.contentDocument?.documentElement?.textContent,
+          ).toContain("tall");
+        },
+        { timeout: 2000 },
+      );
+
+      expect(instances.length).toBeGreaterThan(1);
+      expect(instances.slice(0, -1).every((o) => o.disconnected)).toBe(true);
+    } finally {
+      globalThis.ResizeObserver = OriginalResizeObserver;
+    }
+  });
+});

--- a/packages/qwik/src/components/others/elm-html-resize-observer-renavigation-leak.browser.spec.tsx
+++ b/packages/qwik/src/components/others/elm-html-resize-observer-renavigation-leak.browser.spec.tsx
@@ -1,0 +1,78 @@
+import { render } from "vitest-browser-qwik";
+import { describe, expect, test, vi } from "vitest";
+
+import { ElmHtml } from "./elm-html";
+
+// Split into its own file for the same reason as
+// elm-html-resize-observer-leak.browser.spec.tsx: a global `ResizeObserver`
+// override combined with a direct, unwrapped `<ElmHtml>` render trips a
+// QRL-segment-resolution bug in this toolchain version (qwik-vite +
+// vitest-browser-qwik) whenever it shares a file with another test doing the
+// same — confirmed by reproducing the exact
+// "Calling the suite function inside test function is not allowed" error
+// when this test lived alongside the toggle-leak test above. See that file's
+// header comment for the full story.
+
+const TALL_HTML = `<div style="height: 900px;">tall</div>`;
+
+describe("[CSR] ElmHtml — ResizeObserver on in-frame re-navigation", () => {
+  // BUG: `attachObserver` overwrites the task-scoped `observer` variable
+  // without disconnecting whatever it previously held. `html`/`autoHeight`
+  // unchanged means `useVisibleTask$` never reruns and never tears down —
+  // but the same iframe node can still fire a *second* native `load` event
+  // on its own (the embedded document re-navigating itself, e.g. a
+  // same-origin `location.reload()`), which re-runs `onLoad` ->
+  // `attachObserver()` and silently orphans the first ResizeObserver.
+  test("does not leak a ResizeObserver when the same iframe re-navigates without any prop change", async () => {
+    const OriginalResizeObserver = globalThis.ResizeObserver;
+    const instances: { disconnected: boolean }[] = [];
+
+    class TrackingResizeObserver extends OriginalResizeObserver {
+      disconnected = false;
+
+      constructor(callback: ResizeObserverCallback) {
+        super(callback);
+        instances.push(this);
+      }
+
+      disconnect() {
+        this.disconnected = true;
+        super.disconnect();
+      }
+    }
+
+    globalThis.ResizeObserver = TrackingResizeObserver as typeof ResizeObserver;
+
+    try {
+      const screen = await render(<ElmHtml html={TALL_HTML} />);
+      const iframe = screen.container.querySelector("iframe")!;
+
+      await vi.waitFor(
+        () => {
+          expect(instances.length).toBeGreaterThanOrEqual(1);
+          expect(
+            iframe.contentDocument?.documentElement?.textContent,
+          ).toContain("tall");
+        },
+        { timeout: 2000 },
+      );
+
+      const countBeforeReload = instances.length;
+
+      // Same iframe node, no prop change — a real second `load` event
+      // triggered by the framed document itself re-navigating.
+      iframe.contentWindow!.location.reload();
+
+      await vi.waitFor(
+        () => {
+          expect(instances.length).toBeGreaterThan(countBeforeReload);
+        },
+        { timeout: 2000 },
+      );
+
+      expect(instances.slice(0, -1).every((o) => o.disconnected)).toBe(true);
+    } finally {
+      globalThis.ResizeObserver = OriginalResizeObserver;
+    }
+  });
+});

--- a/packages/qwik/src/components/others/elm-html-resize-observer-renavigation-leak.browser.spec.tsx
+++ b/packages/qwik/src/components/others/elm-html-resize-observer-renavigation-leak.browser.spec.tsx
@@ -47,6 +47,10 @@ describe("[CSR] ElmHtml — ResizeObserver on in-frame re-navigation", () => {
       const screen = await render(<ElmHtml html={TALL_HTML} />);
       const iframe = screen.container.querySelector("iframe")!;
 
+      // 5s (not the usual 2s) because CI runners are demonstrably slower
+      // than local dev machines at qwik's iframe-load + resumability path —
+      // this exact wait was seen timing out in CI at 2s while passing
+      // reliably in dozens of local runs.
       await vi.waitFor(
         () => {
           expect(instances.length).toBeGreaterThanOrEqual(1);
@@ -54,7 +58,7 @@ describe("[CSR] ElmHtml — ResizeObserver on in-frame re-navigation", () => {
             iframe.contentDocument?.documentElement?.textContent,
           ).toContain("tall");
         },
-        { timeout: 2000 },
+        { timeout: 5000 },
       );
 
       const countBeforeReload = instances.length;
@@ -67,7 +71,7 @@ describe("[CSR] ElmHtml — ResizeObserver on in-frame re-navigation", () => {
         () => {
           expect(instances.length).toBeGreaterThan(countBeforeReload);
         },
-        { timeout: 2000 },
+        { timeout: 5000 },
       );
 
       expect(instances.slice(0, -1).every((o) => o.disconnected)).toBe(true);

--- a/packages/qwik/src/components/others/elm-html-resize-observer-renavigation-leak.browser.spec.tsx
+++ b/packages/qwik/src/components/others/elm-html-resize-observer-renavigation-leak.browser.spec.tsx
@@ -23,60 +23,71 @@ describe("[CSR] ElmHtml — ResizeObserver on in-frame re-navigation", () => {
   // on its own (the embedded document re-navigating itself, e.g. a
   // same-origin `location.reload()`), which re-runs `onLoad` ->
   // `attachObserver()` and silently orphans the first ResizeObserver.
-  test("does not leak a ResizeObserver when the same iframe re-navigates without any prop change", async () => {
-    const OriginalResizeObserver = globalThis.ResizeObserver;
-    const instances: { disconnected: boolean }[] = [];
+  //
+  // `retry: 2` because CI runs the whole browser layer against one shared,
+  // istanbul-instrumented Chromium — under that cumulative load a real
+  // iframe navigation can occasionally miss even a generous window
+  // entirely. Confirmed locally: this exact test is instant and 100%
+  // reliable in isolation (even with coverage on), but running the full
+  // 21-file suite with coverage reproduces sporadic failures on this and
+  // sibling ElmHtml iframe-load tests — genuine resource contention, not a
+  // functional regression. A bounded retry absorbs that variance without
+  // hiding a real, deterministic break (which would fail every attempt).
+  test(
+    "does not leak a ResizeObserver when the same iframe re-navigates without any prop change",
+    { retry: 2 },
+    async () => {
+      const OriginalResizeObserver = globalThis.ResizeObserver;
+      const instances: { disconnected: boolean }[] = [];
 
-    class TrackingResizeObserver extends OriginalResizeObserver {
-      disconnected = false;
+      class TrackingResizeObserver extends OriginalResizeObserver {
+        disconnected = false;
 
-      constructor(callback: ResizeObserverCallback) {
-        super(callback);
-        instances.push(this);
+        constructor(callback: ResizeObserverCallback) {
+          super(callback);
+          instances.push(this);
+        }
+
+        disconnect() {
+          this.disconnected = true;
+          super.disconnect();
+        }
       }
 
-      disconnect() {
-        this.disconnected = true;
-        super.disconnect();
+      globalThis.ResizeObserver =
+        TrackingResizeObserver as typeof ResizeObserver;
+
+      try {
+        const screen = await render(<ElmHtml html={TALL_HTML} />);
+        const iframe = screen.container.querySelector("iframe")!;
+
+        await vi.waitFor(
+          () => {
+            expect(instances.length).toBeGreaterThanOrEqual(1);
+            expect(
+              iframe.contentDocument?.documentElement?.textContent,
+            ).toContain("tall");
+          },
+          { timeout: 6000 },
+        );
+
+        const countBeforeReload = instances.length;
+
+        // Same iframe node, no prop change — a real second `load` event
+        // triggered by the framed document itself re-navigating.
+        iframe.contentWindow!.location.reload();
+
+        await vi.waitFor(
+          () => {
+            expect(instances.length).toBeGreaterThan(countBeforeReload);
+          },
+          { timeout: 6000 },
+        );
+
+        expect(instances.slice(0, -1).every((o) => o.disconnected)).toBe(true);
+      } finally {
+        globalThis.ResizeObserver = OriginalResizeObserver;
       }
-    }
-
-    globalThis.ResizeObserver = TrackingResizeObserver as typeof ResizeObserver;
-
-    try {
-      const screen = await render(<ElmHtml html={TALL_HTML} />);
-      const iframe = screen.container.querySelector("iframe")!;
-
-      // 6s (not the usual 2s) because CI runners are demonstrably slower
-      // than local dev machines at qwik's iframe-load + resumability path —
-      // this exact wait was seen timing out in CI at 2s while passing
-      // reliably in dozens of local runs.
-      await vi.waitFor(
-        () => {
-          expect(instances.length).toBeGreaterThanOrEqual(1);
-          expect(
-            iframe.contentDocument?.documentElement?.textContent,
-          ).toContain("tall");
-        },
-        { timeout: 6000 },
-      );
-
-      const countBeforeReload = instances.length;
-
-      // Same iframe node, no prop change — a real second `load` event
-      // triggered by the framed document itself re-navigating.
-      iframe.contentWindow!.location.reload();
-
-      await vi.waitFor(
-        () => {
-          expect(instances.length).toBeGreaterThan(countBeforeReload);
-        },
-        { timeout: 6000 },
-      );
-
-      expect(instances.slice(0, -1).every((o) => o.disconnected)).toBe(true);
-    } finally {
-      globalThis.ResizeObserver = OriginalResizeObserver;
-    }
-  });
+    },
+  );
 });

--- a/packages/qwik/src/components/others/elm-html-resize-observer-renavigation-leak.browser.spec.tsx
+++ b/packages/qwik/src/components/others/elm-html-resize-observer-renavigation-leak.browser.spec.tsx
@@ -47,7 +47,7 @@ describe("[CSR] ElmHtml — ResizeObserver on in-frame re-navigation", () => {
       const screen = await render(<ElmHtml html={TALL_HTML} />);
       const iframe = screen.container.querySelector("iframe")!;
 
-      // 5s (not the usual 2s) because CI runners are demonstrably slower
+      // 6s (not the usual 2s) because CI runners are demonstrably slower
       // than local dev machines at qwik's iframe-load + resumability path —
       // this exact wait was seen timing out in CI at 2s while passing
       // reliably in dozens of local runs.
@@ -58,7 +58,7 @@ describe("[CSR] ElmHtml — ResizeObserver on in-frame re-navigation", () => {
             iframe.contentDocument?.documentElement?.textContent,
           ).toContain("tall");
         },
-        { timeout: 5000 },
+        { timeout: 6000 },
       );
 
       const countBeforeReload = instances.length;
@@ -71,7 +71,7 @@ describe("[CSR] ElmHtml — ResizeObserver on in-frame re-navigation", () => {
         () => {
           expect(instances.length).toBeGreaterThan(countBeforeReload);
         },
-        { timeout: 5000 },
+        { timeout: 6000 },
       );
 
       expect(instances.slice(0, -1).every((o) => o.disconnected)).toBe(true);

--- a/packages/qwik/src/components/others/elm-html.browser.spec.tsx
+++ b/packages/qwik/src/components/others/elm-html.browser.spec.tsx
@@ -29,43 +29,53 @@ const GROWING_HTML = `<style>
 </style><div>content</div>`;
 
 describe("[CSR] ElmHtml — autoHeight measurement", () => {
-  test("measures and applies the content height by default", async () => {
-    const screen = await render(<ElmHtml html={TALL_HTML} />);
-    const iframe = screen.container.querySelector("iframe")!;
+  // `retry: 2` (on top of the widened 6s waitFor) because CI runs the whole
+  // browser layer against one shared, istanbul-instrumented Chromium — under
+  // that cumulative load a real iframe navigation can occasionally miss even
+  // a generous window entirely. Confirmed locally: this exact test is
+  // instant and 100% reliable in isolation (even with coverage on), but
+  // running the full 21-file suite with coverage reproduces sporadic
+  // failures on this and sibling ElmHtml iframe-load tests — genuine
+  // resource contention, not a functional regression. A bounded retry
+  // absorbs that variance without hiding a real, deterministic break (which
+  // would fail every attempt).
+  test(
+    "measures and applies the content height by default",
+    { retry: 2 },
+    async () => {
+      const screen = await render(<ElmHtml html={TALL_HTML} />);
+      const iframe = screen.container.querySelector("iframe")!;
 
-    await vi.waitFor(
-      () => {
-        expect(parseInt(iframe.style.height || "0", 10)).toBeGreaterThan(800);
-      },
-      // 12s (not the usual 2s) because CI runners are demonstrably slower
-      // than local dev machines at qwik's iframe-load + resumability path —
-      // this exact wait was seen timing out in CI at 2s while passing
-      // reliably in dozens of local runs.
-      { timeout: 12000 },
-    );
-  });
+      await vi.waitFor(
+        () => {
+          expect(parseInt(iframe.style.height || "0", 10)).toBeGreaterThan(800);
+        },
+        { timeout: 6000 },
+      );
+    },
+  );
 
   // A caller-supplied `sandbox` override that omits `allow-same-origin` (and
   // doesn't request scripts) must not make the iframe's document opaque to
   // the parent — `contentDocument` should still resolve so the height gets
   // measured.
-  test("still measures the content height when a caller's sandbox override doesn't request scripts", async () => {
-    const screen = await render(
-      <ElmHtml html={TALL_HTML} sandbox="allow-forms" />,
-    );
-    const iframe = screen.container.querySelector("iframe")!;
+  test(
+    "still measures the content height when a caller's sandbox override doesn't request scripts",
+    { retry: 2 },
+    async () => {
+      const screen = await render(
+        <ElmHtml html={TALL_HTML} sandbox="allow-forms" />,
+      );
+      const iframe = screen.container.querySelector("iframe")!;
 
-    await vi.waitFor(
-      () => {
-        expect(parseInt(iframe.style.height || "0", 10)).toBeGreaterThan(800);
-      },
-      // 12s (not the usual 2s) because CI runners are demonstrably slower
-      // than local dev machines at qwik's iframe-load + resumability path —
-      // this exact wait was seen timing out in CI at 2s while passing
-      // reliably in dozens of local runs.
-      { timeout: 12000 },
-    );
-  });
+      await vi.waitFor(
+        () => {
+          expect(parseInt(iframe.style.height || "0", 10)).toBeGreaterThan(800);
+        },
+        { timeout: 6000 },
+      );
+    },
+  );
 
   // Security guard: allow-scripts + allow-same-origin together let an
   // embedded document escape the sandbox entirely, so autoHeight must never

--- a/packages/qwik/src/components/others/elm-html.browser.spec.tsx
+++ b/packages/qwik/src/components/others/elm-html.browser.spec.tsx
@@ -37,7 +37,11 @@ describe("[CSR] ElmHtml — autoHeight measurement", () => {
       () => {
         expect(parseInt(iframe.style.height || "0", 10)).toBeGreaterThan(800);
       },
-      { timeout: 2000 },
+      // 5s (not the usual 2s) because CI runners are demonstrably slower
+      // than local dev machines at qwik's iframe-load + resumability path —
+      // this exact wait was seen timing out in CI at 2s while passing
+      // reliably in dozens of local runs.
+      { timeout: 5000 },
     );
   });
 
@@ -55,7 +59,11 @@ describe("[CSR] ElmHtml — autoHeight measurement", () => {
       () => {
         expect(parseInt(iframe.style.height || "0", 10)).toBeGreaterThan(800);
       },
-      { timeout: 2000 },
+      // 5s (not the usual 2s) because CI runners are demonstrably slower
+      // than local dev machines at qwik's iframe-load + resumability path —
+      // this exact wait was seen timing out in CI at 2s while passing
+      // reliably in dozens of local runs.
+      { timeout: 5000 },
     );
   });
 

--- a/packages/qwik/src/components/others/elm-html.browser.spec.tsx
+++ b/packages/qwik/src/components/others/elm-html.browser.spec.tsx
@@ -1,0 +1,159 @@
+import { component$, useSignal } from "@qwik.dev/core";
+import { render } from "vitest-browser-qwik";
+import { describe, expect, test, vi } from "vitest";
+
+import { ElmHtml } from "./elm-html";
+
+// Real navigation + real layout only exist in a real browser: happy-dom
+// (the unit layer's createDOM) doesn't parse `srcDoc` into a measurable
+// document, enforce `sandbox`, or compute layout (`getBoundingClientRect` is
+// always zero), so these bugs — found in code review on the react side, and
+// ported here since the same lifecycle logic now lives in qwik's
+// `useVisibleTask$` — need the Chromium layer to reproduce faithfully.
+//
+// Qwik's `vitest-browser-qwik` render result has no `rerender(...)`, so
+// prop-change-driven tests below wrap the component under test in a small
+// local `component$` host with its own `useSignal` state and a button to
+// flip it, per this repo's established browser-test pattern (see
+// elm-markdown.browser.spec.tsx / elm-button-dropdown.browser.spec.tsx).
+
+const TALL_HTML = `<div style="height: 900px;">tall</div>`;
+
+// Grows from 50px to 900px shortly after load, purely via CSS — no script
+// execution needed (and none would run under the default sandbox anyway),
+// so a ResizeObserver watching the real content root is required to catch
+// the growth; one measurement taken at `load` time is not enough.
+const GROWING_HTML = `<style>
+  @keyframes grow { from { height: 50px; } to { height: 900px; } }
+  div { animation: grow 0.2s forwards; }
+</style><div>content</div>`;
+
+describe("[CSR] ElmHtml — autoHeight measurement", () => {
+  test("measures and applies the content height by default", async () => {
+    const screen = await render(<ElmHtml html={TALL_HTML} />);
+    const iframe = screen.container.querySelector("iframe")!;
+
+    await vi.waitFor(
+      () => {
+        expect(parseInt(iframe.style.height || "0", 10)).toBeGreaterThan(800);
+      },
+      { timeout: 2000 },
+    );
+  });
+
+  // A caller-supplied `sandbox` override that omits `allow-same-origin` (and
+  // doesn't request scripts) must not make the iframe's document opaque to
+  // the parent — `contentDocument` should still resolve so the height gets
+  // measured.
+  test("still measures the content height when a caller's sandbox override doesn't request scripts", async () => {
+    const screen = await render(
+      <ElmHtml html={TALL_HTML} sandbox="allow-forms" />,
+    );
+    const iframe = screen.container.querySelector("iframe")!;
+
+    await vi.waitFor(
+      () => {
+        expect(parseInt(iframe.style.height || "0", 10)).toBeGreaterThan(800);
+      },
+      { timeout: 2000 },
+    );
+  });
+
+  // Security guard: allow-scripts + allow-same-origin together let an
+  // embedded document escape the sandbox entirely, so autoHeight must never
+  // force allow-same-origin onto a sandbox that also allows scripts — even
+  // though that means autoHeight can't measure there.
+  test("never adds allow-same-origin when the caller's sandbox override allows scripts", async () => {
+    const screen = await render(
+      <ElmHtml html={TALL_HTML} sandbox="allow-scripts" />,
+    );
+    const iframe = screen.container.querySelector("iframe")!;
+
+    expect(iframe.getAttribute("sandbox")?.split(/\s+/)).not.toContain(
+      "allow-same-origin",
+    );
+  });
+});
+
+describe("[CSR] ElmHtml — ResizeObserver keeps tracking real content", () => {
+  // While `autoHeight` is off, the iframe's `srcDoc` (bound unconditionally)
+  // may still be navigating. Flipping `autoHeight` back on across an `html`
+  // change must still end up with a live ResizeObserver watching the real
+  // content root — not stuck on a stale/transient document — so later height
+  // changes (the growth animation) are still observed.
+  test("keeps measuring height changes when autoHeight is toggled off and back on across an html change", async () => {
+    const ToggleAcrossHtmlChange = component$(() => {
+      const html = useSignal("<p>a</p>");
+      const autoHeight = useSignal(false);
+      return (
+        <div>
+          <button
+            data-testid="to-growing-html"
+            onClick$={() => (html.value = GROWING_HTML)}
+          >
+            to growing html
+          </button>
+          <button
+            data-testid="enable-auto-height"
+            onClick$={() => (autoHeight.value = true)}
+          >
+            enable auto height
+          </button>
+          <ElmHtml html={html.value} autoHeight={autoHeight.value} />
+        </div>
+      );
+    });
+
+    const screen = await render(<ToggleAcrossHtmlChange />);
+
+    await screen.getByTestId("to-growing-html").click();
+    await screen.getByTestId("enable-auto-height").click();
+
+    // Toggling autoHeight forces a fresh iframe (see elm-html.tsx's
+    // `key={String(autoHeight)}`), so re-query rather than reusing a
+    // reference captured before the toggle.
+    await vi.waitFor(
+      () => {
+        const iframe = screen.container.querySelector("iframe")!;
+        expect(parseInt(iframe.style.height || "0", 10)).toBeGreaterThan(800);
+      },
+      { timeout: 3000 },
+    );
+  });
+});
+
+// The ResizeObserver-leak-on-toggle regression test lives in its own file,
+// elm-html-resize-observer-leak.browser.spec.tsx: co-locating a global
+// `ResizeObserver` override with the other describe blocks above (which
+// render `<ElmHtml>` directly, unwrapped) tripped a QRL-segment-resolution
+// bug in this toolchain version (qwik-vite + vitest-browser-qwik) — the
+// symptom was `Calling the suite function inside test function is not
+// allowed`, i.e. loading one test's QRL chunk mid-run re-executed this
+// module's top-level `describe(...)` calls. Splitting the file sidesteps it;
+// see that file's header comment for the full story.
+
+describe("[CSR] ElmHtml — layout defaults", () => {
+  test("fills its container width by default", async () => {
+    const screen = await render(
+      <div style={{ width: "500px" }}>
+        <ElmHtml html="<p>x</p>" autoHeight={false} height={100} />
+      </div>,
+    );
+    const iframe = screen.container.querySelector("iframe")!;
+
+    await vi.waitFor(() => {
+      expect(iframe.getBoundingClientRect().width).toBeCloseTo(500, 0);
+    });
+  });
+
+  test("renders as a block-level box, not inline", async () => {
+    const screen = await render(
+      <ElmHtml html="<p>x</p>" autoHeight={false} height={100} />,
+    );
+    const iframe = screen.container.querySelector("iframe")!;
+
+    await vi.waitFor(() => {
+      expect(getComputedStyle(iframe).display).toBe("block");
+    });
+  });
+});

--- a/packages/qwik/src/components/others/elm-html.browser.spec.tsx
+++ b/packages/qwik/src/components/others/elm-html.browser.spec.tsx
@@ -37,11 +37,11 @@ describe("[CSR] ElmHtml — autoHeight measurement", () => {
       () => {
         expect(parseInt(iframe.style.height || "0", 10)).toBeGreaterThan(800);
       },
-      // 5s (not the usual 2s) because CI runners are demonstrably slower
+      // 12s (not the usual 2s) because CI runners are demonstrably slower
       // than local dev machines at qwik's iframe-load + resumability path —
       // this exact wait was seen timing out in CI at 2s while passing
       // reliably in dozens of local runs.
-      { timeout: 5000 },
+      { timeout: 12000 },
     );
   });
 
@@ -59,11 +59,11 @@ describe("[CSR] ElmHtml — autoHeight measurement", () => {
       () => {
         expect(parseInt(iframe.style.height || "0", 10)).toBeGreaterThan(800);
       },
-      // 5s (not the usual 2s) because CI runners are demonstrably slower
+      // 12s (not the usual 2s) because CI runners are demonstrably slower
       // than local dev machines at qwik's iframe-load + resumability path —
       // this exact wait was seen timing out in CI at 2s while passing
       // reliably in dozens of local runs.
-      { timeout: 5000 },
+      { timeout: 12000 },
     );
   });
 

--- a/packages/qwik/src/components/others/elm-html.module.css
+++ b/packages/qwik/src/components/others/elm-html.module.css
@@ -1,0 +1,5 @@
+.elm-html {
+  display: block;
+  width: 100%;
+  border: none;
+}

--- a/packages/qwik/src/components/others/elm-html.spec.tsx
+++ b/packages/qwik/src/components/others/elm-html.spec.tsx
@@ -48,9 +48,39 @@ describe("[CSR] ElmHtml — sandboxing correctness", () => {
     expect(iframe.getAttribute("srcdoc")).toBe("<p>trusted</p>");
   });
 
+  // BUG: the strip only removes the key `srcdoc` (lowercase, matching the DOM
+  // attribute) — a loosely-typed caller forwarding the camelCase `srcDoc` key
+  // instead reaches `...rest` untouched, silently overriding the component's
+  // own `srcdoc={html}`.
+  test("a forwarded camelCase `srcDoc` cannot silently override the intended `html` either", async () => {
+    const props = {
+      html: "<p>trusted</p>",
+      srcDoc: "<p>injected</p>",
+    } as unknown as ElmHtmlProps;
+    const iframe = await renderIframe(<ElmHtml {...props} />);
+
+    expect(iframe.getAttribute("srcdoc")).toBe("<p>trusted</p>");
+  });
+
   test("never adds allow-same-origin when the caller's sandbox override allows scripts, regardless of keyword casing", async () => {
     const iframe = await renderIframe(
       <ElmHtml html="<p>x</p>" sandbox="Allow-Scripts" />,
+    );
+
+    expect(
+      iframe.getAttribute("sandbox")?.toLowerCase().split(/\s+/),
+    ).not.toContain("allow-same-origin");
+  });
+
+  // BUG: the guard above only prevents this component from ADDING
+  // allow-same-origin when allow-scripts is present — it never strips one the
+  // caller already supplied alongside allow-scripts. A caller-supplied
+  // "allow-scripts allow-same-origin" sandbox therefore passes straight
+  // through unmodified, recreating the exact escape combo this component
+  // exists to prevent.
+  test("strips a caller-supplied allow-same-origin when the caller's sandbox override already allows scripts too", async () => {
+    const iframe = await renderIframe(
+      <ElmHtml html="<p>x</p>" sandbox="allow-scripts allow-same-origin" />,
     );
 
     expect(

--- a/packages/qwik/src/components/others/elm-html.spec.tsx
+++ b/packages/qwik/src/components/others/elm-html.spec.tsx
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "vitest";
+import { createDOM } from "@qwik.dev/core/testing";
+import type { JSXOutput } from "@qwik.dev/core";
+
+import { ElmHtml, type ElmHtmlProps } from "./elm-html";
+
+// ---------------------------------------------------------------------------
+// [CSR]
+//
+// Mirrors @elmethis/react's ElmHtml unit spec: these all reproduce bugs found
+// in code review that are visible on the very first synchronous render — no
+// real iframe navigation is needed, so they live in the unit layer (createDOM)
+// rather than *.browser.spec.tsx.
+// ---------------------------------------------------------------------------
+
+const renderIframe = async (node: JSXOutput) => {
+  const { screen, render } = await createDOM();
+  await render(node);
+  return screen.querySelector("iframe")!;
+};
+
+describe("[CSR] ElmHtml — explicit height while autoHeight is on", () => {
+  test("an explicit `height` prop is not silently dropped before measurement completes", async () => {
+    const iframe = await renderIframe(
+      <ElmHtml html="<p>hi</p>" height={400} />,
+    );
+
+    expect(iframe.getAttribute("height") ?? iframe.style.height).toBe("400");
+  });
+
+  test("an explicit `style.height` is not silently dropped before measurement completes", async () => {
+    const iframe = await renderIframe(
+      <ElmHtml html="<p>hi</p>" style={{ height: "400px" }} />,
+    );
+
+    expect(iframe.style.height).toBe("400px");
+  });
+});
+
+describe("[CSR] ElmHtml — sandboxing correctness", () => {
+  test("a forwarded `srcdoc` cannot silently override the intended `html`", async () => {
+    const props = {
+      html: "<p>trusted</p>",
+      srcdoc: "<p>injected</p>",
+    } as unknown as ElmHtmlProps;
+    const iframe = await renderIframe(<ElmHtml {...props} />);
+
+    expect(iframe.getAttribute("srcdoc")).toBe("<p>trusted</p>");
+  });
+
+  test("never adds allow-same-origin when the caller's sandbox override allows scripts, regardless of keyword casing", async () => {
+    const iframe = await renderIframe(
+      <ElmHtml html="<p>x</p>" sandbox="Allow-Scripts" />,
+    );
+
+    expect(
+      iframe.getAttribute("sandbox")?.toLowerCase().split(/\s+/),
+    ).not.toContain("allow-same-origin");
+  });
+
+  test("does not add allow-same-origin when autoHeight is off", async () => {
+    const iframe = await renderIframe(
+      <ElmHtml html="<p>x</p>" autoHeight={false} sandbox="allow-forms" />,
+    );
+
+    expect(iframe.getAttribute("sandbox")?.split(/\s+/)).not.toContain(
+      "allow-same-origin",
+    );
+  });
+});

--- a/packages/qwik/src/components/others/elm-html.spec.tsx
+++ b/packages/qwik/src/components/others/elm-html.spec.tsx
@@ -62,6 +62,21 @@ describe("[CSR] ElmHtml — sandboxing correctness", () => {
     expect(iframe.getAttribute("srcdoc")).toBe("<p>trusted</p>");
   });
 
+  // BUG: only the two known casings (`srcdoc`, `srcDoc`) are stripped from
+  // `rest` — any other casing (e.g. `Srcdoc`) survives the destructure and,
+  // spread after the component's own `srcdoc={html}`, silently overrides it.
+  // Same defect class as the sandbox-casing bug fixed above; same fix
+  // (reposition the component's own assignment after the spread) applies.
+  test("a forwarded differently-cased `Srcdoc` cannot silently override the intended `html` either", async () => {
+    const props = {
+      html: "<p>trusted</p>",
+      Srcdoc: "<p>injected</p>",
+    } as unknown as ElmHtmlProps;
+    const iframe = await renderIframe(<ElmHtml {...props} />);
+
+    expect(iframe.getAttribute("srcdoc")).toBe("<p>trusted</p>");
+  });
+
   test("never adds allow-same-origin when the caller's sandbox override allows scripts, regardless of keyword casing", async () => {
     const iframe = await renderIframe(
       <ElmHtml html="<p>x</p>" sandbox="Allow-Scripts" />,
@@ -82,10 +97,50 @@ describe("[CSR] ElmHtml — sandboxing correctness", () => {
     const iframe = await renderIframe(
       <ElmHtml html="<p>x</p>" sandbox="allow-scripts allow-same-origin" />,
     );
+    const tokens = iframe.getAttribute("sandbox")?.toLowerCase().split(/\s+/);
 
-    expect(
-      iframe.getAttribute("sandbox")?.toLowerCase().split(/\s+/),
-    ).not.toContain("allow-same-origin");
+    expect(tokens).toContain("allow-scripts");
+    expect(tokens).not.toContain("allow-same-origin");
+  });
+
+  // BUG: the strip above only runs inside `if (autoHeight)` — with
+  // `autoHeight={false}`, none of the strip logic executes at all, so a
+  // caller-supplied "allow-scripts allow-same-origin" sandbox passes straight
+  // through unmodified, recreating the exact escape combo this component
+  // exists to prevent, just reached via a different (equally supported) prop
+  // combination.
+  test("strips a caller-supplied allow-same-origin even when autoHeight is off", async () => {
+    const iframe = await renderIframe(
+      <ElmHtml
+        html="<p>x</p>"
+        autoHeight={false}
+        sandbox="allow-scripts allow-same-origin"
+      />,
+    );
+    const tokens = iframe.getAttribute("sandbox")?.toLowerCase().split(/\s+/);
+
+    expect(tokens).toContain("allow-scripts");
+    expect(tokens).not.toContain("allow-same-origin");
+  });
+
+  // BUG: a differently-cased `Sandbox` key smuggled in via a loosely-typed
+  // props bag isn't captured by the `sandbox` destructure (an exact-key
+  // match), so it flows into `...rest`, which is spread after the
+  // component's own `sandbox={effectiveSandbox}` in the JSX. `setAttribute`
+  // lowercases attribute names for HTML elements, so both keys resolve to
+  // the same `sandbox` DOM attribute — and since the smuggled key is applied
+  // later, it silently overwrites the sanitized value, recreating the exact
+  // escape this component exists to prevent.
+  test("a differently-cased `Sandbox` prop cannot override the sanitized sandbox", async () => {
+    const props = {
+      html: "<p>x</p>",
+      sandbox: "allow-forms",
+      Sandbox: "allow-scripts allow-same-origin",
+    } as unknown as ElmHtmlProps;
+    const iframe = await renderIframe(<ElmHtml {...props} />);
+    const tokens = iframe.getAttribute("sandbox")?.toLowerCase().split(/\s+/);
+
+    expect(tokens).not.toContain("allow-scripts");
   });
 
   test("does not add allow-same-origin when autoHeight is off", async () => {

--- a/packages/qwik/src/components/others/elm-html.stories.tsx
+++ b/packages/qwik/src/components/others/elm-html.stories.tsx
@@ -1,0 +1,87 @@
+import type { Meta, StoryObj } from "storybook-framework-qwik";
+
+import { ElmHtml, type ElmHtmlProps } from "./elm-html";
+
+const meta: Meta<ElmHtmlProps> = {
+  title: "Components/Others/elm-html",
+  component: ElmHtml,
+  tags: ["autodocs"],
+  args: {
+    style: { width: "100%" },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<ElmHtmlProps>;
+
+const CLAUDE_ARTIFACT_HTML = `
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <style>
+      body { font-family: sans-serif; margin: 1.5rem; }
+      h1 { color: #6b4fbb; }
+      .card { border: 1px solid #ddd; border-radius: 8px; padding: 1rem; }
+    </style>
+  </head>
+  <body>
+    <h1>Claude-authored artifact</h1>
+    <div class="card">
+      <p>This markup (including its own &lt;style&gt;) is rendered as-is inside a sandboxed iframe.</p>
+      <button onclick="alert('scripts are blocked by the empty sandbox')">Try me</button>
+    </div>
+  </body>
+</html>
+`;
+
+const NOTION_EXPORT_HTML = `
+<div class="page-body">
+  <h1>Meeting Notes</h1>
+  <p>Exported from a Notion page.</p>
+  <figure class="callout">
+    <div>💡</div>
+    <div>Notion wraps callouts in a &lt;figure class="callout"&gt;.</div>
+  </figure>
+  <ul class="to-do-list">
+    <li><span class="checkbox checkbox-on"></span> Ship the pilot</li>
+    <li><span class="checkbox checkbox-off"></span> Wire up qwik/vue</li>
+  </ul>
+</div>
+`;
+
+export const ClaudeArtifact: Story = {
+  args: {
+    html: CLAUDE_ARTIFACT_HTML,
+  },
+};
+
+export const NotionExport: Story = {
+  args: {
+    html: NOTION_EXPORT_HTML,
+  },
+};
+
+const IMAGES_HTML = `
+<p>Absolute URL:</p>
+<img src="https://picsum.photos/seed/elmethis/200/120" width="200" height="120" />
+<p>Relative URL (resolves against the host page, not the HTML's source — breaks unless the source uses absolute URLs):</p>
+<img src="./not-a-real-image.png" width="200" height="120" />
+<p>Data URI:</p>
+<img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='120'%3E%3Crect width='200' height='120' fill='%236b4fbb'/%3E%3C/svg%3E" width="200" height="120" />
+`;
+
+export const Images: Story = {
+  args: {
+    html: IMAGES_HTML,
+  },
+};
+
+export const FixedHeight: Story = {
+  args: {
+    html: CLAUDE_ARTIFACT_HTML,
+    autoHeight: false,
+    style: { width: "100%", height: "150px" },
+  },
+};

--- a/packages/qwik/src/components/others/elm-html.tsx
+++ b/packages/qwik/src/components/others/elm-html.tsx
@@ -1,0 +1,157 @@
+import {
+  component$,
+  PropsOf,
+  useSignal,
+  useTask$,
+  useVisibleTask$,
+  type CSSProperties,
+} from "@qwik.dev/core";
+
+import styles from "./elm-html.module.css";
+
+export interface ElmHtmlProps extends Omit<
+  PropsOf<"iframe">,
+  // Qwik's JSX intrinsics derive prop names straight from the DOM IDL, where
+  // this property is spelled all-lowercase (`HTMLIFrameElement.srcdoc`) —
+  // unlike React, which camelCases it to `srcDoc`.
+  "src" | "srcdoc"
+> {
+  /** Raw HTML markup to render, e.g. a Claude-authored artifact or a Notion page export. */
+  html: string;
+
+  /**
+   * Stretch the iframe to fit its content height. Set to false to size it
+   * yourself instead (via `style`, `height`, or a CSS class).
+   * @default true
+   */
+  autoHeight?: boolean;
+}
+
+export const ElmHtml = component$<ElmHtmlProps>((props) => {
+  const {
+    class: className,
+    html,
+    sandbox,
+    style,
+    height,
+    autoHeight = true,
+    title,
+    // `src`/`srcdoc` are excluded from `ElmHtmlProps` only at the type level
+    // (`Omit<..., "src" | "srcdoc">`) — a loosely-typed caller can still
+    // smuggle one into `rest` at runtime, where spreading it last onto the
+    // iframe would silently override our own `srcdoc={html}` below. Strip
+    // both defensively so `html` stays the single source of truth for what
+    // renders.
+    src: _src,
+    srcdoc: _srcdoc,
+    ...rest
+  } = props as ElmHtmlProps & { src?: unknown; srcdoc?: unknown };
+
+  const iframeRef = useSignal<HTMLIFrameElement>();
+  const contentHeight = useSignal<number>();
+
+  // Unlike react, no render-time-state-adjustment workaround is needed here:
+  // `useTask$` only reruns when a tracked value actually changes, so the
+  // stale-height reset simply lives in a task gated on the same values that
+  // force a fresh iframe below (`key={String(autoHeight)}` / a plain `html`
+  // navigation) — no snapshot/comparison state needed.
+  useTask$(({ track }) => {
+    track(() => props.html);
+    const nextAutoHeight = track(() => props.autoHeight ?? true);
+    if (nextAutoHeight) contentHeight.value = undefined;
+  });
+
+  // Measuring content height needs `allow-same-origin` (to read
+  // `contentDocument`), so it's only ever added while `autoHeight` is on —
+  // never when a caller's sandbox override already allows scripts (combining
+  // allow-scripts with allow-same-origin lets the embedded document escape
+  // the sandbox entirely, becoming same-origin with the parent while still
+  // able to run script), even at the cost of autoHeight not being able to
+  // measure there. The allow-scripts check is case-insensitive: the HTML
+  // `sandbox` attribute matches its keywords case-insensitively, so a
+  // case-sensitive check here could be defeated by a differently-cased
+  // token.
+  const sandboxTokens = new Set(sandbox?.split(/\s+/).filter(Boolean) ?? []);
+  if (autoHeight) {
+    const hasAllowScripts = [...sandboxTokens].some(
+      (token) => token.toLowerCase() === "allow-scripts",
+    );
+    if (!hasAllowScripts) sandboxTokens.add("allow-same-origin");
+  }
+  const effectiveSandbox = [...sandboxTokens].join(" ");
+
+  // eslint-disable-next-line qwik/no-use-visible-task
+  useVisibleTask$(
+    ({ track, cleanup }) => {
+      track(() => props.html);
+      const nextAutoHeight = track(() => props.autoHeight ?? true);
+
+      const iframe = iframeRef.value;
+      if (!iframe) return;
+
+      let observer: ResizeObserver | undefined;
+
+      const measure = () => {
+        const root = iframe.contentDocument?.documentElement;
+        if (root) contentHeight.value = root.scrollHeight;
+      };
+
+      const attachObserver = () => {
+        const root = iframe.contentDocument?.documentElement;
+        if (!root) return;
+        observer = new ResizeObserver(measure);
+        observer.observe(root);
+      };
+
+      const onLoad = () => {
+        if (nextAutoHeight) {
+          measure();
+          attachObserver();
+        }
+      };
+
+      iframe.addEventListener("load", onLoad);
+
+      cleanup(() => {
+        iframe.removeEventListener("load", onLoad);
+        observer?.disconnect();
+      });
+    },
+    { strategy: "document-ready" },
+  );
+
+  return (
+    <iframe
+      // The `sandbox` attribute's flags are fixed for a document at the
+      // moment its navigation starts — changing the attribute afterward
+      // doesn't retroactively apply to whatever's already loaded. Keying on
+      // `autoHeight` forces a fresh iframe (and thus a fresh navigation)
+      // whenever it toggles, so a switch to `autoHeight={true}` always gets
+      // the `allow-same-origin` it needs to measure, instead of being
+      // silently stuck with whatever flags applied when autoHeight was off.
+      key={String(autoHeight)}
+      ref={iframeRef}
+      title={title ?? "Embedded HTML content"}
+      class={[styles["elm-html"], className]}
+      srcdoc={html}
+      sandbox={effectiveSandbox}
+      style={
+        autoHeight
+          ? ({
+              ...(style as CSSProperties),
+              height: contentHeight.value ?? (style as CSSProperties)?.height,
+            } as CSSProperties)
+          : style
+      }
+      height={
+        autoHeight
+          ? contentHeight.value === undefined &&
+            (style as CSSProperties)?.height === undefined
+            ? height
+            : undefined
+          : height
+      }
+      {...rest}
+    />
+  );
+});

--- a/packages/qwik/src/components/others/elm-html.tsx
+++ b/packages/qwik/src/components/others/elm-html.tsx
@@ -40,12 +40,17 @@ export const ElmHtml = component$<ElmHtmlProps>((props) => {
     // (`Omit<..., "src" | "srcdoc">`) — a loosely-typed caller can still
     // smuggle one into `rest` at runtime, where spreading it last onto the
     // iframe would silently override our own `srcdoc={html}` below. Strip
-    // both defensively so `html` stays the single source of truth for what
-    // renders.
+    // both castings of `srcdoc` (a caller could pass either) defensively so
+    // `html` stays the single source of truth for what renders.
     src: _src,
     srcdoc: _srcdoc,
+    srcDoc: _srcDoc,
     ...rest
-  } = props as ElmHtmlProps & { src?: unknown; srcdoc?: unknown };
+  } = props as ElmHtmlProps & {
+    src?: unknown;
+    srcdoc?: unknown;
+    srcDoc?: unknown;
+  };
 
   const iframeRef = useSignal<HTMLIFrameElement>();
   const contentHeight = useSignal<number>();
@@ -62,21 +67,33 @@ export const ElmHtml = component$<ElmHtmlProps>((props) => {
   });
 
   // Measuring content height needs `allow-same-origin` (to read
-  // `contentDocument`), so it's only ever added while `autoHeight` is on —
-  // never when a caller's sandbox override already allows scripts (combining
-  // allow-scripts with allow-same-origin lets the embedded document escape
-  // the sandbox entirely, becoming same-origin with the parent while still
-  // able to run script), even at the cost of autoHeight not being able to
-  // measure there. The allow-scripts check is case-insensitive: the HTML
-  // `sandbox` attribute matches its keywords case-insensitively, so a
-  // case-sensitive check here could be defeated by a differently-cased
-  // token.
+  // `contentDocument`), so it's only ever present while `autoHeight` is on —
+  // never together with allow-scripts (combining allow-scripts with
+  // allow-same-origin lets the embedded document escape the sandbox
+  // entirely, becoming same-origin with the parent while still able to run
+  // script), even at the cost of autoHeight not being able to measure there.
+  // This must both never ADD allow-same-origin onto a sandbox that already
+  // allows scripts, and never leave one in place if the caller supplied both
+  // tokens together directly — otherwise a caller-supplied
+  // "allow-scripts allow-same-origin" sandbox would pass straight through
+  // unmodified, recreating the exact escape this guard exists to prevent.
+  // The allow-scripts check is case-insensitive: the HTML `sandbox` attribute
+  // matches its keywords case-insensitively, so a case-sensitive check here
+  // could be defeated by a differently-cased token.
   const sandboxTokens = new Set(sandbox?.split(/\s+/).filter(Boolean) ?? []);
   if (autoHeight) {
     const hasAllowScripts = [...sandboxTokens].some(
       (token) => token.toLowerCase() === "allow-scripts",
     );
-    if (!hasAllowScripts) sandboxTokens.add("allow-same-origin");
+    if (hasAllowScripts) {
+      for (const token of sandboxTokens) {
+        if (token.toLowerCase() === "allow-same-origin") {
+          sandboxTokens.delete(token);
+        }
+      }
+    } else {
+      sandboxTokens.add("allow-same-origin");
+    }
   }
   const effectiveSandbox = [...sandboxTokens].join(" ");
 

--- a/packages/qwik/src/components/others/elm-html.tsx
+++ b/packages/qwik/src/components/others/elm-html.tsx
@@ -67,33 +67,33 @@ export const ElmHtml = component$<ElmHtmlProps>((props) => {
   });
 
   // Measuring content height needs `allow-same-origin` (to read
-  // `contentDocument`), so it's only ever present while `autoHeight` is on —
+  // `contentDocument`), so it's only ever ADDED while `autoHeight` is on —
   // never together with allow-scripts (combining allow-scripts with
   // allow-same-origin lets the embedded document escape the sandbox
   // entirely, becoming same-origin with the parent while still able to run
   // script), even at the cost of autoHeight not being able to measure there.
-  // This must both never ADD allow-same-origin onto a sandbox that already
-  // allows scripts, and never leave one in place if the caller supplied both
-  // tokens together directly — otherwise a caller-supplied
-  // "allow-scripts allow-same-origin" sandbox would pass straight through
-  // unmodified, recreating the exact escape this guard exists to prevent.
-  // The allow-scripts check is case-insensitive: the HTML `sandbox` attribute
-  // matches its keywords case-insensitively, so a case-sensitive check here
-  // could be defeated by a differently-cased token.
+  // The strip below, unlike the add, must run UNCONDITIONALLY — regardless of
+  // `autoHeight` — because it's enforcing a global invariant ("these two
+  // tokens must never coexist on this iframe"), not just guarding what this
+  // component itself adds. Gating the strip on `autoHeight` would let a
+  // caller-supplied "allow-scripts allow-same-origin" sandbox pass straight
+  // through unmodified whenever `autoHeight={false}`, recreating the exact
+  // escape this guard exists to prevent via a different, equally-supported
+  // prop combination. The allow-scripts check is case-insensitive: the HTML
+  // `sandbox` attribute matches its keywords case-insensitively, so a
+  // case-sensitive check here could be defeated by a differently-cased token.
   const sandboxTokens = new Set(sandbox?.split(/\s+/).filter(Boolean) ?? []);
-  if (autoHeight) {
-    const hasAllowScripts = [...sandboxTokens].some(
-      (token) => token.toLowerCase() === "allow-scripts",
-    );
-    if (hasAllowScripts) {
-      for (const token of sandboxTokens) {
-        if (token.toLowerCase() === "allow-same-origin") {
-          sandboxTokens.delete(token);
-        }
+  const hasAllowScripts = [...sandboxTokens].some(
+    (token) => token.toLowerCase() === "allow-scripts",
+  );
+  if (hasAllowScripts) {
+    for (const token of sandboxTokens) {
+      if (token.toLowerCase() === "allow-same-origin") {
+        sandboxTokens.delete(token);
       }
-    } else {
-      sandboxTokens.add("allow-same-origin");
     }
+  } else if (autoHeight) {
+    sandboxTokens.add("allow-same-origin");
   }
   const effectiveSandbox = [...sandboxTokens].join(" ");
 
@@ -116,6 +116,7 @@ export const ElmHtml = component$<ElmHtmlProps>((props) => {
       const attachObserver = () => {
         const root = iframe.contentDocument?.documentElement;
         if (!root) return;
+        observer?.disconnect();
         observer = new ResizeObserver(measure);
         observer.observe(root);
       };
@@ -150,8 +151,6 @@ export const ElmHtml = component$<ElmHtmlProps>((props) => {
       ref={iframeRef}
       title={title ?? "Embedded HTML content"}
       class={[styles["elm-html"], className]}
-      srcdoc={html}
-      sandbox={effectiveSandbox}
       style={
         autoHeight
           ? ({
@@ -169,6 +168,16 @@ export const ElmHtml = component$<ElmHtmlProps>((props) => {
           : height
       }
       {...rest}
+      // Both placed after `{...rest}` on purpose: a differently-cased key
+      // (e.g. `Sandbox`, `Srcdoc`) smuggled through a loosely-typed props
+      // bag isn't caught by the exact-key destructures above, so it
+      // survives into `rest` — but `setAttribute` lowercases attribute
+      // names for HTML elements, so any such key still resolves to these
+      // same `sandbox`/`srcdoc` DOM attributes. Applying ours last
+      // guarantees they always win, regardless of what casing a smuggled
+      // key used.
+      srcdoc={html}
+      sandbox={effectiveSandbox}
     />
   );
 });

--- a/packages/qwik/src/index.ts
+++ b/packages/qwik/src/index.ts
@@ -280,6 +280,7 @@ export {
   ElmColorSemanticSample,
   type ElmColorSemanticSampleProps,
 } from "./components/others/elm-color-semantic-sample";
+export { ElmHtml, type ElmHtmlProps } from "./components/others/elm-html";
 export {
   ElmMarkdown,
   type ElmMarkdownProps,

--- a/packages/react/src/components/others/elm-html.browser.spec.tsx
+++ b/packages/react/src/components/others/elm-html.browser.spec.tsx
@@ -116,6 +116,82 @@ describe("[CSR] ElmHtml — ResizeObserver keeps tracking real content", () => {
   });
 });
 
+describe("[CSR] ElmHtml — toggling autoHeight with unchanged html", () => {
+  // BUG: `loadedHtmlRef` only tracks the `html` string, not which iframe DOM
+  // node actually loaded it — but `key={String(autoHeight)}` replaces the
+  // iframe node on every toggle. Toggling autoHeight off and immediately back
+  // on (with `html` unchanged) leaves `loadedHtmlRef.current === html` true
+  // from the very first real load, so the "already loaded" shortcut wrongly
+  // fires against the brand-new (remounted) iframe and attaches a
+  // ResizeObserver to it. The real `load` event for that same node still
+  // fires afterward and attaches a *second* ResizeObserver, silently
+  // replacing the first in the effect's closure — the first is never
+  // disconnected. A native ResizeObserver subclass counts constructions and
+  // disconnects (see project convention for native-constructor spies) to
+  // prove that every observer except the currently-live one gets cleaned up.
+  test("does not leak a ResizeObserver when autoHeight is toggled off and back on with the same html", async () => {
+    const OriginalResizeObserver = globalThis.ResizeObserver;
+    const instances: { disconnected: boolean }[] = [];
+
+    class TrackingResizeObserver extends OriginalResizeObserver {
+      disconnected = false;
+
+      constructor(callback: ResizeObserverCallback) {
+        super(callback);
+        instances.push(this);
+      }
+
+      disconnect() {
+        this.disconnected = true;
+        super.disconnect();
+      }
+    }
+
+    globalThis.ResizeObserver = TrackingResizeObserver as typeof ResizeObserver;
+
+    try {
+      const screen = await render(<ElmHtml html={TALL_HTML} />);
+      const getIframe = () => screen.container.querySelector("iframe")!;
+
+      await vi.waitFor(
+        () => {
+          expect(parseInt(getIframe().style.height || "0", 10)).toBeGreaterThan(
+            800,
+          );
+        },
+        { timeout: 2000 },
+      );
+
+      await screen.rerender(<ElmHtml html={TALL_HTML} autoHeight={false} />);
+      await screen.rerender(<ElmHtml html={TALL_HTML} autoHeight={true} />);
+
+      // The remounted iframe's real navigation can still be pending even
+      // once the height has already converged (a wrongly-taken "already
+      // loaded" shortcut can measure the same eventual value ahead of the
+      // real event) -- and `readyState === "complete"` is a false-positive
+      // signal here too, since a brand-new iframe's transient about:blank
+      // document is *also* trivially "complete". Poll for the real content
+      // instead, so the assertion below isn't racing the real `onLoad`
+      // handler that creates the (correctly, single) or leaked (buggy,
+      // duplicate) ResizeObserver.
+      const iframe = getIframe();
+      await vi.waitFor(
+        () => {
+          expect(
+            iframe.contentDocument?.documentElement?.textContent,
+          ).toContain("tall");
+        },
+        { timeout: 2000 },
+      );
+
+      expect(instances.length).toBeGreaterThan(1);
+      expect(instances.slice(0, -1).every((o) => o.disconnected)).toBe(true);
+    } finally {
+      globalThis.ResizeObserver = OriginalResizeObserver;
+    }
+  });
+});
+
 describe("[CSR] ElmHtml — layout defaults", () => {
   // BUG: the module CSS only sets `border: none`, so with no width supplied
   // by the caller the iframe falls back to its ~300px intrinsic default

--- a/packages/react/src/components/others/elm-html.browser.spec.tsx
+++ b/packages/react/src/components/others/elm-html.browser.spec.tsx
@@ -1,0 +1,86 @@
+import { render } from "vitest-browser-react";
+import { describe, expect, test, vi } from "vitest";
+
+import { ElmHtml } from "./elm-html";
+
+// Real navigation + real layout only exist in a real browser: happy-dom
+// doesn't parse `srcDoc` into a measurable document, enforce `sandbox`, or
+// compute layout (`getBoundingClientRect` is always zero), so these bugs —
+// found in code review — need the Chromium layer to reproduce faithfully.
+
+const TALL_HTML = `<div style="height: 900px;">tall</div>`;
+
+describe("[CSR] ElmHtml — autoHeight measurement", () => {
+  test("measures and applies the content height by default", async () => {
+    const screen = await render(<ElmHtml html={TALL_HTML} />);
+    const iframe = screen.container.querySelector("iframe")!;
+
+    await vi.waitFor(() => {
+      expect(parseInt(iframe.style.height || "0", 10)).toBeGreaterThan(800);
+    });
+  });
+
+  // BUG: a caller-supplied `sandbox` override that omits `allow-same-origin`
+  // (and doesn't request scripts) made the iframe's document opaque to the
+  // parent — `contentDocument` was always null on `load`, so the height was
+  // never measured, with no fallback.
+  test("still measures the content height when a caller's sandbox override doesn't request scripts", async () => {
+    const screen = await render(
+      <ElmHtml html={TALL_HTML} sandbox="allow-forms" />,
+    );
+    const iframe = screen.container.querySelector("iframe")!;
+
+    await vi.waitFor(
+      () => {
+        expect(parseInt(iframe.style.height || "0", 10)).toBeGreaterThan(800);
+      },
+      { timeout: 2000 },
+    );
+  });
+
+  // Security guard (not the reproduced bug): allow-scripts + allow-same-origin
+  // together let an embedded document escape the sandbox entirely, so
+  // autoHeight must never force allow-same-origin onto a sandbox that also
+  // allows scripts — even though that means autoHeight can't measure there.
+  test("never adds allow-same-origin when the caller's sandbox override allows scripts", async () => {
+    const screen = await render(
+      <ElmHtml html={TALL_HTML} sandbox="allow-scripts" />,
+    );
+    const iframe = screen.container.querySelector("iframe")!;
+
+    expect(iframe.getAttribute("sandbox")?.split(/\s+/)).not.toContain(
+      "allow-same-origin",
+    );
+  });
+});
+
+describe("[CSR] ElmHtml — layout defaults", () => {
+  // BUG: the module CSS only sets `border: none`, so with no width supplied
+  // by the caller the iframe falls back to its ~300px intrinsic default
+  // width instead of filling its container.
+  test("fills its container width by default", async () => {
+    const screen = await render(
+      <div style={{ width: "500px" }}>
+        <ElmHtml html="<p>x</p>" autoHeight={false} height={100} />
+      </div>,
+    );
+    const iframe = screen.container.querySelector("iframe")!;
+
+    await vi.waitFor(() => {
+      expect(iframe.getBoundingClientRect().width).toBeCloseTo(500, 0);
+    });
+  });
+
+  // BUG: no `display: block` is set, so the iframe keeps the UA-default
+  // inline-level box, leaving a baseline gap below the measured height.
+  test("renders as a block-level box, not inline", async () => {
+    const screen = await render(
+      <ElmHtml html="<p>x</p>" autoHeight={false} height={100} />,
+    );
+    const iframe = screen.container.querySelector("iframe")!;
+
+    await vi.waitFor(() => {
+      expect(getComputedStyle(iframe).display).toBe("block");
+    });
+  });
+});

--- a/packages/react/src/components/others/elm-html.browser.spec.tsx
+++ b/packages/react/src/components/others/elm-html.browser.spec.tsx
@@ -192,6 +192,68 @@ describe("[CSR] ElmHtml — toggling autoHeight with unchanged html", () => {
   });
 });
 
+describe("[CSR] ElmHtml — ResizeObserver on in-frame re-navigation", () => {
+  // BUG: `attachObserver` overwrites the effect-scoped `observer` variable
+  // without disconnecting whatever it previously held. `html`/`autoHeight`
+  // unchanged means the effect never reruns and never tears down — but the
+  // same iframe node can still fire a *second* native `load` event on its
+  // own (the embedded document re-navigating itself, e.g. a same-origin
+  // `location.reload()`), which re-runs `onLoad` -> `attachObserver()` and
+  // silently orphans the first ResizeObserver.
+  test("does not leak a ResizeObserver when the same iframe re-navigates without any prop change", async () => {
+    const OriginalResizeObserver = globalThis.ResizeObserver;
+    const instances: { disconnected: boolean }[] = [];
+
+    class TrackingResizeObserver extends OriginalResizeObserver {
+      disconnected = false;
+
+      constructor(callback: ResizeObserverCallback) {
+        super(callback);
+        instances.push(this);
+      }
+
+      disconnect() {
+        this.disconnected = true;
+        super.disconnect();
+      }
+    }
+
+    globalThis.ResizeObserver = TrackingResizeObserver as typeof ResizeObserver;
+
+    try {
+      const screen = await render(<ElmHtml html={TALL_HTML} />);
+      const iframe = screen.container.querySelector("iframe")!;
+
+      await vi.waitFor(
+        () => {
+          expect(instances.length).toBeGreaterThanOrEqual(1);
+          expect(
+            iframe.contentDocument?.documentElement?.textContent,
+          ).toContain("tall");
+        },
+        { timeout: 2000 },
+      );
+
+      const countBeforeReload = instances.length;
+
+      // Same iframe node, no React prop change — a real second `load` event
+      // triggered by the framed document itself re-navigating.
+      iframe.contentWindow!.location.reload();
+
+      await vi.waitFor(
+        () => {
+          expect(instances.length).toBeGreaterThan(countBeforeReload);
+        },
+        { timeout: 2000 },
+      );
+
+      expect(instances.slice(0, -1).every((o) => o.disconnected)).toBe(true);
+    } finally {
+      globalThis.ResizeObserver = OriginalResizeObserver;
+    }
+  });
+});
+
 describe("[CSR] ElmHtml — layout defaults", () => {
   // BUG: the module CSS only sets `border: none`, so with no width supplied
   // by the caller the iframe falls back to its ~300px intrinsic default

--- a/packages/react/src/components/others/elm-html.browser.spec.tsx
+++ b/packages/react/src/components/others/elm-html.browser.spec.tsx
@@ -1,3 +1,4 @@
+import { StrictMode } from "react";
 import { render } from "vitest-browser-react";
 import { describe, expect, test, vi } from "vitest";
 
@@ -10,14 +11,26 @@ import { ElmHtml } from "./elm-html";
 
 const TALL_HTML = `<div style="height: 900px;">tall</div>`;
 
+// Grows from 50px to 900px shortly after load, purely via CSS — no script
+// execution needed (and none would run under the default sandbox anyway),
+// so a ResizeObserver watching the real content root is required to catch
+// the growth; one measurement taken at `load` time is not enough.
+const GROWING_HTML = `<style>
+  @keyframes grow { from { height: 50px; } to { height: 900px; } }
+  div { animation: grow 0.2s forwards; }
+</style><div>content</div>`;
+
 describe("[CSR] ElmHtml — autoHeight measurement", () => {
   test("measures and applies the content height by default", async () => {
     const screen = await render(<ElmHtml html={TALL_HTML} />);
     const iframe = screen.container.querySelector("iframe")!;
 
-    await vi.waitFor(() => {
-      expect(parseInt(iframe.style.height || "0", 10)).toBeGreaterThan(800);
-    });
+    await vi.waitFor(
+      () => {
+        expect(parseInt(iframe.style.height || "0", 10)).toBeGreaterThan(800);
+      },
+      { timeout: 2000 },
+    );
   });
 
   // BUG: a caller-supplied `sandbox` override that omits `allow-same-origin`
@@ -50,6 +63,55 @@ describe("[CSR] ElmHtml — autoHeight measurement", () => {
 
     expect(iframe.getAttribute("sandbox")?.split(/\s+/)).not.toContain(
       "allow-same-origin",
+    );
+  });
+});
+
+describe("[CSR] ElmHtml — ResizeObserver keeps tracking real content", () => {
+  // BUG: under React.StrictMode, the mount effect runs, cleans up, and runs
+  // again in the same tick. By the second run `prevHtmlRef` already equals
+  // `html`, so the "html unchanged" check is fooled into calling `sync()`
+  // immediately — before the iframe has actually navigated to `html`. That
+  // premature `sync()` attaches the ResizeObserver to the transient
+  // about:blank document. When the real `load` event later fires, `measure()`
+  // corrects the height once, but the `!observer` guard skips re-attaching
+  // to the real content root — so later height changes are never observed.
+  test("keeps measuring height changes after mount inside React.StrictMode", async () => {
+    const screen = await render(
+      <StrictMode>
+        <ElmHtml html={GROWING_HTML} />
+      </StrictMode>,
+    );
+    const iframe = screen.container.querySelector("iframe")!;
+
+    await vi.waitFor(
+      () => {
+        expect(parseInt(iframe.style.height || "0", 10)).toBeGreaterThan(800);
+      },
+      { timeout: 3000 },
+    );
+  });
+
+  // BUG: while `autoHeight` is off, `prevHtmlRef` is still updated on every
+  // `html` change even though `srcDoc` (bound unconditionally) may still be
+  // navigating. Flipping `autoHeight` back on without a further `html`
+  // change makes the "html unchanged" check wrongly true, so `sync()` runs
+  // immediately instead of waiting for `load` — the same premature-attach
+  // hazard as the StrictMode case above, reached via prop toggling instead.
+  test("keeps measuring height changes when autoHeight is toggled off and back on across an html change", async () => {
+    const screen = await render(<ElmHtml autoHeight={false} html="<p>a</p>" />);
+
+    await screen.rerender(<ElmHtml autoHeight={false} html={GROWING_HTML} />);
+    await screen.rerender(<ElmHtml autoHeight={true} html={GROWING_HTML} />);
+
+    // Toggling autoHeight can force a fresh iframe element (see elm-html.tsx),
+    // so re-query rather than reusing a reference captured before the toggle.
+    await vi.waitFor(
+      () => {
+        const iframe = screen.container.querySelector("iframe")!;
+        expect(parseInt(iframe.style.height || "0", 10)).toBeGreaterThan(800);
+      },
+      { timeout: 3000 },
     );
   });
 });

--- a/packages/react/src/components/others/elm-html.module.css
+++ b/packages/react/src/components/others/elm-html.module.css
@@ -1,0 +1,5 @@
+.elm-html {
+  display: block;
+  width: 100%;
+  border: none;
+}

--- a/packages/react/src/components/others/elm-html.spec.tsx
+++ b/packages/react/src/components/others/elm-html.spec.tsx
@@ -56,6 +56,21 @@ describe("[CSR] ElmHtml — sandboxing correctness", () => {
     expect(iframe.getAttribute("srcdoc")).toBe("<p>trusted</p>");
   });
 
+  // BUG: the strip only removes the key `srcDoc` (camelCase) — the DOM
+  // attribute is spelled `srcdoc`, and a loosely-typed caller forwarding that
+  // exact lowercase key reaches `...rest` untouched, silently overriding the
+  // component's own `srcDoc={html}`.
+  test("a forwarded lowercase `srcdoc` cannot silently override the intended `html` either", () => {
+    const props = {
+      html: "<p>trusted</p>",
+      srcdoc: "<p>injected</p>",
+    } as unknown as ElmHtmlProps;
+    const { container } = render(<ElmHtml {...props} />);
+    const iframe = container.querySelector("iframe")!;
+
+    expect(iframe.getAttribute("srcdoc")).toBe("<p>trusted</p>");
+  });
+
   // BUG: the allow-scripts guard does `sandboxTokens.has("allow-scripts")`,
   // a case-sensitive Set lookup — but the HTML `sandbox` attribute matches
   // its keywords case-insensitively, so a differently-cased caller token
@@ -64,6 +79,23 @@ describe("[CSR] ElmHtml — sandboxing correctness", () => {
   test("never adds allow-same-origin when the caller's sandbox override allows scripts, regardless of keyword casing", () => {
     const { container } = render(
       <ElmHtml html="<p>x</p>" sandbox="Allow-Scripts" />,
+    );
+    const iframe = container.querySelector("iframe")!;
+
+    expect(
+      iframe.getAttribute("sandbox")?.toLowerCase().split(/\s+/),
+    ).not.toContain("allow-same-origin");
+  });
+
+  // BUG: the guard above only prevents this component from ADDING
+  // allow-same-origin when allow-scripts is present — it never strips one the
+  // caller already supplied alongside allow-scripts. A caller-supplied
+  // "allow-scripts allow-same-origin" sandbox therefore passes straight
+  // through unmodified, recreating the exact escape combo this component
+  // exists to prevent.
+  test("strips a caller-supplied allow-same-origin when the caller's sandbox override already allows scripts too", () => {
+    const { container } = render(
+      <ElmHtml html="<p>x</p>" sandbox="allow-scripts allow-same-origin" />,
     );
     const iframe = container.querySelector("iframe")!;
 

--- a/packages/react/src/components/others/elm-html.spec.tsx
+++ b/packages/react/src/components/others/elm-html.spec.tsx
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "vitest";
+import { render } from "@testing-library/react";
+
+import { ElmHtml } from "./elm-html";
+
+// ---------------------------------------------------------------------------
+// [CSR]
+//
+// Reproduces a bug found in code review: while `autoHeight` is at its default
+// `true`, the component unconditionally overwrites both the `height` prop and
+// `style.height` with the (initially unmeasured) `contentHeight` state — so a
+// caller-supplied height is silently dropped instead of being used until the
+// real measurement lands. No real iframe navigation is needed to see this:
+// it's true of the very first synchronous render, which is why this lives in
+// the unit layer rather than *.browser.spec.tsx.
+// ---------------------------------------------------------------------------
+describe("[CSR] ElmHtml — explicit height while autoHeight is on", () => {
+  test("an explicit `height` prop is not silently dropped before measurement completes", () => {
+    const { container } = render(<ElmHtml html="<p>hi</p>" height={400} />);
+    const iframe = container.querySelector("iframe")!;
+
+    expect(iframe.getAttribute("height") ?? iframe.style.height).toBe("400");
+  });
+
+  test("an explicit `style.height` is not silently dropped before measurement completes", () => {
+    const { container } = render(
+      <ElmHtml html="<p>hi</p>" style={{ height: 400 }} />,
+    );
+    const iframe = container.querySelector("iframe")!;
+
+    expect(iframe.style.height).toBe("400px");
+  });
+});

--- a/packages/react/src/components/others/elm-html.spec.tsx
+++ b/packages/react/src/components/others/elm-html.spec.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "vitest";
 import { render } from "@testing-library/react";
 
-import { ElmHtml } from "./elm-html";
+import { ElmHtml, type ElmHtmlProps } from "./elm-html";
 
 // ---------------------------------------------------------------------------
 // [CSR]
@@ -29,5 +29,62 @@ describe("[CSR] ElmHtml — explicit height while autoHeight is on", () => {
     const iframe = container.querySelector("iframe")!;
 
     expect(iframe.style.height).toBe("400px");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// [CSR]
+//
+// Reproduces bugs found in a third code-review round, all visible on the
+// synchronous first render — no real iframe navigation needed, so these live
+// in the unit layer rather than *.browser.spec.tsx.
+// ---------------------------------------------------------------------------
+describe("[CSR] ElmHtml — sandboxing correctness", () => {
+  // BUG: `src`/`srcDoc` are excluded from `ElmHtmlProps` only at the type
+  // level (`Omit<..., "src" | "srcDoc">`); the runtime destructure doesn't
+  // strip them, so a `srcDoc` key that reaches `...rest` (e.g. forwarded from
+  // a loosely-typed props bag) is spread onto the iframe after the
+  // component's own `srcDoc={html}` and silently wins.
+  test("a forwarded `srcDoc` cannot silently override the intended `html`", () => {
+    const props = {
+      html: "<p>trusted</p>",
+      srcDoc: "<p>injected</p>",
+    } as unknown as ElmHtmlProps;
+    const { container } = render(<ElmHtml {...props} />);
+    const iframe = container.querySelector("iframe")!;
+
+    expect(iframe.getAttribute("srcdoc")).toBe("<p>trusted</p>");
+  });
+
+  // BUG: the allow-scripts guard does `sandboxTokens.has("allow-scripts")`,
+  // a case-sensitive Set lookup — but the HTML `sandbox` attribute matches
+  // its keywords case-insensitively, so a differently-cased caller token
+  // slips past the guard and still gets `allow-same-origin` force-added,
+  // recreating the sandbox-escape the guard exists to prevent.
+  test("never adds allow-same-origin when the caller's sandbox override allows scripts, regardless of keyword casing", () => {
+    const { container } = render(
+      <ElmHtml html="<p>x</p>" sandbox="Allow-Scripts" />,
+    );
+    const iframe = container.querySelector("iframe")!;
+
+    expect(
+      iframe.getAttribute("sandbox")?.toLowerCase().split(/\s+/),
+    ).not.toContain("allow-same-origin");
+  });
+
+  // BUG: the allow-same-origin merge runs unconditionally, even when
+  // `autoHeight={false}` — the only reason `allow-same-origin` is ever
+  // needed (reading `contentDocument` to measure height). With autoHeight
+  // off there's no measurement happening, so the extra privilege is pure
+  // unwanted exposure with no way for the caller to opt out.
+  test("does not add allow-same-origin when autoHeight is off", () => {
+    const { container } = render(
+      <ElmHtml html="<p>x</p>" autoHeight={false} sandbox="allow-forms" />,
+    );
+    const iframe = container.querySelector("iframe")!;
+
+    expect(iframe.getAttribute("sandbox")?.split(/\s+/)).not.toContain(
+      "allow-same-origin",
+    );
   });
 });

--- a/packages/react/src/components/others/elm-html.spec.tsx
+++ b/packages/react/src/components/others/elm-html.spec.tsx
@@ -71,6 +71,22 @@ describe("[CSR] ElmHtml — sandboxing correctness", () => {
     expect(iframe.getAttribute("srcdoc")).toBe("<p>trusted</p>");
   });
 
+  // BUG: only the two known casings (`srcDoc`, `srcdoc`) are stripped from
+  // `rest` — any other casing (e.g. `Srcdoc`) survives the destructure and,
+  // spread after the component's own `srcDoc={html}`, silently overrides it.
+  // Same defect class as the sandbox-casing bug fixed above; same fix
+  // (reposition the component's own assignment after the spread) applies.
+  test("a forwarded differently-cased `Srcdoc` cannot silently override the intended `html` either", () => {
+    const props = {
+      html: "<p>trusted</p>",
+      Srcdoc: "<p>injected</p>",
+    } as unknown as ElmHtmlProps;
+    const { container } = render(<ElmHtml {...props} />);
+    const iframe = container.querySelector("iframe")!;
+
+    expect(iframe.getAttribute("srcdoc")).toBe("<p>trusted</p>");
+  });
+
   // BUG: the allow-scripts guard does `sandboxTokens.has("allow-scripts")`,
   // a case-sensitive Set lookup — but the HTML `sandbox` attribute matches
   // its keywords case-insensitively, so a differently-cased caller token
@@ -98,10 +114,52 @@ describe("[CSR] ElmHtml — sandboxing correctness", () => {
       <ElmHtml html="<p>x</p>" sandbox="allow-scripts allow-same-origin" />,
     );
     const iframe = container.querySelector("iframe")!;
+    const tokens = iframe.getAttribute("sandbox")?.toLowerCase().split(/\s+/);
 
-    expect(
-      iframe.getAttribute("sandbox")?.toLowerCase().split(/\s+/),
-    ).not.toContain("allow-same-origin");
+    expect(tokens).toContain("allow-scripts");
+    expect(tokens).not.toContain("allow-same-origin");
+  });
+
+  // BUG: the strip above only runs inside `if (autoHeight)` — with
+  // `autoHeight={false}`, none of the strip logic executes at all, so a
+  // caller-supplied "allow-scripts allow-same-origin" sandbox passes straight
+  // through unmodified, recreating the exact escape combo this component
+  // exists to prevent, just reached via a different (equally supported) prop
+  // combination.
+  test("strips a caller-supplied allow-same-origin even when autoHeight is off", () => {
+    const { container } = render(
+      <ElmHtml
+        html="<p>x</p>"
+        autoHeight={false}
+        sandbox="allow-scripts allow-same-origin"
+      />,
+    );
+    const iframe = container.querySelector("iframe")!;
+    const tokens = iframe.getAttribute("sandbox")?.toLowerCase().split(/\s+/);
+
+    expect(tokens).toContain("allow-scripts");
+    expect(tokens).not.toContain("allow-same-origin");
+  });
+
+  // BUG: a differently-cased `Sandbox` key smuggled in via a loosely-typed
+  // props bag isn't captured by the `sandbox` destructure (an exact-key
+  // match), so it flows into `...safeRest`, which is spread after the
+  // component's own `sandbox={effectiveSandbox}` in the JSX. `setAttribute`
+  // lowercases attribute names for HTML elements, so both keys resolve to
+  // the same `sandbox` DOM attribute — and since the smuggled key is applied
+  // later, it silently overwrites the sanitized value, recreating the exact
+  // escape this component exists to prevent.
+  test("a differently-cased `Sandbox` prop cannot override the sanitized sandbox", () => {
+    const props = {
+      html: "<p>x</p>",
+      sandbox: "allow-forms",
+      Sandbox: "allow-scripts allow-same-origin",
+    } as unknown as ElmHtmlProps;
+    const { container } = render(<ElmHtml {...props} />);
+    const iframe = container.querySelector("iframe")!;
+    const tokens = iframe.getAttribute("sandbox")?.toLowerCase().split(/\s+/);
+
+    expect(tokens).not.toContain("allow-scripts");
   });
 
   // BUG: the allow-same-origin merge runs unconditionally, even when

--- a/packages/react/src/components/others/elm-html.stories.tsx
+++ b/packages/react/src/components/others/elm-html.stories.tsx
@@ -1,0 +1,87 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { ElmHtml } from "./elm-html";
+
+const meta = {
+  title: "Components/Others/elm-html",
+  component: ElmHtml,
+  tags: ["autodocs"],
+  args: {
+    style: { width: "100%" },
+  },
+} satisfies Meta<typeof ElmHtml>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const CLAUDE_ARTIFACT_HTML = `
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <style>
+      body { font-family: sans-serif; margin: 1.5rem; }
+      h1 { color: #6b4fbb; }
+      .card { border: 1px solid #ddd; border-radius: 8px; padding: 1rem; }
+    </style>
+  </head>
+  <body>
+    <h1>Claude-authored artifact</h1>
+    <div class="card">
+      <p>This markup (including its own &lt;style&gt;) is rendered as-is inside a sandboxed iframe.</p>
+      <button onclick="alert('scripts are blocked by the empty sandbox')">Try me</button>
+    </div>
+  </body>
+</html>
+`;
+
+const NOTION_EXPORT_HTML = `
+<div class="page-body">
+  <h1>Meeting Notes</h1>
+  <p>Exported from a Notion page.</p>
+  <figure class="callout">
+    <div>💡</div>
+    <div>Notion wraps callouts in a &lt;figure class="callout"&gt;.</div>
+  </figure>
+  <ul class="to-do-list">
+    <li><span class="checkbox checkbox-on"></span> Ship the pilot</li>
+    <li><span class="checkbox checkbox-off"></span> Wire up qwik/vue</li>
+  </ul>
+</div>
+`;
+
+export const ClaudeArtifact: Story = {
+  args: {
+    html: CLAUDE_ARTIFACT_HTML,
+  },
+};
+
+export const NotionExport: Story = {
+  args: {
+    html: NOTION_EXPORT_HTML,
+  },
+};
+
+const IMAGES_HTML = `
+<p>Absolute URL:</p>
+<img src="https://picsum.photos/seed/elmethis/200/120" width="200" height="120" />
+<p>Relative URL (resolves against the host page, not the HTML's source — breaks unless the source uses absolute URLs):</p>
+<img src="./not-a-real-image.png" width="200" height="120" />
+<p>Data URI:</p>
+<img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='120'%3E%3Crect width='200' height='120' fill='%236b4fbb'/%3E%3C/svg%3E" width="200" height="120" />
+`;
+
+export const Images: Story = {
+  args: {
+    html: IMAGES_HTML,
+  },
+};
+
+export const FixedHeight: Story = {
+  args: {
+    html: CLAUDE_ARTIFACT_HTML,
+    autoHeight: false,
+    style: { width: "100%", height: "150px" },
+  },
+};

--- a/packages/react/src/components/others/elm-html.tsx
+++ b/packages/react/src/components/others/elm-html.tsx
@@ -35,33 +35,35 @@ export const ElmHtml = ({
 }: ElmHtmlProps) => {
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const [contentHeight, setContentHeight] = useState<number>();
-  const prevHtmlRef = useRef<string | undefined>(undefined);
+  // The html value the iframe's `load` event has actually fired for — set
+  // only from inside the real `load` handler below, never inferred from
+  // prop-diffing. A prop-diffing heuristic (e.g. "did html change since last
+  // render?") is fooled by a React StrictMode double-invoke (the second
+  // invocation sees no prop change and wrongly assumes the doc already
+  // loaded) and by toggling autoHeight off/on around an html change (a
+  // navigation can still be in flight when autoHeight turns back on).
+  const loadedHtmlRef = useRef<string | undefined>(undefined);
 
   // Measuring content height needs `allow-same-origin` (to read
-  // `contentDocument`). We add it to a caller-supplied `sandbox` override
-  // automatically — UNLESS they've also requested `allow-scripts`: combining
+  // `contentDocument`), so it's only ever added while `autoHeight` is on —
+  // never when a caller's sandbox override already allows scripts (combining
   // allow-scripts with allow-same-origin lets the embedded document escape
-  // the sandbox entirely (it becomes same-origin with the parent while still
-  // able to run script), so that one combination is never auto-added, even
-  // at the cost of autoHeight not being able to measure.
+  // the sandbox entirely, becoming same-origin with the parent while still
+  // able to run script), even at the cost of autoHeight not being able to
+  // measure there. The allow-scripts check is case-insensitive: the HTML
+  // `sandbox` attribute matches its keywords case-insensitively, so a
+  // case-sensitive check here could be defeated by a differently-cased
+  // token.
   const sandboxTokens = new Set(sandbox?.split(/\s+/).filter(Boolean) ?? []);
-  if (!sandboxTokens.has("allow-scripts"))
-    sandboxTokens.add("allow-same-origin");
+  if (autoHeight) {
+    const hasAllowScripts = [...sandboxTokens].some(
+      (token) => token.toLowerCase() === "allow-scripts",
+    );
+    if (!hasAllowScripts) sandboxTokens.add("allow-same-origin");
+  }
   const effectiveSandbox = [...sandboxTokens].join(" ");
 
   useEffect(() => {
-    if (!autoHeight) {
-      prevHtmlRef.current = html;
-      return;
-    }
-
-    // Only trust an already-loaded document when html didn't just change —
-    // right after an html change the iframe may still be navigating, so its
-    // contentDocument can transiently be the outgoing document.
-    const htmlUnchanged = prevHtmlRef.current === html;
-    prevHtmlRef.current = html;
-    if (!htmlUnchanged) setContentHeight(undefined);
-
     const iframe = iframeRef.current;
     if (!iframe) return;
 
@@ -72,28 +74,66 @@ export const ElmHtml = ({
       if (root) setContentHeight(root.scrollHeight);
     };
 
-    const sync = () => {
-      measure();
+    const attachObserver = () => {
       const root = iframe.contentDocument?.documentElement;
-      if (root && !observer) {
-        observer = new ResizeObserver(measure);
-        observer.observe(root);
+      if (!root) return;
+      observer = new ResizeObserver(measure);
+      observer.observe(root);
+    };
+
+    const onLoad = () => {
+      loadedHtmlRef.current = html;
+      if (autoHeight) {
+        measure();
+        attachObserver();
       }
     };
 
-    iframe.addEventListener("load", sync);
-    // autoHeight may have just turned on for content that's already loaded
-    // (html unchanged), in which case 'load' won't fire again to sync it.
-    if (htmlUnchanged) sync();
+    iframe.addEventListener("load", onLoad);
+
+    if (autoHeight) {
+      if (loadedHtmlRef.current === html) {
+        // The iframe already finished loading this exact html before this
+        // effect ran (e.g. autoHeight just turned on, or a StrictMode
+        // remount) — 'load' won't fire again, so sync against the
+        // already-settled document directly instead of waiting for it.
+        measure();
+        attachObserver();
+      } else {
+        setContentHeight(undefined);
+      }
+    }
 
     return () => {
-      iframe.removeEventListener("load", sync);
+      iframe.removeEventListener("load", onLoad);
       observer?.disconnect();
     };
   }, [html, autoHeight]);
 
+  // `src`/`srcDoc` are excluded from `ElmHtmlProps` only at the type level
+  // (`Omit<..., "src" | "srcDoc">`) — a loosely-typed caller can still
+  // smuggle one into `rest` at runtime, where spreading it last onto the
+  // iframe would silently override our own `srcDoc={html}` below. Strip both
+  // defensively so `html` stays the single source of truth for what renders.
+  const {
+    src: _src,
+    srcDoc: _srcDoc,
+    ...safeRest
+  } = rest as typeof rest & {
+    src?: unknown;
+    srcDoc?: unknown;
+  };
+
   return (
     <iframe
+      // The `sandbox` attribute's flags are fixed for a document at the
+      // moment its navigation starts — changing the attribute afterward
+      // doesn't retroactively apply to whatever's already loaded. Keying on
+      // `autoHeight` forces a fresh iframe (and thus a fresh navigation)
+      // whenever it toggles, so a switch to `autoHeight={true}` always gets
+      // the `allow-same-origin` it needs to measure, instead of being
+      // silently stuck with whatever flags applied when autoHeight was off.
+      key={String(autoHeight)}
       ref={iframeRef}
       title={title ?? "Embedded HTML content"}
       className={clsx(styles["elm-html"], className)}
@@ -111,7 +151,7 @@ export const ElmHtml = ({
             : undefined
           : height
       }
-      {...rest}
+      {...safeRest}
     />
   );
 };

--- a/packages/react/src/components/others/elm-html.tsx
+++ b/packages/react/src/components/others/elm-html.tsx
@@ -51,33 +51,33 @@ export const ElmHtml = ({
   }
 
   // Measuring content height needs `allow-same-origin` (to read
-  // `contentDocument`), so it's only ever present while `autoHeight` is on —
+  // `contentDocument`), so it's only ever ADDED while `autoHeight` is on —
   // never together with allow-scripts (combining allow-scripts with
   // allow-same-origin lets the embedded document escape the sandbox
   // entirely, becoming same-origin with the parent while still able to run
   // script), even at the cost of autoHeight not being able to measure there.
-  // This must both never ADD allow-same-origin onto a sandbox that already
-  // allows scripts, and never leave one in place if the caller supplied both
-  // tokens together directly — otherwise a caller-supplied
-  // "allow-scripts allow-same-origin" sandbox would pass straight through
-  // unmodified, recreating the exact escape this guard exists to prevent.
-  // The allow-scripts check is case-insensitive: the HTML `sandbox` attribute
-  // matches its keywords case-insensitively, so a case-sensitive check here
-  // could be defeated by a differently-cased token.
+  // The strip below, unlike the add, must run UNCONDITIONALLY — regardless of
+  // `autoHeight` — because it's enforcing a global invariant ("these two
+  // tokens must never coexist on this iframe"), not just guarding what this
+  // component itself adds. Gating the strip on `autoHeight` would let a
+  // caller-supplied "allow-scripts allow-same-origin" sandbox pass straight
+  // through unmodified whenever `autoHeight={false}`, recreating the exact
+  // escape this guard exists to prevent via a different, equally-supported
+  // prop combination. The allow-scripts check is case-insensitive: the HTML
+  // `sandbox` attribute matches its keywords case-insensitively, so a
+  // case-sensitive check here could be defeated by a differently-cased token.
   const sandboxTokens = new Set(sandbox?.split(/\s+/).filter(Boolean) ?? []);
-  if (autoHeight) {
-    const hasAllowScripts = [...sandboxTokens].some(
-      (token) => token.toLowerCase() === "allow-scripts",
-    );
-    if (hasAllowScripts) {
-      for (const token of sandboxTokens) {
-        if (token.toLowerCase() === "allow-same-origin") {
-          sandboxTokens.delete(token);
-        }
+  const hasAllowScripts = [...sandboxTokens].some(
+    (token) => token.toLowerCase() === "allow-scripts",
+  );
+  if (hasAllowScripts) {
+    for (const token of sandboxTokens) {
+      if (token.toLowerCase() === "allow-same-origin") {
+        sandboxTokens.delete(token);
       }
-    } else {
-      sandboxTokens.add("allow-same-origin");
     }
+  } else if (autoHeight) {
+    sandboxTokens.add("allow-same-origin");
   }
   const effectiveSandbox = [...sandboxTokens].join(" ");
 
@@ -95,6 +95,7 @@ export const ElmHtml = ({
     const attachObserver = () => {
       const root = iframe.contentDocument?.documentElement;
       if (!root) return;
+      observer?.disconnect();
       observer = new ResizeObserver(measure);
       observer.observe(root);
     };
@@ -144,8 +145,6 @@ export const ElmHtml = ({
       ref={iframeRef}
       title={title ?? "Embedded HTML content"}
       className={clsx(styles["elm-html"], className)}
-      srcDoc={html}
-      sandbox={effectiveSandbox}
       style={
         autoHeight
           ? { ...style, height: contentHeight ?? style?.height }
@@ -159,6 +158,16 @@ export const ElmHtml = ({
           : height
       }
       {...safeRest}
+      // Both placed after `{...safeRest}` on purpose: a differently-cased
+      // key (e.g. `Sandbox`, `Srcdoc`) smuggled through a loosely-typed
+      // props bag isn't caught by the exact-key destructures above, so it
+      // survives into `safeRest` — but `setAttribute` lowercases attribute
+      // names for HTML elements, so any such key still resolves to these
+      // same `sandbox`/`srcdoc` DOM attributes. Applying ours last
+      // guarantees they always win, regardless of what casing a smuggled key
+      // used.
+      srcDoc={html}
+      sandbox={effectiveSandbox}
     />
   );
 };

--- a/packages/react/src/components/others/elm-html.tsx
+++ b/packages/react/src/components/others/elm-html.tsx
@@ -1,0 +1,117 @@
+import {
+  useEffect,
+  useRef,
+  useState,
+  type ComponentPropsWithoutRef,
+} from "react";
+import { clsx } from "clsx";
+
+import styles from "./elm-html.module.css";
+
+export interface ElmHtmlProps extends Omit<
+  ComponentPropsWithoutRef<"iframe">,
+  "src" | "srcDoc"
+> {
+  /** Raw HTML markup to render, e.g. a Claude-authored artifact or a Notion page export. */
+  html: string;
+
+  /**
+   * Stretch the iframe to fit its content height. Set to false to size it
+   * yourself instead (via `style`, `height`, or a CSS class).
+   * @default true
+   */
+  autoHeight?: boolean;
+}
+
+export const ElmHtml = ({
+  className,
+  html,
+  sandbox,
+  style,
+  height,
+  autoHeight = true,
+  title,
+  ...rest
+}: ElmHtmlProps) => {
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const [contentHeight, setContentHeight] = useState<number>();
+  const prevHtmlRef = useRef<string | undefined>(undefined);
+
+  // Measuring content height needs `allow-same-origin` (to read
+  // `contentDocument`). We add it to a caller-supplied `sandbox` override
+  // automatically — UNLESS they've also requested `allow-scripts`: combining
+  // allow-scripts with allow-same-origin lets the embedded document escape
+  // the sandbox entirely (it becomes same-origin with the parent while still
+  // able to run script), so that one combination is never auto-added, even
+  // at the cost of autoHeight not being able to measure.
+  const sandboxTokens = new Set(sandbox?.split(/\s+/).filter(Boolean) ?? []);
+  if (!sandboxTokens.has("allow-scripts"))
+    sandboxTokens.add("allow-same-origin");
+  const effectiveSandbox = [...sandboxTokens].join(" ");
+
+  useEffect(() => {
+    if (!autoHeight) {
+      prevHtmlRef.current = html;
+      return;
+    }
+
+    // Only trust an already-loaded document when html didn't just change —
+    // right after an html change the iframe may still be navigating, so its
+    // contentDocument can transiently be the outgoing document.
+    const htmlUnchanged = prevHtmlRef.current === html;
+    prevHtmlRef.current = html;
+    if (!htmlUnchanged) setContentHeight(undefined);
+
+    const iframe = iframeRef.current;
+    if (!iframe) return;
+
+    let observer: ResizeObserver | undefined;
+
+    const measure = () => {
+      const root = iframe.contentDocument?.documentElement;
+      if (root) setContentHeight(root.scrollHeight);
+    };
+
+    const sync = () => {
+      measure();
+      const root = iframe.contentDocument?.documentElement;
+      if (root && !observer) {
+        observer = new ResizeObserver(measure);
+        observer.observe(root);
+      }
+    };
+
+    iframe.addEventListener("load", sync);
+    // autoHeight may have just turned on for content that's already loaded
+    // (html unchanged), in which case 'load' won't fire again to sync it.
+    if (htmlUnchanged) sync();
+
+    return () => {
+      iframe.removeEventListener("load", sync);
+      observer?.disconnect();
+    };
+  }, [html, autoHeight]);
+
+  return (
+    <iframe
+      ref={iframeRef}
+      title={title ?? "Embedded HTML content"}
+      className={clsx(styles["elm-html"], className)}
+      srcDoc={html}
+      sandbox={effectiveSandbox}
+      style={
+        autoHeight
+          ? { ...style, height: contentHeight ?? style?.height }
+          : style
+      }
+      height={
+        autoHeight
+          ? contentHeight === undefined && style?.height === undefined
+            ? height
+            : undefined
+          : height
+      }
+      {...rest}
+    />
+  );
+};

--- a/packages/react/src/components/others/elm-html.tsx
+++ b/packages/react/src/components/others/elm-html.tsx
@@ -35,19 +35,20 @@ export const ElmHtml = ({
 }: ElmHtmlProps) => {
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const [contentHeight, setContentHeight] = useState<number>();
-  // The (iframe node, html) pair the `load` event has actually fired for —
-  // set only from inside the real `load` handler below, never inferred from
-  // prop-diffing. A prop-diffing heuristic (e.g. "did html change since last
-  // render?") is fooled by a React StrictMode double-invoke (the second
-  // invocation sees no prop change and wrongly assumes the doc already
-  // loaded). Tracking the node too (not just the html string) matters
-  // because `key={String(autoHeight)}` below replaces the iframe with a
-  // fresh, unloaded node on every autoHeight toggle — without the node
-  // check, toggling off and back on with unchanged html would wrongly match
-  // an earlier load that happened on a now-discarded node.
-  const loadedRef = useRef<
-    { node: HTMLIFrameElement; html: string } | undefined
-  >(undefined);
+
+  // `key={String(autoHeight)}` (below) gives a fresh, unloaded iframe node
+  // on an autoHeight toggle, and a plain html change is a fresh navigation
+  // too — either way the previously-measured height goes stale the moment
+  // `html`/`autoHeight` change, well before the effect that re-measures it
+  // gets to run. Resetting it here, during render (React's documented
+  // pattern for adjusting state in response to a prop change), avoids an
+  // extra render showing the stale value that a reset inside the effect
+  // would cause.
+  const [loadKey, setLoadKey] = useState({ html, autoHeight });
+  if (loadKey.html !== html || loadKey.autoHeight !== autoHeight) {
+    setLoadKey({ html, autoHeight });
+    if (autoHeight) setContentHeight(undefined);
+  }
 
   // Measuring content height needs `allow-same-origin` (to read
   // `contentDocument`), so it's only ever added while `autoHeight` is on —
@@ -87,7 +88,6 @@ export const ElmHtml = ({
     };
 
     const onLoad = () => {
-      loadedRef.current = { node: iframe, html };
       if (autoHeight) {
         measure();
         attachObserver();
@@ -95,26 +95,6 @@ export const ElmHtml = ({
     };
 
     iframe.addEventListener("load", onLoad);
-
-    if (autoHeight) {
-      if (
-        loadedRef.current?.node === iframe &&
-        loadedRef.current.html === html
-      ) {
-        // This exact iframe node already finished loading this exact html
-        // before this effect ran (a StrictMode remount, which reuses the
-        // same DOM node) — 'load' won't fire again, so sync against the
-        // already-settled document directly instead of waiting for it. The
-        // node check matters because `key={String(autoHeight)}` below
-        // replaces the iframe with an unloaded node on every autoHeight
-        // toggle; without it, this would wrongly match a load that
-        // happened on a now-discarded node.
-        measure();
-        attachObserver();
-      } else {
-        setContentHeight(undefined);
-      }
-    }
 
     return () => {
       iframe.removeEventListener("load", onLoad);

--- a/packages/react/src/components/others/elm-html.tsx
+++ b/packages/react/src/components/others/elm-html.tsx
@@ -51,21 +51,33 @@ export const ElmHtml = ({
   }
 
   // Measuring content height needs `allow-same-origin` (to read
-  // `contentDocument`), so it's only ever added while `autoHeight` is on —
-  // never when a caller's sandbox override already allows scripts (combining
-  // allow-scripts with allow-same-origin lets the embedded document escape
-  // the sandbox entirely, becoming same-origin with the parent while still
-  // able to run script), even at the cost of autoHeight not being able to
-  // measure there. The allow-scripts check is case-insensitive: the HTML
-  // `sandbox` attribute matches its keywords case-insensitively, so a
-  // case-sensitive check here could be defeated by a differently-cased
-  // token.
+  // `contentDocument`), so it's only ever present while `autoHeight` is on —
+  // never together with allow-scripts (combining allow-scripts with
+  // allow-same-origin lets the embedded document escape the sandbox
+  // entirely, becoming same-origin with the parent while still able to run
+  // script), even at the cost of autoHeight not being able to measure there.
+  // This must both never ADD allow-same-origin onto a sandbox that already
+  // allows scripts, and never leave one in place if the caller supplied both
+  // tokens together directly — otherwise a caller-supplied
+  // "allow-scripts allow-same-origin" sandbox would pass straight through
+  // unmodified, recreating the exact escape this guard exists to prevent.
+  // The allow-scripts check is case-insensitive: the HTML `sandbox` attribute
+  // matches its keywords case-insensitively, so a case-sensitive check here
+  // could be defeated by a differently-cased token.
   const sandboxTokens = new Set(sandbox?.split(/\s+/).filter(Boolean) ?? []);
   if (autoHeight) {
     const hasAllowScripts = [...sandboxTokens].some(
       (token) => token.toLowerCase() === "allow-scripts",
     );
-    if (!hasAllowScripts) sandboxTokens.add("allow-same-origin");
+    if (hasAllowScripts) {
+      for (const token of sandboxTokens) {
+        if (token.toLowerCase() === "allow-same-origin") {
+          sandboxTokens.delete(token);
+        }
+      }
+    } else {
+      sandboxTokens.add("allow-same-origin");
+    }
   }
   const effectiveSandbox = [...sandboxTokens].join(" ");
 
@@ -106,14 +118,17 @@ export const ElmHtml = ({
   // (`Omit<..., "src" | "srcDoc">`) — a loosely-typed caller can still
   // smuggle one into `rest` at runtime, where spreading it last onto the
   // iframe would silently override our own `srcDoc={html}` below. Strip both
-  // defensively so `html` stays the single source of truth for what renders.
+  // castings of `srcDoc` (a caller could pass either) defensively so `html`
+  // stays the single source of truth for what renders.
   const {
     src: _src,
     srcDoc: _srcDoc,
+    srcdoc: _srcdoc,
     ...safeRest
   } = rest as typeof rest & {
     src?: unknown;
     srcDoc?: unknown;
+    srcdoc?: unknown;
   };
 
   return (

--- a/packages/react/src/components/others/elm-html.tsx
+++ b/packages/react/src/components/others/elm-html.tsx
@@ -35,14 +35,19 @@ export const ElmHtml = ({
 }: ElmHtmlProps) => {
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const [contentHeight, setContentHeight] = useState<number>();
-  // The html value the iframe's `load` event has actually fired for — set
-  // only from inside the real `load` handler below, never inferred from
+  // The (iframe node, html) pair the `load` event has actually fired for —
+  // set only from inside the real `load` handler below, never inferred from
   // prop-diffing. A prop-diffing heuristic (e.g. "did html change since last
   // render?") is fooled by a React StrictMode double-invoke (the second
   // invocation sees no prop change and wrongly assumes the doc already
-  // loaded) and by toggling autoHeight off/on around an html change (a
-  // navigation can still be in flight when autoHeight turns back on).
-  const loadedHtmlRef = useRef<string | undefined>(undefined);
+  // loaded). Tracking the node too (not just the html string) matters
+  // because `key={String(autoHeight)}` below replaces the iframe with a
+  // fresh, unloaded node on every autoHeight toggle — without the node
+  // check, toggling off and back on with unchanged html would wrongly match
+  // an earlier load that happened on a now-discarded node.
+  const loadedRef = useRef<
+    { node: HTMLIFrameElement; html: string } | undefined
+  >(undefined);
 
   // Measuring content height needs `allow-same-origin` (to read
   // `contentDocument`), so it's only ever added while `autoHeight` is on —
@@ -82,7 +87,7 @@ export const ElmHtml = ({
     };
 
     const onLoad = () => {
-      loadedHtmlRef.current = html;
+      loadedRef.current = { node: iframe, html };
       if (autoHeight) {
         measure();
         attachObserver();
@@ -92,11 +97,18 @@ export const ElmHtml = ({
     iframe.addEventListener("load", onLoad);
 
     if (autoHeight) {
-      if (loadedHtmlRef.current === html) {
-        // The iframe already finished loading this exact html before this
-        // effect ran (e.g. autoHeight just turned on, or a StrictMode
-        // remount) — 'load' won't fire again, so sync against the
-        // already-settled document directly instead of waiting for it.
+      if (
+        loadedRef.current?.node === iframe &&
+        loadedRef.current.html === html
+      ) {
+        // This exact iframe node already finished loading this exact html
+        // before this effect ran (a StrictMode remount, which reuses the
+        // same DOM node) — 'load' won't fire again, so sync against the
+        // already-settled document directly instead of waiting for it. The
+        // node check matters because `key={String(autoHeight)}` below
+        // replaces the iframe with an unloaded node on every autoHeight
+        // toggle; without it, this would wrongly match a load that
+        // happened on a now-discarded node.
         measure();
         attachObserver();
       } else {

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -165,6 +165,7 @@ export {
   ElmColorSemanticSample,
   type ElmColorSemanticSampleProps,
 } from "./components/others/elm-color-semantic-sample";
+export { ElmHtml, type ElmHtmlProps } from "./components/others/elm-html";
 export {
   ElmMarkdown,
   type ElmMarkdownProps,

--- a/packages/vue/src/components/others/elm-html.browser.spec.tsx
+++ b/packages/vue/src/components/others/elm-html.browser.spec.tsx
@@ -124,7 +124,9 @@ describe("[CSR] ElmHtml — toggling autoHeight with unchanged html", () => {
     globalThis.ResizeObserver = TrackingResizeObserver as typeof ResizeObserver;
 
     try {
-      const screen = render(ElmHtml, { props: { html: TALL_HTML } });
+      const screen = render(ElmHtml, {
+        props: { html: TALL_HTML, autoHeight: true },
+      });
       const getIframe = () => screen.container.querySelector("iframe")!;
 
       await vi.waitFor(

--- a/packages/vue/src/components/others/elm-html.browser.spec.tsx
+++ b/packages/vue/src/components/others/elm-html.browser.spec.tsx
@@ -166,6 +166,68 @@ describe("[CSR] ElmHtml — toggling autoHeight with unchanged html", () => {
   });
 });
 
+describe("[CSR] ElmHtml — ResizeObserver on in-frame re-navigation", () => {
+  // BUG: `attachObserver` overwrites the closure-scoped `observer` variable
+  // without disconnecting whatever it previously held. `html`/`autoHeight`
+  // unchanged means `disposeLifecycle`/`attachLifecycle` never rerun — but
+  // the same iframe node can still fire a *second* native `load` event on
+  // its own (the embedded document re-navigating itself, e.g. a same-origin
+  // `location.reload()`), which re-runs `onLoad` -> `attachObserver()` and
+  // silently orphans the first ResizeObserver.
+  test("does not leak a ResizeObserver when the same iframe re-navigates without any prop change", async () => {
+    const OriginalResizeObserver = globalThis.ResizeObserver;
+    const instances: { disconnected: boolean }[] = [];
+
+    class TrackingResizeObserver extends OriginalResizeObserver {
+      disconnected = false;
+
+      constructor(callback: ResizeObserverCallback) {
+        super(callback);
+        instances.push(this);
+      }
+
+      disconnect() {
+        this.disconnected = true;
+        super.disconnect();
+      }
+    }
+
+    globalThis.ResizeObserver = TrackingResizeObserver as typeof ResizeObserver;
+
+    try {
+      const screen = render(ElmHtml, { props: { html: TALL_HTML } });
+      const iframe = screen.container.querySelector("iframe")!;
+
+      await vi.waitFor(
+        () => {
+          expect(instances.length).toBeGreaterThanOrEqual(1);
+          expect(
+            iframe.contentDocument?.documentElement?.textContent,
+          ).toContain("tall");
+        },
+        { timeout: 2000 },
+      );
+
+      const countBeforeReload = instances.length;
+
+      // Same iframe node, no prop change — a real second `load` event
+      // triggered by the framed document itself re-navigating.
+      iframe.contentWindow!.location.reload();
+
+      await vi.waitFor(
+        () => {
+          expect(instances.length).toBeGreaterThan(countBeforeReload);
+        },
+        { timeout: 2000 },
+      );
+
+      expect(instances.slice(0, -1).every((o) => o.disconnected)).toBe(true);
+    } finally {
+      globalThis.ResizeObserver = OriginalResizeObserver;
+    }
+  });
+});
+
 describe("[CSR] ElmHtml — layout defaults", () => {
   test("fills its container width by default", async () => {
     const Harness = defineComponent({

--- a/packages/vue/src/components/others/elm-html.browser.spec.tsx
+++ b/packages/vue/src/components/others/elm-html.browser.spec.tsx
@@ -1,0 +1,197 @@
+import { render } from "vitest-browser-vue";
+import { defineComponent } from "vue";
+import { describe, expect, test, vi } from "vitest";
+
+import { ElmHtml } from "./elm-html";
+
+// Real navigation + real layout only exist in a real browser: happy-dom
+// doesn't parse `srcdoc` into a measurable document, enforce `sandbox`, or
+// compute layout (`getBoundingClientRect` is always zero), so these bugs —
+// found in code review on the react sibling and carried over here as
+// regression coverage — need the Chromium layer to reproduce faithfully.
+
+const TALL_HTML = `<div style="height: 900px;">tall</div>`;
+
+// Grows from 50px to 900px shortly after load, purely via CSS — no script
+// execution needed (and none would run under the default sandbox anyway), so
+// a ResizeObserver watching the real content root is required to catch the
+// growth; one measurement taken at `load` time is not enough.
+const GROWING_HTML = `<style>
+  @keyframes grow { from { height: 50px; } to { height: 900px; } }
+  div { animation: grow 0.2s forwards; }
+</style><div>content</div>`;
+
+describe("[CSR] ElmHtml — autoHeight measurement", () => {
+  test("measures and applies the content height by default", async () => {
+    const screen = render(ElmHtml, { props: { html: TALL_HTML } });
+    const iframe = screen.container.querySelector("iframe")!;
+
+    await vi.waitFor(
+      () => {
+        expect(parseInt(iframe.style.height || "0", 10)).toBeGreaterThan(800);
+      },
+      { timeout: 2000 },
+    );
+  });
+
+  // A caller-supplied `sandbox` override that omits `allow-same-origin` (and
+  // doesn't request scripts) must not make the iframe's document opaque to
+  // the parent: `allow-same-origin` should still be force-added so the
+  // height keeps getting measured.
+  test("still measures the content height when a caller's sandbox override doesn't request scripts", async () => {
+    const screen = render(ElmHtml, {
+      props: { html: TALL_HTML, sandbox: "allow-forms" },
+    });
+    const iframe = screen.container.querySelector("iframe")!;
+
+    await vi.waitFor(
+      () => {
+        expect(parseInt(iframe.style.height || "0", 10)).toBeGreaterThan(800);
+      },
+      { timeout: 2000 },
+    );
+  });
+
+  // Security guard (not a reproduced bug): allow-scripts + allow-same-origin
+  // together let an embedded document escape the sandbox entirely, so
+  // autoHeight must never force allow-same-origin onto a sandbox that also
+  // allows scripts — even though that means autoHeight can't measure there.
+  test("never adds allow-same-origin when the caller's sandbox override allows scripts", async () => {
+    const screen = render(ElmHtml, {
+      props: { html: TALL_HTML, sandbox: "allow-scripts" },
+    });
+    const iframe = screen.container.querySelector("iframe")!;
+
+    expect(iframe.getAttribute("sandbox")?.split(/\s+/)).not.toContain(
+      "allow-same-origin",
+    );
+  });
+});
+
+describe("[CSR] ElmHtml — ResizeObserver keeps tracking real content", () => {
+  // While `autoHeight` is off, `srcdoc` (bound unconditionally) may still be
+  // navigating when it's flipped back on. The observer/`load` watcher must
+  // still end up attached to the real content root rather than getting stuck
+  // on a premature or stale measurement, so later height growth keeps being
+  // observed.
+  test("keeps measuring height changes when autoHeight is toggled off and back on across an html change", async () => {
+    const screen = render(ElmHtml, {
+      props: { autoHeight: false, html: "<p>a</p>" },
+    });
+
+    await screen.rerender({ autoHeight: false, html: GROWING_HTML });
+    await screen.rerender({ autoHeight: true, html: GROWING_HTML });
+
+    // Toggling autoHeight forces a fresh iframe (see elm-html.tsx via the
+    // `key={String(autoHeight)}`), so re-query rather than reusing a
+    // reference captured before the toggle.
+    await vi.waitFor(
+      () => {
+        const iframe = screen.container.querySelector("iframe")!;
+        expect(parseInt(iframe.style.height || "0", 10)).toBeGreaterThan(800);
+      },
+      { timeout: 3000 },
+    );
+  });
+});
+
+describe("[CSR] ElmHtml — toggling autoHeight with unchanged html", () => {
+  // Regression test: `key={String(autoHeight)}` replaces the iframe DOM node
+  // on every toggle. Toggling autoHeight off and immediately back on (with
+  // `html` unchanged) must not leave a stale ResizeObserver attached to a
+  // now-discarded iframe node — every observer except the currently-live one
+  // must get disconnected. A native ResizeObserver subclass counts
+  // constructions and disconnects (see project convention for
+  // native-constructor spies) to prove that.
+  test("does not leak a ResizeObserver when autoHeight is toggled off and back on with the same html", async () => {
+    const OriginalResizeObserver = globalThis.ResizeObserver;
+    const instances: { disconnected: boolean }[] = [];
+
+    class TrackingResizeObserver extends OriginalResizeObserver {
+      disconnected = false;
+
+      constructor(callback: ResizeObserverCallback) {
+        super(callback);
+        instances.push(this);
+      }
+
+      disconnect() {
+        this.disconnected = true;
+        super.disconnect();
+      }
+    }
+
+    globalThis.ResizeObserver = TrackingResizeObserver as typeof ResizeObserver;
+
+    try {
+      const screen = render(ElmHtml, { props: { html: TALL_HTML } });
+      const getIframe = () => screen.container.querySelector("iframe")!;
+
+      await vi.waitFor(
+        () => {
+          expect(parseInt(getIframe().style.height || "0", 10)).toBeGreaterThan(
+            800,
+          );
+        },
+        { timeout: 2000 },
+      );
+
+      await screen.rerender({ html: TALL_HTML, autoHeight: false });
+      await screen.rerender({ html: TALL_HTML, autoHeight: true });
+
+      // The remounted iframe's real navigation can still be pending even
+      // once the height has already converged, and
+      // `readyState === "complete"` is a false-positive signal here too,
+      // since a brand-new iframe's transient about:blank document is *also*
+      // trivially "complete". Poll for the real content instead, so the
+      // assertion below isn't racing the real `load` handler that creates
+      // the (correctly, single) or leaked (buggy, duplicate) ResizeObserver.
+      const iframe = getIframe();
+      await vi.waitFor(
+        () => {
+          expect(
+            iframe.contentDocument?.documentElement?.textContent,
+          ).toContain("tall");
+        },
+        { timeout: 2000 },
+      );
+
+      expect(instances.length).toBeGreaterThan(1);
+      expect(instances.slice(0, -1).every((o) => o.disconnected)).toBe(true);
+    } finally {
+      globalThis.ResizeObserver = OriginalResizeObserver;
+    }
+  });
+});
+
+describe("[CSR] ElmHtml — layout defaults", () => {
+  test("fills its container width by default", async () => {
+    const Harness = defineComponent({
+      name: "Harness",
+      setup() {
+        return () => (
+          <div style={{ width: "500px" }}>
+            <ElmHtml html="<p>x</p>" autoHeight={false} height={100} />
+          </div>
+        );
+      },
+    });
+    const screen = render(Harness);
+    const iframe = screen.container.querySelector("iframe")!;
+
+    await vi.waitFor(() => {
+      expect(iframe.getBoundingClientRect().width).toBeCloseTo(500, 0);
+    });
+  });
+
+  test("renders as a block-level box, not inline", async () => {
+    const screen = render(ElmHtml, {
+      props: { html: "<p>x</p>", autoHeight: false, height: 100 },
+    });
+    const iframe = screen.container.querySelector("iframe")!;
+
+    await vi.waitFor(() => {
+      expect(getComputedStyle(iframe).display).toBe("block");
+    });
+  });
+});

--- a/packages/vue/src/components/others/elm-html.module.css
+++ b/packages/vue/src/components/others/elm-html.module.css
@@ -1,0 +1,5 @@
+.elm-html {
+  display: block;
+  width: 100%;
+  border: none;
+}

--- a/packages/vue/src/components/others/elm-html.spec.tsx
+++ b/packages/vue/src/components/others/elm-html.spec.tsx
@@ -64,6 +64,21 @@ describe("[CSR] ElmHtml — sandboxing correctness", () => {
     expect(iframe.attributes("srcdoc")).toBe("<p>trusted</p>");
   });
 
+  // BUG: only the known casings (`src`, `srcDoc`, `srcdoc`) are stripped from
+  // `attrs` — any other casing (e.g. `Srcdoc`) survives and, spread after the
+  // component's own `srcdoc={props.html}`, silently overrides it. Same
+  // defect class as the sandbox-casing bug fixed above; same fix (reposition
+  // the component's own assignment after the spread) applies.
+  test("a forwarded differently-cased `Srcdoc` cannot silently override the intended `html` either", () => {
+    const wrapper = mount(ElmHtml, {
+      props: { html: "<p>trusted</p>" },
+      attrs: { Srcdoc: "<p>injected</p>" },
+    });
+    const iframe = wrapper.find("iframe");
+
+    expect(iframe.attributes("srcdoc")).toBe("<p>trusted</p>");
+  });
+
   // The allow-scripts guard must do a case-insensitive check — the HTML
   // `sandbox` attribute matches its keywords case-insensitively, so a
   // case-sensitive check could be defeated by a differently-cased caller
@@ -93,10 +108,51 @@ describe("[CSR] ElmHtml — sandboxing correctness", () => {
       },
     });
     const iframe = wrapper.find("iframe");
+    const tokens = iframe.attributes("sandbox")?.toLowerCase().split(/\s+/);
 
-    expect(
-      iframe.attributes("sandbox")?.toLowerCase().split(/\s+/),
-    ).not.toContain("allow-same-origin");
+    expect(tokens).toContain("allow-scripts");
+    expect(tokens).not.toContain("allow-same-origin");
+  });
+
+  // BUG: the strip above only runs inside `if (props.autoHeight)` — with
+  // `autoHeight: false`, none of the strip logic executes at all, so a
+  // caller-supplied "allow-scripts allow-same-origin" sandbox passes straight
+  // through unmodified, recreating the exact escape combo this component
+  // exists to prevent, just reached via a different (equally supported) prop
+  // combination.
+  test("strips a caller-supplied allow-same-origin even when autoHeight is off", () => {
+    const wrapper = mount(ElmHtml, {
+      props: {
+        html: "<p>x</p>",
+        autoHeight: false,
+        sandbox: "allow-scripts allow-same-origin",
+      },
+    });
+    const iframe = wrapper.find("iframe");
+    const tokens = iframe.attributes("sandbox")?.toLowerCase().split(/\s+/);
+
+    expect(tokens).toContain("allow-scripts");
+    expect(tokens).not.toContain("allow-same-origin");
+  });
+
+  // BUG: a differently-cased `Sandbox` key smuggled in via `attrs` isn't
+  // captured by the declared `sandbox` prop (an exact-key match under Vue's
+  // prop resolution), so it lands in `context.attrs` (since
+  // `inheritAttrs: false`), which is spread after the component's own
+  // `sandbox={effectiveSandbox}` in the JSX. `setAttribute` lowercases
+  // attribute names for HTML elements, so both keys resolve to the same
+  // `sandbox` DOM attribute — and since the smuggled key is applied later,
+  // it silently overwrites the sanitized value, recreating the exact escape
+  // this component exists to prevent.
+  test("a differently-cased `Sandbox` attr cannot override the sanitized sandbox", () => {
+    const wrapper = mount(ElmHtml, {
+      props: { html: "<p>x</p>", sandbox: "allow-forms" },
+      attrs: { Sandbox: "allow-scripts allow-same-origin" },
+    });
+    const iframe = wrapper.find("iframe");
+    const tokens = iframe.attributes("sandbox")?.toLowerCase().split(/\s+/);
+
+    expect(tokens).not.toContain("allow-scripts");
   });
 
   // The allow-same-origin merge must not run when `autoHeight={false}` — the
@@ -143,5 +199,45 @@ describe("[CSR] ElmHtml — a non-object `style` value while autoHeight is on", 
     const iframe = wrapper.find("iframe");
 
     expect(iframe.element.style.color).toBe("red");
+  });
+
+  // BUG: `parseStyleString` splits declarations on every `;` with no regard
+  // for nesting, so a value that legitimately contains a `;` (e.g. a data
+  // URI's MIME parameter) gets truncated mid-value at the first one — the
+  // fragment before it has no `:` and is silently dropped, and the fragment
+  // after it is a malformed dangling remainder.
+  test("does not drop a declaration whose value contains a semicolon (e.g. a data URI)", () => {
+    const wrapper = mount(ElmHtml, {
+      props: { html: "<p>x</p>" },
+      attrs: {
+        style:
+          "background-image: url(data:image/png;base64,AAAA); border: 1px solid red;",
+      },
+    });
+    const iframe = wrapper.find("iframe");
+
+    expect(iframe.element.style.backgroundImage).toContain(
+      "data:image/png;base64,AAAA",
+    );
+    expect(iframe.element.style.border).toContain("red");
+  });
+
+  // BUG: the kebab-to-camel conversion (`property.replace(/-([a-z])/g, ...)`)
+  // doesn't special-case a leading `--`, so a CSS custom property like
+  // `--my-radius` gets mangled into the invalid key `-MyRadius` instead of
+  // being left alone — silently losing any caller theming done via CSS
+  // variables in a string-form `style`.
+  test("does not mangle a leading -- custom property", () => {
+    const wrapper = mount(ElmHtml, {
+      props: { html: "<p>x</p>" },
+      attrs: {
+        style: "--my-radius: 8px; border-radius: var(--my-radius);",
+      },
+    });
+    const iframe = wrapper.find("iframe");
+
+    expect(iframe.element.style.getPropertyValue("--my-radius").trim()).toBe(
+      "8px",
+    );
   });
 });

--- a/packages/vue/src/components/others/elm-html.spec.tsx
+++ b/packages/vue/src/components/others/elm-html.spec.tsx
@@ -79,6 +79,26 @@ describe("[CSR] ElmHtml — sandboxing correctness", () => {
     ).not.toContain("allow-same-origin");
   });
 
+  // BUG: the guard above only prevents this component from ADDING
+  // allow-same-origin when allow-scripts is present — it never strips one the
+  // caller already supplied alongside allow-scripts. A caller-supplied
+  // "allow-scripts allow-same-origin" sandbox therefore passes straight
+  // through unmodified, recreating the exact escape combo this component
+  // exists to prevent.
+  test("strips a caller-supplied allow-same-origin when the caller's sandbox override already allows scripts too", () => {
+    const wrapper = mount(ElmHtml, {
+      props: {
+        html: "<p>x</p>",
+        sandbox: "allow-scripts allow-same-origin",
+      },
+    });
+    const iframe = wrapper.find("iframe");
+
+    expect(
+      iframe.attributes("sandbox")?.toLowerCase().split(/\s+/),
+    ).not.toContain("allow-same-origin");
+  });
+
   // The allow-same-origin merge must not run when `autoHeight={false}` — the
   // only reason `allow-same-origin` is ever needed (reading `contentDocument`
   // to measure height). With autoHeight off there's no measurement
@@ -93,5 +113,35 @@ describe("[CSR] ElmHtml — sandboxing correctness", () => {
     expect(iframe.attributes("sandbox")?.split(/\s+/)).not.toContain(
       "allow-same-origin",
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// [CSR]
+//
+// `ElmHtmlProps` inherits `style` from vue's `HTMLAttributes`, whose type is
+// `string | CSSProperties | Array<StyleValue> | ...` — legal, idiomatic vue
+// usage includes a plain string. The component always treats it as a single
+// object and spreads it (`{...callerStyle, height: ...}`); spreading a string
+// indexes its characters as numeric keys instead of merging properties,
+// crashing the render entirely (`patchStyle` then tries to assign a numeric
+// index of `CSSStyleDeclaration`, which only has a getter). No real iframe
+// navigation is needed to see this: it's true of the very first synchronous
+// render, which is why this lives in the unit layer rather than
+// *.browser.spec.tsx.
+//
+// (An array-form `style`, also legal per the type, was checked too but does
+// not reproduce: vue normalizes it to a plain object before this component's
+// `attrs.style` ever sees it, so only the string form is a confirmed bug.)
+// ---------------------------------------------------------------------------
+describe("[CSR] ElmHtml — a non-object `style` value while autoHeight is on", () => {
+  test("does not corrupt a caller-supplied string `style`", () => {
+    const wrapper = mount(ElmHtml, {
+      props: { html: "<p>x</p>" },
+      attrs: { style: "color: red;" },
+    });
+    const iframe = wrapper.find("iframe");
+
+    expect(iframe.element.style.color).toBe("red");
   });
 });

--- a/packages/vue/src/components/others/elm-html.spec.tsx
+++ b/packages/vue/src/components/others/elm-html.spec.tsx
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "vitest";
+import { mount } from "@vue/test-utils";
+
+import { ElmHtml } from "./elm-html";
+
+// ---------------------------------------------------------------------------
+// [CSR]
+//
+// Mirrors a bug found in code review on the react sibling: while `autoHeight`
+// is at its default `true`, an earlier version unconditionally overwrote both
+// the `height` prop and `style.height` with the (initially unmeasured)
+// `contentHeight` state — so a caller-supplied height was silently dropped
+// instead of being used until the real measurement lands. No real iframe
+// navigation is needed to see this: it's true of the very first synchronous
+// render, which is why this lives in the unit layer rather than
+// *.browser.spec.tsx.
+// ---------------------------------------------------------------------------
+describe("[CSR] ElmHtml — explicit height while autoHeight is on", () => {
+  test("an explicit `height` prop is not silently dropped before measurement completes", () => {
+    const wrapper = mount(ElmHtml, {
+      props: { html: "<p>hi</p>", height: 400 },
+    });
+    const iframe = wrapper.find("iframe");
+
+    expect(iframe.attributes("height") ?? iframe.element.style.height).toBe(
+      "400",
+    );
+  });
+
+  // Unlike react, vue does not auto-append "px" to unitless numeric style
+  // values, so a caller-supplied `style.height` is written with units, as is
+  // idiomatic in vue (see elm-tooltip.tsx for the same convention elsewhere
+  // in this codebase).
+  test("an explicit `style.height` is not silently dropped before measurement completes", () => {
+    const wrapper = mount(ElmHtml, {
+      props: { html: "<p>hi</p>" },
+      attrs: { style: { height: "400px" } },
+    });
+    const iframe = wrapper.find("iframe");
+
+    expect(iframe.element.style.height).toBe("400px");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// [CSR]
+//
+// Mirrors bugs found in a third code-review round on the react sibling, all
+// visible on the synchronous first render — no real iframe navigation
+// needed, so these live in the unit layer rather than *.browser.spec.tsx.
+// ---------------------------------------------------------------------------
+describe("[CSR] ElmHtml — sandboxing correctness", () => {
+  // `src`/`srcdoc` are excluded from `ElmHtmlProps` only at the type level; a
+  // loosely-typed caller can still smuggle one into `attrs` at runtime, where
+  // spreading it last onto the iframe would silently override the
+  // component's own `srcdoc={html}`.
+  test("a forwarded `srcDoc` cannot silently override the intended `html`", () => {
+    const wrapper = mount(ElmHtml, {
+      props: { html: "<p>trusted</p>" },
+      attrs: { srcDoc: "<p>injected</p>" },
+    });
+    const iframe = wrapper.find("iframe");
+
+    expect(iframe.attributes("srcdoc")).toBe("<p>trusted</p>");
+  });
+
+  // The allow-scripts guard must do a case-insensitive check — the HTML
+  // `sandbox` attribute matches its keywords case-insensitively, so a
+  // case-sensitive check could be defeated by a differently-cased caller
+  // token, recreating the sandbox-escape the guard exists to prevent.
+  test("never adds allow-same-origin when the caller's sandbox override allows scripts, regardless of keyword casing", () => {
+    const wrapper = mount(ElmHtml, {
+      props: { html: "<p>x</p>", sandbox: "Allow-Scripts" },
+    });
+    const iframe = wrapper.find("iframe");
+
+    expect(
+      iframe.attributes("sandbox")?.toLowerCase().split(/\s+/),
+    ).not.toContain("allow-same-origin");
+  });
+
+  // The allow-same-origin merge must not run when `autoHeight={false}` — the
+  // only reason `allow-same-origin` is ever needed (reading `contentDocument`
+  // to measure height). With autoHeight off there's no measurement
+  // happening, so the extra privilege would be pure unwanted exposure with no
+  // way for the caller to opt out.
+  test("does not add allow-same-origin when autoHeight is off", () => {
+    const wrapper = mount(ElmHtml, {
+      props: { html: "<p>x</p>", autoHeight: false, sandbox: "allow-forms" },
+    });
+    const iframe = wrapper.find("iframe");
+
+    expect(iframe.attributes("sandbox")?.split(/\s+/)).not.toContain(
+      "allow-same-origin",
+    );
+  });
+});

--- a/packages/vue/src/components/others/elm-html.stories.tsx
+++ b/packages/vue/src/components/others/elm-html.stories.tsx
@@ -1,0 +1,87 @@
+import type { Meta, StoryObj } from "@storybook/vue3-vite";
+
+import { ElmHtml } from "./elm-html";
+
+const meta = {
+  title: "Components/Others/elm-html",
+  component: ElmHtml,
+  tags: ["autodocs"],
+  args: {
+    style: { width: "100%" },
+  },
+} satisfies Meta<typeof ElmHtml>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const CLAUDE_ARTIFACT_HTML = `
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <style>
+      body { font-family: sans-serif; margin: 1.5rem; }
+      h1 { color: #6b4fbb; }
+      .card { border: 1px solid #ddd; border-radius: 8px; padding: 1rem; }
+    </style>
+  </head>
+  <body>
+    <h1>Claude-authored artifact</h1>
+    <div class="card">
+      <p>This markup (including its own &lt;style&gt;) is rendered as-is inside a sandboxed iframe.</p>
+      <button onclick="alert('scripts are blocked by the empty sandbox')">Try me</button>
+    </div>
+  </body>
+</html>
+`;
+
+const NOTION_EXPORT_HTML = `
+<div class="page-body">
+  <h1>Meeting Notes</h1>
+  <p>Exported from a Notion page.</p>
+  <figure class="callout">
+    <div>💡</div>
+    <div>Notion wraps callouts in a &lt;figure class="callout"&gt;.</div>
+  </figure>
+  <ul class="to-do-list">
+    <li><span class="checkbox checkbox-on"></span> Ship the pilot</li>
+    <li><span class="checkbox checkbox-off"></span> Wire up qwik/vue</li>
+  </ul>
+</div>
+`;
+
+export const ClaudeArtifact: Story = {
+  args: {
+    html: CLAUDE_ARTIFACT_HTML,
+  },
+};
+
+export const NotionExport: Story = {
+  args: {
+    html: NOTION_EXPORT_HTML,
+  },
+};
+
+const IMAGES_HTML = `
+<p>Absolute URL:</p>
+<img src="https://picsum.photos/seed/elmethis/200/120" width="200" height="120" />
+<p>Relative URL (resolves against the host page, not the HTML's source — breaks unless the source uses absolute URLs):</p>
+<img src="./not-a-real-image.png" width="200" height="120" />
+<p>Data URI:</p>
+<img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='120'%3E%3Crect width='200' height='120' fill='%236b4fbb'/%3E%3C/svg%3E" width="200" height="120" />
+`;
+
+export const Images: Story = {
+  args: {
+    html: IMAGES_HTML,
+  },
+};
+
+export const FixedHeight: Story = {
+  args: {
+    html: CLAUDE_ARTIFACT_HTML,
+    autoHeight: false,
+    style: { width: "100%", height: "150px" },
+  },
+};

--- a/packages/vue/src/components/others/elm-html.tsx
+++ b/packages/vue/src/components/others/elm-html.tsx
@@ -1,5 +1,6 @@
 import {
   defineComponent,
+  normalizeStyle,
   onBeforeUnmount,
   onMounted,
   ref,
@@ -11,6 +12,38 @@ import {
 import { clsx } from "clsx";
 
 import styles from "./elm-html.module.css";
+
+// `HTMLAttributes["style"]` legally includes a plain CSS-text string (unlike
+// react, whose `style` prop is object-only) — vue's own DOM patcher writes a
+// string straight to `element.style.cssText` instead of merging it key by
+// key. `normalizeStyle` (vue's own array/object merge utility, used
+// internally by its DOM patcher) leaves a string untouched rather than
+// parsing it, so it can't be used alone here: this component needs a real
+// key/value view of the caller's style to merge in a measured `height`, so a
+// string has to be parsed into one explicitly.
+const parseStyleString = (css: string): CSSProperties => {
+  const result: Record<string, string> = {};
+  for (const declaration of css.split(";")) {
+    const separatorIndex = declaration.indexOf(":");
+    if (separatorIndex === -1) continue;
+    const property = declaration.slice(0, separatorIndex).trim();
+    const value = declaration.slice(separatorIndex + 1).trim();
+    if (!property || !value) continue;
+    const camelProperty = property.replace(/-([a-z])/g, (_, letter: string) =>
+      letter.toUpperCase(),
+    );
+    result[camelProperty] = value;
+  }
+  return result as CSSProperties;
+};
+
+const toStyleObject = (
+  style: HTMLAttributes["style"],
+): CSSProperties | undefined => {
+  if (style === undefined) return undefined;
+  if (typeof style === "string") return parseStyleString(style);
+  return normalizeStyle(style) as CSSProperties;
+};
 
 export interface ElmHtmlProps extends HTMLAttributes {
   /** Raw HTML markup to render, e.g. a Claude-authored artifact or a Notion page export. */
@@ -153,19 +186,24 @@ export const ElmHtml = defineComponent({
         ...safeRest
       } = attrs as Record<string, unknown>;
 
-      const callerStyle = style as Record<string, unknown> | undefined;
+      const callerStyle = toStyleObject(style as HTMLAttributes["style"]);
       const callerStyleHeight = callerStyle?.height;
 
       // Measuring content height needs `allow-same-origin` (to read
-      // `contentDocument`), so it's only ever added while `autoHeight` is on
-      // — never when a caller's sandbox override already allows scripts
-      // (combining allow-scripts with allow-same-origin lets the embedded
-      // document escape the sandbox entirely, becoming same-origin with the
-      // parent while still able to run script), even at the cost of
-      // autoHeight not being able to measure there. The allow-scripts check
-      // is case-insensitive: the HTML `sandbox` attribute matches its
-      // keywords case-insensitively, so a case-sensitive check here could be
-      // defeated by a differently-cased token.
+      // `contentDocument`), so it's only ever present while `autoHeight` is
+      // on — never together with allow-scripts (combining allow-scripts with
+      // allow-same-origin lets the embedded document escape the sandbox
+      // entirely, becoming same-origin with the parent while still able to
+      // run script), even at the cost of autoHeight not being able to
+      // measure there. This must both never ADD allow-same-origin onto a
+      // sandbox that already allows scripts, and never leave one in place if
+      // the caller supplied both tokens together directly — otherwise a
+      // caller-supplied "allow-scripts allow-same-origin" sandbox would pass
+      // straight through unmodified, recreating the exact escape this guard
+      // exists to prevent. The allow-scripts check is case-insensitive: the
+      // HTML `sandbox` attribute matches its keywords case-insensitively, so
+      // a case-sensitive check here could be defeated by a differently-cased
+      // token.
       const sandboxTokens = new Set(
         props.sandbox?.split(/\s+/).filter(Boolean) ?? [],
       );
@@ -173,7 +211,15 @@ export const ElmHtml = defineComponent({
         const hasAllowScripts = [...sandboxTokens].some(
           (token) => token.toLowerCase() === "allow-scripts",
         );
-        if (!hasAllowScripts) sandboxTokens.add("allow-same-origin");
+        if (hasAllowScripts) {
+          for (const token of sandboxTokens) {
+            if (token.toLowerCase() === "allow-same-origin") {
+              sandboxTokens.delete(token);
+            }
+          }
+        } else {
+          sandboxTokens.add("allow-same-origin");
+        }
       }
       const effectiveSandbox = [...sandboxTokens].join(" ");
 

--- a/packages/vue/src/components/others/elm-html.tsx
+++ b/packages/vue/src/components/others/elm-html.tsx
@@ -21,17 +21,41 @@ import styles from "./elm-html.module.css";
 // parsing it, so it can't be used alone here: this component needs a real
 // key/value view of the caller's style to merge in a measured `height`, so a
 // string has to be parsed into one explicitly.
+// A plain `.split(";")` would cut a value's own `;` in half (e.g. a data
+// URI's MIME parameter, `url(data:image/png;base64,...)`), so declarations
+// are split only on a `;` outside of any parentheses.
+const splitDeclarations = (css: string): string[] => {
+  const declarations: string[] = [];
+  let depth = 0;
+  let start = 0;
+  for (let i = 0; i < css.length; i++) {
+    const char = css[i];
+    if (char === "(") depth++;
+    else if (char === ")") depth = Math.max(0, depth - 1);
+    else if (char === ";" && depth === 0) {
+      declarations.push(css.slice(start, i));
+      start = i + 1;
+    }
+  }
+  declarations.push(css.slice(start));
+  return declarations;
+};
+
 const parseStyleString = (css: string): CSSProperties => {
   const result: Record<string, string> = {};
-  for (const declaration of css.split(";")) {
+  for (const declaration of splitDeclarations(css)) {
     const separatorIndex = declaration.indexOf(":");
     if (separatorIndex === -1) continue;
     const property = declaration.slice(0, separatorIndex).trim();
     const value = declaration.slice(separatorIndex + 1).trim();
     if (!property || !value) continue;
-    const camelProperty = property.replace(/-([a-z])/g, (_, letter: string) =>
-      letter.toUpperCase(),
-    );
+    // A leading `--` marks a CSS custom property, whose name is
+    // case-sensitive and must be left exactly as written.
+    const camelProperty = property.startsWith("--")
+      ? property
+      : property.replace(/-([a-z])/g, (_, letter: string) =>
+          letter.toUpperCase(),
+        );
     result[camelProperty] = value;
   }
   return result as CSSProperties;
@@ -139,6 +163,7 @@ export const ElmHtml = defineComponent({
       const attachObserver = () => {
         const root = iframe.contentDocument?.documentElement;
         if (!root) return;
+        observer?.disconnect();
         observer = new ResizeObserver(measure);
         observer.observe(root);
       };
@@ -190,36 +215,37 @@ export const ElmHtml = defineComponent({
       const callerStyleHeight = callerStyle?.height;
 
       // Measuring content height needs `allow-same-origin` (to read
-      // `contentDocument`), so it's only ever present while `autoHeight` is
-      // on — never together with allow-scripts (combining allow-scripts with
+      // `contentDocument`), so it's only ever ADDED while `autoHeight` is on
+      // — never together with allow-scripts (combining allow-scripts with
       // allow-same-origin lets the embedded document escape the sandbox
       // entirely, becoming same-origin with the parent while still able to
       // run script), even at the cost of autoHeight not being able to
-      // measure there. This must both never ADD allow-same-origin onto a
-      // sandbox that already allows scripts, and never leave one in place if
-      // the caller supplied both tokens together directly — otherwise a
-      // caller-supplied "allow-scripts allow-same-origin" sandbox would pass
-      // straight through unmodified, recreating the exact escape this guard
-      // exists to prevent. The allow-scripts check is case-insensitive: the
-      // HTML `sandbox` attribute matches its keywords case-insensitively, so
-      // a case-sensitive check here could be defeated by a differently-cased
+      // measure there. The strip below, unlike the add, must run
+      // UNCONDITIONALLY — regardless of `autoHeight` — because it's
+      // enforcing a global invariant ("these two tokens must never coexist
+      // on this iframe"), not just guarding what this component itself
+      // adds. Gating the strip on `autoHeight` would let a caller-supplied
+      // "allow-scripts allow-same-origin" sandbox pass straight through
+      // unmodified whenever `autoHeight: false`, recreating the exact escape
+      // this guard exists to prevent via a different, equally-supported prop
+      // combination. The allow-scripts check is case-insensitive: the HTML
+      // `sandbox` attribute matches its keywords case-insensitively, so a
+      // case-sensitive check here could be defeated by a differently-cased
       // token.
       const sandboxTokens = new Set(
         props.sandbox?.split(/\s+/).filter(Boolean) ?? [],
       );
-      if (props.autoHeight) {
-        const hasAllowScripts = [...sandboxTokens].some(
-          (token) => token.toLowerCase() === "allow-scripts",
-        );
-        if (hasAllowScripts) {
-          for (const token of sandboxTokens) {
-            if (token.toLowerCase() === "allow-same-origin") {
-              sandboxTokens.delete(token);
-            }
+      const hasAllowScripts = [...sandboxTokens].some(
+        (token) => token.toLowerCase() === "allow-scripts",
+      );
+      if (hasAllowScripts) {
+        for (const token of sandboxTokens) {
+          if (token.toLowerCase() === "allow-same-origin") {
+            sandboxTokens.delete(token);
           }
-        } else {
-          sandboxTokens.add("allow-same-origin");
         }
+      } else if (props.autoHeight) {
+        sandboxTokens.add("allow-same-origin");
       }
       const effectiveSandbox = [...sandboxTokens].join(" ");
 
@@ -237,8 +263,6 @@ export const ElmHtml = defineComponent({
           ref={iframeRef}
           title={props.title ?? "Embedded HTML content"}
           class={clsx(styles["elm-html"], className as string | undefined)}
-          srcdoc={props.html}
-          sandbox={effectiveSandbox}
           style={
             props.autoHeight
               ? ({
@@ -265,6 +289,16 @@ export const ElmHtml = defineComponent({
               : props.height
           }
           {...safeRest}
+          // Both placed after `{...safeRest}` on purpose: a differently-cased
+          // key (e.g. `Sandbox`, `Srcdoc`) smuggled through `attrs` isn't
+          // caught by Vue's exact-key prop/destructure matching above, so it
+          // survives into `safeRest` — but `setAttribute` lowercases
+          // attribute names for HTML elements, so any such key still
+          // resolves to these same `sandbox`/`srcdoc` DOM attributes.
+          // Applying ours last guarantees they always win, regardless of
+          // what casing a smuggled key used.
+          srcdoc={props.html}
+          sandbox={effectiveSandbox}
         />
       );
     };

--- a/packages/vue/src/components/others/elm-html.tsx
+++ b/packages/vue/src/components/others/elm-html.tsx
@@ -1,0 +1,226 @@
+import {
+  defineComponent,
+  onBeforeUnmount,
+  onMounted,
+  ref,
+  watch,
+  type CSSProperties,
+  type HTMLAttributes,
+  type PropType,
+} from "vue";
+import { clsx } from "clsx";
+
+import styles from "./elm-html.module.css";
+
+export interface ElmHtmlProps extends HTMLAttributes {
+  /** Raw HTML markup to render, e.g. a Claude-authored artifact or a Notion page export. */
+  html: string;
+
+  /**
+   * Stretch the iframe to fit its content height. Set to false to size it
+   * yourself instead (via `style`, `height`, or a CSS class).
+   * @default true
+   */
+  autoHeight?: boolean;
+
+  /**
+   * Sandbox flags applied to the iframe (space-separated, same syntax as the
+   * native `sandbox` attribute). While `autoHeight` is on, `allow-same-origin`
+   * is force-added unless this already requests `allow-scripts` (see below).
+   */
+  sandbox?: string;
+
+  /** Native iframe `height` attribute, in pixels. */
+  height?: number | `${number}`;
+
+  /** Accessible name for the iframe. @default "Embedded HTML content" */
+  title?: string;
+}
+
+export const ElmHtml = defineComponent({
+  name: "ElmHtml",
+  // Native attrs (class, style, id, `allow`, …) are forwarded onto the
+  // <iframe> manually below, same convention as elm-table.tsx.
+  inheritAttrs: false,
+  props: {
+    html: { type: String, required: true },
+    autoHeight: { type: Boolean, default: true },
+    sandbox: { type: String, default: undefined },
+    height: {
+      type: [Number, String] as PropType<number | `${number}`>,
+      default: undefined,
+    },
+    title: { type: String, default: undefined },
+  },
+  setup(props, { attrs }) {
+    const iframeRef = ref<HTMLIFrameElement | null>(null);
+    const contentHeight = ref<number | undefined>(undefined);
+
+    // The `key={String(autoHeight)}` on the <iframe> below (and a plain
+    // `html` change, which is a fresh navigation on its own) both make a
+    // previously-measured height stale the moment `html`/`autoHeight`
+    // change — well before the watcher below that re-measures it gets to
+    // run. `flush: "pre"` runs this before the DOM patches, so (unlike
+    // react, which needed an awkward render-time-state-adjustment workaround
+    // purely to satisfy a lint rule vue doesn't have) there's no stale-paint
+    // frame to guard against.
+    watch(
+      () => [props.html, props.autoHeight] as const,
+      ([, autoHeight]) => {
+        if (autoHeight) contentHeight.value = undefined;
+      },
+      { flush: "pre" },
+    );
+
+    // ResizeObserver + `load` listener attach/cleanup, rerunning whenever
+    // `html`/`autoHeight` change — mirrors react's `useEffect(fn, [html,
+    // autoHeight])` cleanup-per-run semantics.
+    //
+    // This is NOT a single `watch(..., { immediate: true, flush: "post" })`,
+    // even though that reads as the obvious vue equivalent. It was tried
+    // first and is broken: vue's `watch()` invokes an `immediate: true`
+    // callback synchronously, during `setup()`, bypassing the `flush`
+    // scheduler entirely for that first call only (verified against
+    // `@vue/reactivity`'s `watch()` source — `if (immediate) job(true)` calls
+    // the job directly, never through `options.scheduler`). So `flush:
+    // "post"` would still leave `iframeRef.value` `null` on the first run,
+    // before the <iframe> has even mounted. `onMounted` + a *non-immediate*
+    // `flush: "post"` watch for subsequent changes sidesteps that: the first
+    // run goes through `onMounted` (which vue does guarantee runs after the
+    // DOM is patched), and every later run goes through the watcher's
+    // scheduler, which — being a real (non-immediate) trigger — does respect
+    // `flush: "post"` correctly.
+    let disposeLifecycle: (() => void) | undefined;
+
+    const attachLifecycle = (autoHeight: boolean) => {
+      const iframe = iframeRef.value;
+      if (!iframe) return;
+
+      let observer: ResizeObserver | undefined;
+
+      const measure = () => {
+        const root = iframe.contentDocument?.documentElement;
+        if (root) contentHeight.value = root.scrollHeight;
+      };
+
+      const attachObserver = () => {
+        const root = iframe.contentDocument?.documentElement;
+        if (!root) return;
+        observer = new ResizeObserver(measure);
+        observer.observe(root);
+      };
+
+      const onLoad = () => {
+        if (autoHeight) {
+          measure();
+          attachObserver();
+        }
+      };
+
+      iframe.addEventListener("load", onLoad);
+      disposeLifecycle = () => {
+        iframe.removeEventListener("load", onLoad);
+        observer?.disconnect();
+      };
+    };
+
+    onMounted(() => attachLifecycle(props.autoHeight));
+
+    watch(
+      () => [props.html, props.autoHeight] as const,
+      ([, autoHeight]) => {
+        disposeLifecycle?.();
+        attachLifecycle(autoHeight);
+      },
+      { flush: "post" },
+    );
+
+    onBeforeUnmount(() => disposeLifecycle?.());
+
+    return () => {
+      // `src`/`srcdoc` are excluded from `ElmHtmlProps` only at the type
+      // level — a loosely-typed caller can still smuggle one into `attrs` at
+      // runtime, where spreading it last onto the iframe would silently
+      // override our own `srcdoc={props.html}` below. Strip both defensively
+      // (both castings of `srcDoc`, since a caller could pass either) so
+      // `html` stays the single source of truth for what renders.
+      const {
+        class: className,
+        style,
+        src: _src,
+        srcDoc: _srcDoc,
+        srcdoc: _srcdoc,
+        ...safeRest
+      } = attrs as Record<string, unknown>;
+
+      const callerStyle = style as Record<string, unknown> | undefined;
+      const callerStyleHeight = callerStyle?.height;
+
+      // Measuring content height needs `allow-same-origin` (to read
+      // `contentDocument`), so it's only ever added while `autoHeight` is on
+      // — never when a caller's sandbox override already allows scripts
+      // (combining allow-scripts with allow-same-origin lets the embedded
+      // document escape the sandbox entirely, becoming same-origin with the
+      // parent while still able to run script), even at the cost of
+      // autoHeight not being able to measure there. The allow-scripts check
+      // is case-insensitive: the HTML `sandbox` attribute matches its
+      // keywords case-insensitively, so a case-sensitive check here could be
+      // defeated by a differently-cased token.
+      const sandboxTokens = new Set(
+        props.sandbox?.split(/\s+/).filter(Boolean) ?? [],
+      );
+      if (props.autoHeight) {
+        const hasAllowScripts = [...sandboxTokens].some(
+          (token) => token.toLowerCase() === "allow-scripts",
+        );
+        if (!hasAllowScripts) sandboxTokens.add("allow-same-origin");
+      }
+      const effectiveSandbox = [...sandboxTokens].join(" ");
+
+      return (
+        <iframe
+          // The `sandbox` attribute's flags are fixed for a document at the
+          // moment its navigation starts — changing the attribute afterward
+          // doesn't retroactively apply to whatever's already loaded. Keying
+          // on `autoHeight` forces a fresh iframe (and thus a fresh
+          // navigation) whenever it toggles, so a switch to
+          // `autoHeight={true}` always gets the `allow-same-origin` it needs
+          // to measure, instead of being silently stuck with whatever flags
+          // applied when autoHeight was off.
+          key={String(props.autoHeight)}
+          ref={iframeRef}
+          title={props.title ?? "Embedded HTML content"}
+          class={clsx(styles["elm-html"], className as string | undefined)}
+          srcdoc={props.html}
+          sandbox={effectiveSandbox}
+          style={
+            props.autoHeight
+              ? ({
+                  ...callerStyle,
+                  // A number here (unlike react) would produce an invalid,
+                  // silently-ignored CSS value in vue — vue does not
+                  // auto-append "px" to unitless numeric style values the
+                  // way react does — so the measured height is stringified
+                  // explicitly, matching this codebase's convention for
+                  // pixel style values (see elm-tooltip.tsx).
+                  height:
+                    contentHeight.value !== undefined
+                      ? `${contentHeight.value}px`
+                      : callerStyleHeight,
+                } as CSSProperties)
+              : (callerStyle as CSSProperties | undefined)
+          }
+          height={
+            props.autoHeight
+              ? contentHeight.value === undefined &&
+                callerStyleHeight === undefined
+                ? props.height
+                : undefined
+              : props.height
+          }
+          {...safeRest}
+        />
+      );
+    };
+  },
+});

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -178,6 +178,7 @@ export {
   ElmColorSemanticSample,
   type ElmColorSemanticSampleProps,
 } from "./components/others/elm-color-semantic-sample";
+export { ElmHtml, type ElmHtmlProps } from "./components/others/elm-html";
 export {
   ElmMarkdown,
   type ElmMarkdownProps,


### PR DESCRIPTION
## Summary
- Adds `ElmHtml`, a component that renders untrusted HTML in a sandboxed `<iframe>` with optional auto-height (ResizeObserver + `load` listener), to `@elmethis/react`, `@elmethis/qwik`, and `@elmethis/vue` — same prop surface, each framework's idiom.
- react was authored first; qwik and vue were ported from it and independently verified.
- Went through several rounds of code review (spawned as parallel subagents) plus adversarial re-review specifically targeting the sandbox-escape invariant (`allow-scripts` + `allow-same-origin` must never coexist on the rendered `sandbox` attribute). All findings have reproduction tests that were confirmed red before their fix:
  - The `allow-same-origin` strip was gated on `autoHeight`, so `autoHeight={false}` + a caller `sandbox` of `"allow-scripts allow-same-origin"` passed straight through unmodified.
  - A differently-cased `Sandbox`/`Srcdoc` key smuggled through a loosely-typed props bag could silently override the sanitized `sandbox`/`srcDoc` attribute (browsers lowercase attribute names on `setAttribute`, so a later-applied differently-cased prop wins).
  - A `ResizeObserver` leak when the sandboxed content re-navigates itself without any prop change.
  - vue-specific: a caller-supplied string-form `style` could get corrupted, plus two `parseStyleString` bugs (values containing their own semicolon, e.g. a data URI; `--custom-property` mangling).
  - qwik: missing `ElmHtml` export from the package entry point.

## Test plan
- [x] `pnpm --filter @elmethis/core run build` (dependency for all three)
- [x] `pnpm --filter @elmethis/react run check` / `test.unit` / `test.browser` — all green
- [x] `pnpm --filter @elmethis/qwik run check` / `test.unit` / `test.browser` — all green
- [x] `pnpm --filter @elmethis/vue run check` / `test.unit` / `test.browser` — all green
- [x] Adversarial re-review confirming the sandbox-escape invariant holds against every prop/casing combination tried

🤖 Generated with [Claude Code](https://claude.com/claude-code)