### PR TITLE
fix(eslint): pin tsconfigRootDir in react/vue/core/ag-ui-stub

### DIFF
--- a/packages/ag-ui-stub/eslint.config.js
+++ b/packages/ag-ui-stub/eslint.config.js
@@ -14,6 +14,9 @@ export default defineConfig([
         ...globals.node,
         ...globals.browser,
       },
+      parserOptions: {
+        tsconfigRootDir: import.meta.dirname,
+      },
     },
     rules: {
       "@typescript-eslint/no-empty-object-type": "off",

--- a/packages/core/eslint.config.js
+++ b/packages/core/eslint.config.js
@@ -11,6 +11,9 @@ export default defineConfig([
     languageOptions: {
       ecmaVersion: 2020,
       globals: globals.browser,
+      parserOptions: {
+        tsconfigRootDir: import.meta.dirname,
+      },
     },
     rules: {
       "@typescript-eslint/no-empty-object-type": "off",

--- a/packages/react/eslint.config.js
+++ b/packages/react/eslint.config.js
@@ -26,6 +26,9 @@ export default defineConfig([
     languageOptions: {
       ecmaVersion: 2020,
       globals: globals.browser,
+      parserOptions: {
+        tsconfigRootDir: import.meta.dirname,
+      },
     },
     rules: {
       "@typescript-eslint/no-empty-object-type": "off",

--- a/packages/vue/eslint.config.js
+++ b/packages/vue/eslint.config.js
@@ -19,6 +19,9 @@ export default defineConfig([
     languageOptions: {
       ecmaVersion: 2020,
       globals: globals.browser,
+      parserOptions: {
+        tsconfigRootDir: import.meta.dirname,
+      },
     },
     rules: {
       "@typescript-eslint/no-empty-object-type": "off",


### PR DESCRIPTION
## Summary
- VS Code's ESLint extension runs a single Node process for the whole monorepo, and typescript-eslint caches inferred `tsconfigRootDir` candidates in a process-wide singleton. Only `packages/qwik/eslint.config.js` set `tsconfigRootDir` explicitly, so linting a file in `react` after `vue` (or vice versa) had already been linted surfaced two ambiguous candidates and threw a parsing error.
- Explicitly set `parserOptions.tsconfigRootDir: import.meta.dirname` in `react`, `vue`, `core`, and `ag-ui-stub`'s `eslint.config.js`, matching the pattern qwik already used.

## Test plan
- [x] `pnpm exec eslint src/components/others/elm-html.tsx` in `packages/react` — clean, no parsing error
- [x] `pnpm exec eslint .` run in each of `react`, `vue`, `core`, `ag-ui-stub`, `qwik` — no new errors introduced (remaining warnings/errors are pre-existing and unrelated: `vitest.config.ts` triple-slash-reference, local `coverage`/`storybook-static` build artifacts)
- [x] `lefthook` pre-commit `check` hook passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)