### PR TITLE
Add ElmSlider component (React, Qwik, Vue)

### DIFF
--- a/packages/qwik/src/components/form/elm-slider.browser.spec.tsx
+++ b/packages/qwik/src/components/form/elm-slider.browser.spec.tsx
@@ -1,0 +1,228 @@
+// Real `@elmethis/core` tokens (incl. the monospace font stack `.mark-label`
+// uses) so label widths in this file's regression tests reflect the actual
+// rendered font metrics instead of the browser's default serif fallback.
+import "@elmethis/core/tokens.css";
+import { render } from "vitest-browser-qwik";
+import { describe, expect, test } from "vitest";
+
+import { ElmSlider } from "./elm-slider";
+
+// happy-dom/createDOM has no layout engine, so `getBoundingClientRect()`
+// always reports a zero-sized box — pointer-driven dragging (ratio-from-
+// position math) and real CSS layout assertions can only be exercised
+// against a real Chromium layout, hence this lives here rather than in the
+// unit spec.
+
+type Screen = Awaited<ReturnType<typeof render>>;
+const sliderEl = (screen: Screen) =>
+  screen.container.querySelector('[role="slider"]') as HTMLElement;
+
+describe("[CSR] ElmSlider pointer interaction", () => {
+  test("clicking the track sets the value proportionally to the click position", async () => {
+    const screen = await render(<ElmSlider min={0} max={100} step={1} />);
+    const el = sliderEl(screen);
+    el.style.width = "200px";
+
+    const rect = el.getBoundingClientRect();
+    el.dispatchEvent(
+      new PointerEvent("pointerdown", {
+        bubbles: true,
+        clientX: rect.left + rect.width * 0.75,
+        pointerId: 1,
+      }),
+    );
+
+    await expect
+      .poll(() => Number(el.getAttribute("aria-valuenow")))
+      .toBeGreaterThanOrEqual(70);
+  });
+
+  test("dragging past innerMax clamps the value at the inner bound", async () => {
+    const screen = await render(
+      <ElmSlider min={0} max={100} innerMin={20} innerMax={80} />,
+    );
+    const el = sliderEl(screen);
+    el.style.width = "200px";
+
+    const rect = el.getBoundingClientRect();
+    el.dispatchEvent(
+      new PointerEvent("pointerdown", {
+        bubbles: true,
+        clientX: rect.right,
+        pointerId: 1,
+      }),
+    );
+
+    await expect.poll(() => Number(el.getAttribute("aria-valuenow"))).toBe(80);
+  });
+
+  test("vertical orientation increases the value toward the top of the track", async () => {
+    const screen = await render(
+      <ElmSlider min={0} max={100} orientation="vertical" />,
+    );
+    const el = sliderEl(screen);
+    el.style.height = "200px";
+
+    const rect = el.getBoundingClientRect();
+    el.dispatchEvent(
+      new PointerEvent("pointerdown", {
+        bubbles: true,
+        clientY: rect.top + rect.height * 0.1,
+        pointerId: 1,
+      }),
+    );
+
+    await expect
+      .poll(() => Number(el.getAttribute("aria-valuenow")))
+      .toBeGreaterThanOrEqual(80);
+  });
+
+  test("pointerdown snaps to the step grid when step is negative", async () => {
+    // Keyboard stepping treats `step` as a granularity via `Math.abs(step)`,
+    // so ArrowRight/PageUp move in multiples of 10 even when step is -10.
+    // Pointer-driven clicks must snap to the same grid.
+    const screen = await render(<ElmSlider min={0} max={100} step={-10} />);
+    const el = sliderEl(screen);
+    el.style.width = "200px";
+
+    const rect = el.getBoundingClientRect();
+    el.dispatchEvent(
+      new PointerEvent("pointerdown", {
+        bubbles: true,
+        clientX: rect.left + rect.width * 0.53,
+        pointerId: 1,
+      }),
+    );
+
+    await expect
+      .poll(() => Number(el.getAttribute("aria-valuenow")) % 10)
+      .toBe(0);
+  });
+});
+
+describe("[CSR] ElmSlider vertical/marker layout", () => {
+  test("vertical: the progress fill renders with non-zero width", async () => {
+    const screen = await render(
+      <ElmSlider min={0} max={100} orientation="vertical" defaultValue={70} />,
+    );
+    const fill = screen.container.querySelector(
+      '[class*="fill"]',
+    ) as HTMLElement;
+
+    await expect
+      .poll(() => fill.getBoundingClientRect().width)
+      .toBeGreaterThan(0);
+  });
+
+  test("vertical: the progress fill spans the rail's full cross-axis width", async () => {
+    const screen = await render(
+      <ElmSlider min={0} max={100} orientation="vertical" defaultValue={70} />,
+    );
+    const fill = screen.container.querySelector(
+      '[class*="fill"]',
+    ) as HTMLElement;
+    const rail = screen.container.querySelector(
+      '[class*="rail"]',
+    ) as HTMLElement;
+
+    // The vertical fill's *length* (height) represents progress, the way the
+    // horizontal fill's *length* (width) does — its cross-axis thickness
+    // (width) must match the rail's, not shrink toward 0 as value approaches
+    // innerMin.
+    await expect
+      .poll(() => fill.getBoundingClientRect().width)
+      .toBeCloseTo(rail.getBoundingClientRect().width, 1);
+  });
+
+  test("markerLabels: the wrapper reserves layout space so labels render inside its own box", async () => {
+    const screen = await render(
+      <ElmSlider min={0} max={100} step={25} markers markerLabels />,
+    );
+    const wrapper = screen.container.querySelector(
+      '[class*="elm-slider"]',
+    ) as HTMLElement;
+    wrapper.style.width = "300px";
+    const labels = screen.container.querySelectorAll('[class*="mark-label"]');
+    expect(labels.length).toBeGreaterThan(0);
+
+    const wrapperRect = wrapper.getBoundingClientRect();
+    Array.from(labels).forEach((label) => {
+      const labelRect = label.getBoundingClientRect();
+      expect(labelRect.bottom).toBeLessThanOrEqual(wrapperRect.bottom);
+    });
+  });
+
+  test("vertical + markerLabels: wide (5-digit) labels still render inside the wrapper's inline-end edge", async () => {
+    const screen = await render(
+      <ElmSlider
+        orientation="vertical"
+        min={0}
+        max={100000}
+        step={25000}
+        markers
+        markerLabels
+      />,
+    );
+    const wrapper = screen.container.querySelector(
+      '[class*="elm-slider"]',
+    ) as HTMLElement;
+    const labels = screen.container.querySelectorAll('[class*="mark-label"]');
+    expect(labels.length).toBeGreaterThan(0);
+
+    const wrapperRect = wrapper.getBoundingClientRect();
+    Array.from(labels).forEach((label) => {
+      const labelRect = label.getBoundingClientRect();
+      expect(labelRect.right).toBeLessThanOrEqual(wrapperRect.right);
+    });
+  });
+
+  test("vertical + markerLabels under dir=rtl: wide (5-digit) labels still render inside the wrapper's own edge", async () => {
+    const screen = await render(
+      <div dir="rtl">
+        <ElmSlider
+          orientation="vertical"
+          min={0}
+          max={100000}
+          step={25000}
+          markers
+          markerLabels
+        />
+      </div>,
+    );
+    const wrapper = screen.container.querySelector(
+      '[class*="elm-slider"]',
+    ) as HTMLElement;
+    const labels = screen.container.querySelectorAll('[class*="mark-label"]');
+    expect(labels.length).toBeGreaterThan(0);
+
+    const wrapperRect = wrapper.getBoundingClientRect();
+    Array.from(labels).forEach((label) => {
+      const labelRect = label.getBoundingClientRect();
+      expect(labelRect.right).toBeLessThanOrEqual(wrapperRect.right);
+    });
+  });
+
+  test("vertical: the max-value mark sits flush with the track's top edge", async () => {
+    const screen = await render(
+      <ElmSlider
+        orientation="vertical"
+        min={0}
+        max={10}
+        step={1}
+        markers
+        markerLabels
+      />,
+    );
+    const track = screen.container.querySelector(
+      '[class*="track"]',
+    ) as HTMLElement;
+    const markEnd = screen.container.querySelector(
+      '[class*="mark-end"]',
+    ) as HTMLElement;
+
+    const trackRect = track.getBoundingClientRect();
+    const markEndRect = markEnd.getBoundingClientRect();
+
+    expect(Math.abs(markEndRect.top - trackRect.top)).toBeLessThan(2);
+  });
+});

--- a/packages/qwik/src/components/form/elm-slider.module.css
+++ b/packages/qwik/src/components/form/elm-slider.module.css
@@ -1,0 +1,301 @@
+.elm-slider {
+  box-sizing: border-box;
+  width: 100%;
+  margin-block-start: var(--elmethis-margin-block-start);
+  user-select: none;
+}
+
+.elm-slider.vertical {
+  width: fit-content;
+  height: 12rem;
+}
+
+.elm-slider.disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+/* ---- Track ---------------------------------------------------------------- */
+
+/* A roomy hit area so the thin rail stays easy to grab/tap. */
+.track {
+  position: relative;
+  width: 100%;
+  height: 1.25rem;
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  touch-action: none;
+}
+
+.vertical .track {
+  flex-direction: column;
+  width: 1.25rem;
+  height: 100%;
+}
+
+.disabled .track {
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+.track:focus-visible {
+  outline: 2px solid var(--elmethis-color-primary);
+  outline-offset: 4px;
+  border-radius: 0.25rem;
+}
+
+.rail {
+  position: relative;
+  width: 100%;
+  height: 0.25rem;
+  border-radius: 999px;
+  background-color: var(--elmethis-color-neutral-weak);
+  overflow: hidden;
+}
+
+.vertical .rail {
+  width: 0.25rem;
+  height: 100%;
+}
+
+/* Regions of the track outside [innerMin, innerMax] — visually unreachable. */
+.restricted-start,
+.restricted-end {
+  position: absolute;
+  background-color: var(--elmethis-color-neutral-weak);
+  background-image: repeating-linear-gradient(
+    45deg,
+    color-mix(in srgb, var(--elmethis-color-neutral) 35%, transparent) 0,
+    color-mix(in srgb, var(--elmethis-color-neutral) 35%, transparent) 2px,
+    transparent 2px,
+    transparent 6px
+  );
+}
+
+.restricted-start {
+  inset: 0 auto 0 0;
+  width: calc(var(--elmethis-scoped-inner-min-ratio, 0) * 100%);
+}
+
+.restricted-end {
+  inset: 0 0 0 auto;
+  width: calc((1 - var(--elmethis-scoped-inner-max-ratio, 1)) * 100%);
+}
+
+.vertical .restricted-start,
+.vertical .restricted-end {
+  width: auto;
+}
+
+.vertical .restricted-start {
+  inset: auto 0 0;
+  height: calc(var(--elmethis-scoped-inner-min-ratio, 0) * 100%);
+}
+
+.vertical .restricted-end {
+  inset: 0 0 auto;
+  height: calc((1 - var(--elmethis-scoped-inner-max-ratio, 1)) * 100%);
+}
+
+.fill {
+  position: absolute;
+  inset: 0 auto;
+  left: calc(var(--elmethis-scoped-inner-min-ratio, 0) * 100%);
+  width: calc(
+    (
+        var(--elmethis-scoped-value-ratio, 0) -
+          var(--elmethis-scoped-inner-min-ratio, 0)
+      ) *
+      100%
+  );
+  border-radius: 999px;
+  background-color: var(--elmethis-color-primary);
+}
+
+.vertical .fill {
+  inset: auto 0 0;
+  width: auto;
+  bottom: calc(var(--elmethis-scoped-inner-min-ratio, 0) * 100%);
+  height: calc(
+    (
+        var(--elmethis-scoped-value-ratio, 0) -
+          var(--elmethis-scoped-inner-min-ratio, 0)
+      ) *
+      100%
+  );
+}
+
+/* Draggable handle. */
+.thumb {
+  position: absolute;
+  top: 50%;
+  left: calc(var(--elmethis-scoped-value-ratio, 0) * 100%);
+  width: 0.875rem;
+  height: 0.875rem;
+  border-radius: 50%;
+  background-color: var(--elmethis-color-primary-strong);
+  box-shadow: 0 0.125rem 0.375rem -0.0625rem var(--elmethis-box-shadow-color);
+  transform: translate(-50%, -50%);
+  transition: transform 140ms cubic-bezier(0.34, 1.56, 0.64, 1);
+  pointer-events: none;
+}
+
+.vertical .thumb {
+  top: auto;
+  left: 50%;
+  bottom: calc(var(--elmethis-scoped-value-ratio, 0) * 100%);
+  transform: translate(-50%, 50%);
+}
+
+.track:hover .thumb,
+.track:focus-visible .thumb {
+  transform: translate(-50%, -50%) scale(1.2);
+}
+
+.vertical .track:hover .thumb,
+.vertical .track:focus-visible .thumb {
+  transform: translate(-50%, 50%) scale(1.2);
+}
+
+/* ---- Markers ---------------------------------------------------------------- */
+
+/*
+ * `.marks` and its descendants are `position: absolute` so a tick/label can
+ * sit at an arbitrary percentage along the track without disturbing the
+ * track's own flex layout — but that also means none of it ever contributes
+ * to `.track`'s or `.elm-slider`'s box size. Reserve the extra space these
+ * rows need on the element that participates in normal flow (`.elm-slider`),
+ * sized generously enough to fit a tick, the gap, and a label's line box.
+ */
+.elm-slider.has-markers {
+  padding-block-end: 0.5rem;
+}
+
+.elm-slider.has-marker-labels {
+  padding-block-end: 1.75rem;
+}
+
+.elm-slider.vertical.has-markers {
+  padding-block-end: 0;
+
+  /*
+   * Physical, not logical: `.vertical .mark`'s `left: 50%` +
+   * `transform: translate(0.75rem, ...)` (and the tick/label layout that
+   * follows) always render on the physical right regardless of `dir` — they
+   * don't participate in the inline axis at all. A logical
+   * `padding-inline-end` would flip to physical `padding-left` under
+   * `dir="rtl"`, reserving space on the side opposite the one the marks
+   * actually occupy.
+   */
+  padding-right: 0.5rem;
+}
+
+.elm-slider.vertical.has-marker-labels {
+  padding-block-end: 0;
+
+  /*
+   * Unlike the horizontal axis (where the reserved `padding-block-end` only
+   * ever needs to hold a label's roughly-constant line-height), a vertical
+   * label's *width* scales with its character count — a fixed rem constant
+   * only fits short labels and lets 4+ digit values (or wide negative
+   * values) spill past this element's own inline-end edge.
+   *
+   * `0.75rem` covers the fixed part of the offset from the track's
+   * inline-end edge to where the label starts (the mark's own translate
+   * plus the tick + gap that precede the label in `.mark`'s row layout).
+   * The remainder scales with the longest rendered label's character count,
+   * via `1ch` — exact here because `.mark-label` uses a monospace font, so
+   * every character has the same advance width. `font-family`/`font-size`
+   * are set to match `.mark-label` so `ch` resolves against the same font
+   * metrics; this element renders no text of its own, so it doesn't leak
+   * into any child that doesn't set its own font (they all do). The extra
+   * `0.5ch` is a small rounding buffer for subpixel layout drift between
+   * this element's `ch` and the label's own rendered width.
+   *
+   * This is a physical `padding-right`, not the logical `padding-inline-end`
+   * its name suggests it should be: `.vertical .mark`'s `left: 50%` +
+   * `transform: translate(0.75rem, ...)` (and everything downstream of it —
+   * the tick, the gap, the label) render on the physical right regardless of
+   * `dir` — none of it is expressed in logical/inline terms. Reserving the
+   * space with a logical property would flip it to physical `padding-left`
+   * under `dir="rtl"`, leaving the actual marks unprotected on the right.
+   */
+  font-family: var(--elmethis-font-family-monospace);
+  font-size: 0.7rem;
+  padding-right: calc(
+    0.75rem + (var(--elmethis-scoped-max-marker-label-chars, 4) + 0.5) * 1ch
+  );
+}
+
+.marks {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.mark {
+  position: absolute;
+  top: 50%;
+  left: calc(var(--elmethis-scoped-marker-ratio, 0) * 100%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+  transform: translate(-50%, 0.75rem);
+}
+
+.vertical .mark {
+  top: auto;
+  left: 50%;
+  bottom: calc(var(--elmethis-scoped-marker-ratio, 0) * 100%);
+  flex-direction: row;
+  transform: translate(0.75rem, 50%);
+}
+
+/* The default transform centers a tick/label on its marker position, which
+   pushes the first/last mark half its own size past the track's start/end
+   edge. Align those two inward instead of centering them. */
+.mark-start {
+  transform: translate(0, 0.75rem);
+}
+
+.mark-end {
+  transform: translate(-100%, 0.75rem);
+}
+
+.vertical .mark-start {
+  transform: translate(0.75rem, 0);
+}
+
+.vertical .mark-end {
+  transform: translate(0.75rem, 100%);
+}
+
+.tick {
+  width: 0.125rem;
+  height: 0.375rem;
+  border-radius: 999px;
+  background-color: var(--elmethis-color-neutral);
+  font-style: normal;
+}
+
+.vertical .tick {
+  width: 0.375rem;
+  height: 0.125rem;
+}
+
+.mark-restricted .tick {
+  background-color: var(--elmethis-color-neutral-weak);
+}
+
+.mark-label {
+  font-family: var(--elmethis-font-family-monospace);
+  font-size: 0.7rem;
+  color: var(--elmethis-color-neutral);
+  white-space: nowrap;
+}
+
+.mark-restricted .mark-label {
+  opacity: 0.6;
+}

--- a/packages/qwik/src/components/form/elm-slider.spec.tsx
+++ b/packages/qwik/src/components/form/elm-slider.spec.tsx
@@ -1,0 +1,450 @@
+import { describe, expect, test, vi } from "vitest";
+import { createDOM } from "@qwik.dev/core/testing";
+import { component$, useSignal } from "@qwik.dev/core";
+import { renderToString } from "@qwik.dev/core/server";
+
+import { ElmSlider } from "./elm-slider";
+
+// CSS Modules mangle authored class names to `_<name>_<hash>`, so target the
+// interactive element by its ARIA role — that's how a real consumer (and
+// assistive tech) would find it too.
+const SLIDER = '[role="slider"]';
+
+const slider = (screen: { querySelector: (s: string) => Element | null }) =>
+  screen.querySelector(SLIDER) as HTMLElement;
+
+// createDOM's bundled CSS parser throws (`Cannot read properties of
+// undefined (reading 'type')`) on ANY `element.style.getPropertyValue(...)`
+// call for a custom property, regardless of the declaration's shape — a
+// limitation of the test harness's CSSOM implementation, not this component.
+// Read the raw `style` attribute string and regex-match the declaration
+// instead of going through the live CSSOM.
+const customProperty = (el: Element, name: string): string | null => {
+  const raw = el.getAttribute("style") ?? "";
+  const match = raw.match(new RegExp(`(?:^|;)\\s*${name}\\s*:\\s*([^;]+)`));
+  return match ? match[1].trim() : null;
+};
+
+describe("[CSR] ElmSlider — rendering", () => {
+  test("defaults to horizontal, min 0, max 100, midpoint value", async () => {
+    const { screen, render } = await createDOM();
+    await render(<ElmSlider />);
+    const el = slider(screen);
+    expect(el.getAttribute("aria-orientation")).toBe("horizontal");
+    expect(el.getAttribute("aria-valuemin")).toBe("0");
+    expect(el.getAttribute("aria-valuemax")).toBe("100");
+    expect(el.getAttribute("aria-valuenow")).toBe("50");
+  });
+
+  test("renders vertical orientation", async () => {
+    const { screen, render } = await createDOM();
+    await render(<ElmSlider orientation="vertical" />);
+    expect(slider(screen).getAttribute("aria-orientation")).toBe("vertical");
+  });
+
+  test("defaultValue seeds the uncontrolled value", async () => {
+    const { screen, render } = await createDOM();
+    await render(<ElmSlider defaultValue={30} />);
+    expect(slider(screen).getAttribute("aria-valuenow")).toBe("30");
+  });
+
+  test("clamps aria-valuemin/max to the inner range", async () => {
+    const { screen, render } = await createDOM();
+    await render(<ElmSlider innerMin={20} innerMax={80} defaultValue={50} />);
+    const el = slider(screen);
+    expect(el.getAttribute("aria-valuemin")).toBe("20");
+    expect(el.getAttribute("aria-valuemax")).toBe("80");
+  });
+
+  test("clamps an out-of-inner-range defaultValue on mount", async () => {
+    const { screen, render } = await createDOM();
+    await render(<ElmSlider innerMin={20} innerMax={80} defaultValue={5} />);
+    expect(slider(screen).getAttribute("aria-valuenow")).toBe("20");
+  });
+
+  test("aria-disabled and tabIndex reflect the disabled prop", async () => {
+    const { screen, render } = await createDOM();
+    await render(<ElmSlider disabled />);
+    const el = slider(screen);
+    expect(el.getAttribute("aria-disabled")).toBe("true");
+    expect(el.getAttribute("tabindex")).toBe("-1");
+  });
+
+  test("renders one tick per step when markers is set", async () => {
+    const { screen, render } = await createDOM();
+    await render(<ElmSlider min={0} max={100} step={25} markers />);
+    // 0, 25, 50, 75, 100
+    expect(screen.querySelectorAll("i")).toHaveLength(5);
+  });
+
+  test("renders marker labels with the formatted value", async () => {
+    const { screen, render } = await createDOM();
+    await render(
+      <ElmSlider
+        min={0}
+        max={100}
+        step={50}
+        markers
+        markerLabels
+        formatMarkerLabel={(v) => `${v}%`}
+      />,
+    );
+    expect(screen.outerHTML).toContain("0%");
+    expect(screen.outerHTML).toContain("50%");
+    expect(screen.outerHTML).toContain("100%");
+  });
+});
+
+describe("[CSR] ElmSlider — keyboard interaction", () => {
+  test("ArrowRight/ArrowUp increases the value by step", async () => {
+    const { screen, render, userEvent } = await createDOM();
+    await render(<ElmSlider defaultValue={50} step={5} />);
+
+    await userEvent(SLIDER, "keydown", { key: "ArrowRight" });
+    expect(slider(screen).getAttribute("aria-valuenow")).toBe("55");
+
+    await userEvent(SLIDER, "keydown", { key: "ArrowUp" });
+    expect(slider(screen).getAttribute("aria-valuenow")).toBe("60");
+  });
+
+  test("ArrowLeft/ArrowDown decreases the value by step", async () => {
+    const { screen, render, userEvent } = await createDOM();
+    await render(<ElmSlider defaultValue={50} step={5} />);
+
+    await userEvent(SLIDER, "keydown", { key: "ArrowLeft" });
+    expect(slider(screen).getAttribute("aria-valuenow")).toBe("45");
+
+    await userEvent(SLIDER, "keydown", { key: "ArrowDown" });
+    expect(slider(screen).getAttribute("aria-valuenow")).toBe("40");
+  });
+
+  test("PageUp/PageDown move by ten steps", async () => {
+    const { screen, render, userEvent } = await createDOM();
+    await render(<ElmSlider defaultValue={50} step={2} />);
+
+    await userEvent(SLIDER, "keydown", { key: "PageUp" });
+    expect(slider(screen).getAttribute("aria-valuenow")).toBe("70");
+
+    await userEvent(SLIDER, "keydown", { key: "PageDown" });
+    expect(slider(screen).getAttribute("aria-valuenow")).toBe("50");
+  });
+
+  test("Home/End jump to the inner bounds", async () => {
+    const { screen, render, userEvent } = await createDOM();
+    await render(<ElmSlider innerMin={20} innerMax={80} defaultValue={50} />);
+
+    await userEvent(SLIDER, "keydown", { key: "End" });
+    expect(slider(screen).getAttribute("aria-valuenow")).toBe("80");
+
+    await userEvent(SLIDER, "keydown", { key: "Home" });
+    expect(slider(screen).getAttribute("aria-valuenow")).toBe("20");
+  });
+
+  test("does not move past the inner bounds", async () => {
+    const { screen, render, userEvent } = await createDOM();
+    await render(
+      <ElmSlider innerMin={0} innerMax={100} defaultValue={98} step={5} />,
+    );
+
+    await userEvent(SLIDER, "keydown", { key: "ArrowRight" });
+    expect(slider(screen).getAttribute("aria-valuenow")).toBe("100");
+  });
+
+  test("does not respond to keyboard input when disabled", async () => {
+    const { screen, render, userEvent } = await createDOM();
+    await render(<ElmSlider defaultValue={50} disabled />);
+
+    await userEvent(SLIDER, "keydown", { key: "ArrowRight" });
+    expect(slider(screen).getAttribute("aria-valuenow")).toBe("50");
+  });
+
+  test("writes through to a bound parent signal", async () => {
+    const Harness = component$(() => {
+      const value = useSignal(50);
+      return (
+        <div>
+          <output data-testid="state">{value.value}</output>
+          <ElmSlider value={value} step={10} />
+        </div>
+      );
+    });
+
+    const { screen, render, userEvent } = await createDOM();
+    await render(<Harness />);
+
+    await userEvent(SLIDER, "keydown", { key: "ArrowRight" });
+
+    await vi.waitFor(() =>
+      expect(screen.querySelector('[data-testid="state"]')?.textContent).toBe(
+        "60",
+      ),
+    );
+    expect(slider(screen).getAttribute("aria-valuenow")).toBe("60");
+  });
+});
+
+// Regression coverage for the algorithm's hardened edge cases (ported from
+// the react suite's "known bugs (regression)" describe block — these already
+// hold in this qwik port, they aren't currently-failing bugs here).
+describe("[CSR] ElmSlider — hardened edge cases", () => {
+  test("clamps a controlled value that falls outside the inner range", async () => {
+    const Harness = component$(() => {
+      const signal = useSignal(5);
+      return <ElmSlider innerMin={20} innerMax={80} value={signal} />;
+    });
+
+    const { screen, render } = await createDOM();
+    await render(<Harness />);
+    const el = slider(screen);
+    expect(Number(el.getAttribute("aria-valuenow"))).toBeGreaterThanOrEqual(20);
+  });
+
+  test("formats marker labels without floating-point dust for a fractional step", async () => {
+    const { screen, render } = await createDOM();
+    await render(<ElmSlider min={0} max={1} step={0.1} markers markerLabels />);
+    // 0 + 3*0.1 drifts to 0.30000000000000004 in JS float math.
+    expect(screen.outerHTML).not.toMatch(/0\.30000/);
+  });
+
+  test("does not skip a tick due to floating-point step-count error", async () => {
+    const { screen, render } = await createDOM();
+    await render(
+      <ElmSlider min={0} max={0.3} step={0.1} markers markerLabels />,
+    );
+    const labels = Array.from(
+      screen.querySelectorAll('[class*="mark-label"]'),
+    ).map((el) => el.textContent);
+    // Expect all 4 ticks: 0, 0.1, 0.2, 0.3. (0.3-0)/0.1 evaluates to
+    // 2.9999999999999996 in JS float math, so a naive Math.floor undercounts
+    // to 2 and drops the "0.2" tick, jumping straight from 0.1 to the forced
+    // max=0.3.
+    expect(labels).toHaveLength(4);
+  });
+
+  test("spans the full range instead of clustering near min when the tick count exceeds MAX_MARKERS", async () => {
+    const { screen, render } = await createDOM();
+    await render(<ElmSlider min={0} max={100} step={0.01} markers />);
+    const marks = screen.querySelectorAll('[class*="mark"]');
+    const last = marks[marks.length - 1] as HTMLElement;
+    const lastRatio = Number(
+      customProperty(last, "--elmethis-scoped-marker-ratio"),
+    );
+    // The capped 501 rendered ticks should still stretch across [min, max].
+    expect(lastRatio).toBeCloseTo(1, 5);
+  });
+
+  test("sizes the vertical label reservation to a JSX-returning formatMarkerLabel's rendered text, not String(value)", async () => {
+    const { screen, render } = await createDOM();
+    await render(
+      <ElmSlider
+        orientation="vertical"
+        min={0}
+        max={100}
+        step={25}
+        markers
+        markerLabels
+        formatMarkerLabel={(v) => <strong>{v} units of measurement</strong>}
+      />,
+    );
+    const wrapper = screen.querySelector(
+      '[class*="elm-slider"]',
+    ) as HTMLElement;
+    const chars = Number(
+      customProperty(wrapper, "--elmethis-scoped-max-marker-label-chars"),
+    );
+    // "100 units of measurement" is 25 chars; falling back to String(100)
+    // (3 chars) would under-reserve the padding and let the label overflow.
+    expect(chars).toBe("100 units of measurement".length);
+  });
+
+  test("ArrowRight increases the value even when step is negative", async () => {
+    const { screen, render, userEvent } = await createDOM();
+    await render(<ElmSlider defaultValue={50} step={-10} />);
+
+    await userEvent(SLIDER, "keydown", { key: "ArrowRight" });
+
+    expect(
+      Number(slider(screen).getAttribute("aria-valuenow")),
+    ).toBeGreaterThan(50);
+  });
+
+  test("forwards aria-label to the slider element, not an outer wrapper", async () => {
+    const { screen, render } = await createDOM();
+    await render(<ElmSlider aria-label="Volume" />);
+    expect(slider(screen).getAttribute("aria-label")).toBe("Volume");
+  });
+
+  test("renders tick/label values on the actual step grid, not an evenly-resampled one", async () => {
+    const { screen, render } = await createDOM();
+    await render(<ElmSlider min={0} max={10} step={3} markers markerLabels />);
+    const labels = Array.from(
+      screen.querySelectorAll('[class*="mark-label"]'),
+    ).map((el) => el.textContent);
+    // step=3 over [0, 10] only ever snaps to 0, 3, 6, 9 (plus the forced
+    // max=10); it must never render 3.3333.../6.6666... ticks the thumb can
+    // never actually reach.
+    expect(labels).toEqual(["0", "3", "6", "9", "10"]);
+  });
+
+  test("does not render an out-of-range tick when (max-min)/step rounds up", async () => {
+    const { screen, render } = await createDOM();
+    await render(<ElmSlider min={0} max={10} step={6} markers markerLabels />);
+    const labels = Array.from(
+      screen.querySelectorAll('[class*="mark-label"]'),
+    ).map((el) => el.textContent);
+    // (10-0)/6 = 1.666..., which a naive Math.round rounds up to 2,
+    // generating a spurious "12" tick outside [min, max] that overlaps the
+    // forced max=10 tick. Only the real step-ticks (0, 6) plus the forced
+    // max (10) should render.
+    expect(labels).toEqual(["0", "6", "10"]);
+  });
+
+  test("moves by exactly one step from an off-grid controlled value", async () => {
+    const Harness = component$(() => {
+      const value = useSignal(7);
+      return <ElmSlider min={0} max={100} step={10} value={value} />;
+    });
+
+    const { screen, render, userEvent } = await createDOM();
+    await render(<Harness />);
+
+    await userEvent(SLIDER, "keydown", { key: "ArrowRight" });
+
+    // 7 is a legitimate off-grid controlled value (e.g. a persisted user
+    // preference); a single ArrowRight must move by exactly `step` from the
+    // current value (7 + 10 = 17), not re-quantize onto a grid anchored at
+    // `min` (which would jump to 20).
+    expect(slider(screen).getAttribute("aria-valuenow")).toBe("17");
+  });
+
+  test("seeds the uncontrolled initial value verbatim, without re-quantizing it onto the step grid", async () => {
+    const { screen: withDefault, render: renderWithDefault } =
+      await createDOM();
+    await renderWithDefault(<ElmSlider step={10} defaultValue={7} />);
+    expect(slider(withDefault).getAttribute("aria-valuenow")).toBe("7");
+
+    // With no `defaultValue` at all, the JSDoc on `defaultValue` and the
+    // Storybook docs both promise the true midpoint of the range
+    // (100 / 2 = 50), not a value re-quantized onto a step-7 grid anchored
+    // at `min` (which would produce 49).
+    const { screen: atMidpoint, render: renderAtMidpoint } = await createDOM();
+    await renderAtMidpoint(<ElmSlider step={7} />);
+    expect(slider(atMidpoint).getAttribute("aria-valuenow")).toBe("50");
+  });
+
+  test("moves on the first keypress from a controlled value sitting above innerMax", async () => {
+    const Harness = component$(() => {
+      const value = useSignal(95);
+      return (
+        <ElmSlider
+          min={0}
+          max={100}
+          innerMin={0}
+          innerMax={80}
+          step={1}
+          value={value}
+        />
+      );
+    });
+
+    const { screen, render, userEvent } = await createDOM();
+    await render(<Harness />);
+
+    // aria-valuenow is correctly clamped for display before any interaction.
+    expect(slider(screen).getAttribute("aria-valuenow")).toBe("80");
+
+    // The very first ArrowLeft must decrease the *displayed* value by one
+    // step (80 -> 79), not compute from the raw out-of-range controlled
+    // value (95 -> clampToInner(94) = 80, i.e. no visible change).
+    await userEvent(SLIDER, "keydown", { key: "ArrowLeft" });
+    expect(slider(screen).getAttribute("aria-valuenow")).toBe("79");
+  });
+
+  test("a caller-supplied onKeyDown$ fully replaces the internal keyboard handling", async () => {
+    // `{...rest}` (which carries a caller's onKeyDown$) is spread after the
+    // component's own onKeyDown$ on the same JSX element — the established
+    // convention across this package (see elm-checkbox.tsx, elm-switch.tsx)
+    // is that the caller's handler wins outright rather than composing with
+    // the internal one.
+    const onKeyDownSpy = vi.fn();
+    const { screen, render, userEvent } = await createDOM();
+    await render(<ElmSlider defaultValue={50} onKeyDown$={onKeyDownSpy} />);
+
+    await userEvent(SLIDER, "keydown", { key: "ArrowRight" });
+
+    expect(onKeyDownSpy).toHaveBeenCalledTimes(1);
+    // The internal stepping logic never ran — the caller's handler replaced
+    // it outright.
+    expect(slider(screen).getAttribute("aria-valuenow")).toBe("50");
+  });
+
+  test("respects a caller-supplied tabIndex instead of forcing it from disabled", async () => {
+    const { screen, render } = await createDOM();
+    await render(<ElmSlider tabIndex={-1} />);
+    expect(slider(screen).getAttribute("tabindex")).toBe("-1");
+  });
+
+  test("still renders tick marks when step is negative", async () => {
+    const { screen, render } = await createDOM();
+    await render(<ElmSlider min={0} max={20} step={-4} markers />);
+    // `step` is a granularity everywhere else in this component (snapValue()
+    // and the keyboard handler both use Math.abs(step)) — marks must treat
+    // it the same way instead of early-returning `[]` for a raw negative
+    // step. Expect ticks at 0, 4, 8, 12, 16, 20.
+    const ticks = screen.querySelectorAll('[class*="tick"]');
+    expect(ticks).toHaveLength(6);
+  });
+
+  test("honors innerMin/innerMax/defaultValue instead of collapsing to max when min > max", async () => {
+    const { screen, render, userEvent } = await createDOM();
+    await render(
+      <ElmSlider
+        min={100}
+        max={0}
+        innerMin={20}
+        innerMax={80}
+        defaultValue={50}
+      />,
+    );
+    const el = slider(screen);
+
+    // A reversed range (min > max) is a legitimate declining track — ratioOf
+    // already treats it as a valid interpolation — so clamping the inner
+    // bounds must not assume `lo <= hi` and silently force
+    // effectiveInnerMin/effectiveInnerMax (and therefore the seeded
+    // defaultValue) down to `max` regardless of the caller's props.
+    expect(el.getAttribute("aria-valuemin")).toBe("20");
+    expect(el.getAttribute("aria-valuemax")).toBe("80");
+    expect(el.getAttribute("aria-valuenow")).toBe("50");
+
+    // The control must not be frozen: a step still moves the value.
+    await userEvent(SLIDER, "keydown", { key: "ArrowLeft" });
+    expect(slider(screen).getAttribute("aria-valuenow")).toBe("49");
+  });
+
+  test("does not collapse to a single point when min > max and innerMin/innerMax are omitted", async () => {
+    const { screen, render } = await createDOM();
+    await render(<ElmSlider min={100} max={0} defaultValue={30} />);
+    const el = slider(screen);
+
+    // With innerMin/innerMax omitted, the documented defaults ("min" /
+    // "max") must resolve against the logical [low, high] span (0, 100),
+    // not the raw, possibly-reversed `min`/`max` values themselves —
+    // otherwise the default innerMax (the raw `max`, here the smaller
+    // number) gets clamped *up* to innerMin instead of down to the range's
+    // actual high end, collapsing the whole track to one point.
+    expect(el.getAttribute("aria-valuemin")).toBe("0");
+    expect(el.getAttribute("aria-valuemax")).toBe("100");
+    expect(el.getAttribute("aria-valuenow")).toBe("30");
+  });
+});
+
+describe("[SSR] ElmSlider", () => {
+  test("renders the slider role in the server shell", async () => {
+    const { html } = await renderToString(<ElmSlider defaultValue={40} />, {
+      containerTagName: "div",
+    });
+    expect(html).toContain('role="slider"');
+    expect(html).toContain('aria-valuenow="40"');
+  });
+});

--- a/packages/qwik/src/components/form/elm-slider.spec.tsx
+++ b/packages/qwik/src/components/form/elm-slider.spec.tsx
@@ -158,6 +158,26 @@ describe("[CSR] ElmSlider — keyboard interaction", () => {
     expect(slider(screen).getAttribute("aria-valuenow")).toBe("50");
   });
 
+  // Regression: the internal onKeyDown$'s `disabled` guard lives inside the
+  // exact same handler that `{...rest}` fully overwrites when a caller
+  // supplies its own onKeyDown$ (the "caller wins outright" convention — see
+  // "a caller-supplied onKeyDown$ fully replaces the internal keyboard
+  // handling" below). That let a caller-supplied handler run — and the
+  // slider's own stepping still needed to stay inert — even while `disabled`
+  // is true, unlike the sibling test above.
+  test("ignores a caller-supplied onKeyDown$ when disabled", async () => {
+    const onKeyDownSpy = vi.fn();
+    const { screen, render, userEvent } = await createDOM();
+    await render(
+      <ElmSlider defaultValue={50} disabled onKeyDown$={onKeyDownSpy} />,
+    );
+
+    await userEvent(SLIDER, "keydown", { key: "ArrowRight" });
+
+    expect(onKeyDownSpy).not.toHaveBeenCalled();
+    expect(slider(screen).getAttribute("aria-valuenow")).toBe("50");
+  });
+
   test("writes through to a bound parent signal", async () => {
     const Harness = component$(() => {
       const value = useSignal(50);
@@ -436,6 +456,36 @@ describe("[CSR] ElmSlider — hardened edge cases", () => {
     expect(el.getAttribute("aria-valuemin")).toBe("0");
     expect(el.getAttribute("aria-valuemax")).toBe("100");
     expect(el.getAttribute("aria-valuenow")).toBe("30");
+  });
+
+  test("still renders tick marks for a reversed range (min > max)", async () => {
+    const { screen, render } = await createDOM();
+    await render(
+      <ElmSlider min={100} max={0} step={10} markers markerLabels />,
+    );
+    // `buildMarks`'s empty-range guard must only reject a truly empty range
+    // (max === min), not any `max <= min` — a reversed/declining range
+    // (min > max) is a legitimate track (see `ratioOf`'s plain
+    // interpolation and the innerMin/innerMax hardening above), so ticks
+    // must still render walking down from 100 to 0: 100, 90, ..., 0.
+    const ticks = screen.querySelectorAll('[class*="tick"]');
+    expect(ticks).toHaveLength(11);
+    const labels = Array.from(
+      screen.querySelectorAll('[class*="mark-label"]'),
+    ).map((el) => el.textContent);
+    expect(labels).toEqual([
+      "100",
+      "90",
+      "80",
+      "70",
+      "60",
+      "50",
+      "40",
+      "30",
+      "20",
+      "10",
+      "0",
+    ]);
   });
 });
 

--- a/packages/qwik/src/components/form/elm-slider.stories.tsx
+++ b/packages/qwik/src/components/form/elm-slider.stories.tsx
@@ -1,0 +1,118 @@
+import { component$, useSignal } from "@qwik.dev/core";
+import type { Meta, StoryObj } from "storybook-framework-qwik";
+
+import { ElmSlider, type ElmSliderProps } from "./elm-slider";
+
+const meta: Meta<ElmSliderProps> = {
+  title: "Components/Form/elm-slider",
+  component: ElmSlider,
+  tags: ["autodocs"],
+  args: {
+    min: 0,
+    max: 100,
+    step: 1,
+  },
+};
+
+export default meta;
+type Story = StoryObj<ElmSliderProps>;
+
+// Uncontrolled: the slider manages its own value, starting at the midpoint.
+export const Primary: Story = {
+  render() {
+    return <ElmSlider {...(this.args as ElmSliderProps)} />;
+  },
+};
+
+export const Vertical: Story = {
+  args: {
+    orientation: "vertical",
+  },
+  render() {
+    return <ElmSlider {...(this.args as ElmSliderProps)} />;
+  },
+};
+
+export const WithStep: Story = {
+  args: {
+    step: 10,
+  },
+  render() {
+    return <ElmSlider {...(this.args as ElmSliderProps)} />;
+  },
+};
+
+export const WithInnerRange: Story = {
+  args: {
+    innerMin: 20,
+    innerMax: 80,
+    defaultValue: 20,
+  },
+  render() {
+    return <ElmSlider {...(this.args as ElmSliderProps)} />;
+  },
+};
+
+export const WithMarkers: Story = {
+  args: {
+    step: 10,
+    markers: true,
+  },
+  render() {
+    return <ElmSlider {...(this.args as ElmSliderProps)} />;
+  },
+};
+
+export const WithMarkerLabels: Story = {
+  args: {
+    step: 25,
+    markers: true,
+    markerLabels: true,
+  },
+  render() {
+    return <ElmSlider {...(this.args as ElmSliderProps)} />;
+  },
+};
+
+export const WithMarkersAndInnerRange: Story = {
+  args: {
+    step: 10,
+    innerMin: 20,
+    innerMax: 80,
+    defaultValue: 20,
+    markers: true,
+    markerLabels: true,
+  },
+  render() {
+    return <ElmSlider {...(this.args as ElmSliderProps)} />;
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+    defaultValue: 40,
+  },
+  render() {
+    return <ElmSlider {...(this.args as ElmSliderProps)} />;
+  },
+};
+
+// Controlled: parent owns the value via a bound Signal.
+const ControlledSlider = component$<ElmSliderProps>((props) => {
+  const value = useSignal(30);
+
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: "1rem" }}>
+      <ElmSlider {...props} style={{ maxWidth: "16rem" }} value={value} />
+      <span style={{ fontFamily: "monospace" }}>value: {value.value}</span>
+      <button onClick$={() => (value.value = 30)}>Reset</button>
+    </div>
+  );
+});
+
+export const Controlled: Story = {
+  render(args) {
+    return <ControlledSlider {...(args as ElmSliderProps)} />;
+  },
+};

--- a/packages/qwik/src/components/form/elm-slider.tsx
+++ b/packages/qwik/src/components/form/elm-slider.tsx
@@ -188,21 +188,28 @@ const buildMarks = (
   if (!markers && !markerLabels) return [];
   // `step` is a granularity, not a direction — mirror `snapValue()` and the
   // keyboard handler's `Math.abs(step)` so a negative step still renders
-  // ticks (only `step === 0` or an empty range means "no ticks").
+  // ticks. `max === min` is the only genuinely empty range (mirrors
+  // `ratioOf`'s own `max === min` check) — `max < min` is a legitimate
+  // reversed/declining track (see the `rangeLow`/`rangeHigh` handling below
+  // in the component body) and must still produce ticks, just walking down
+  // from `min` to `max` instead of up.
   const magnitude = Math.abs(step);
-  if (magnitude <= 0 || max <= min) return [];
+  if (magnitude <= 0 || max === min) return [];
+  // The real step grid walks from `min` toward `max`, so the per-tick
+  // increment must carry `max - min`'s sign, not just its magnitude.
+  const signedStep = max > min ? magnitude : -magnitude;
   // `preciseRound` absorbs float dust in (max-min)/step (e.g. 0.3/0.1 ->
   // 2.9999999999999996, which must count as 3) without rounding a genuine
   // fraction up to the next integer (e.g. 10/6 -> 1.6666666666666667 must
   // floor to 1, not round up to 2 and generate a tick beyond `max`).
-  const realCount = Math.floor(preciseRound((max - min) / magnitude));
+  const realCount = Math.floor(preciseRound(Math.abs(max - min) / magnitude));
   const out: Mark[] = [];
   if (realCount <= MAX_MARKERS) {
     for (let i = 0; i <= realCount; i++) {
-      const v = preciseRound(min + i * magnitude);
+      const v = preciseRound(min + i * signedStep);
       out.push({ value: v, ratio: ratioOf(v, min, max) });
     }
-    if (preciseRound(min + realCount * magnitude) !== preciseRound(max)) {
+    if (preciseRound(min + realCount * signedStep) !== preciseRound(max)) {
       out.push({ value: max, ratio: ratioOf(max, min, max) });
     }
   } else {
@@ -470,6 +477,16 @@ export const ElmSlider = component$<ElmSliderProps>((props) => {
           }
         }}
         {...rest}
+        // `{...rest}` above lets a caller-supplied onKeyDown$ fully replace
+        // the internal handler (and its `disabled` guard) outright — the
+        // same convention this component's tabIndex/onPointerDown$/
+        // onPointerMove$ props follow. Unlike pointer input, which still has
+        // a CSS backstop (`.disabled .track { pointer-events: none }`) for
+        // real users, there is no equivalent backstop for keyboard input, so
+        // a disabled slider must not leave a caller's onKeyDown$ reachable.
+        // Clear it back out post-spread so `disabled` always wins for
+        // keyboard, regardless of what the caller passed.
+        {...(disabled ? { onKeyDown$: undefined } : undefined)}
       >
         <div class={styles.rail} aria-hidden="true">
           <div class={styles["restricted-start"]} />

--- a/packages/qwik/src/components/form/elm-slider.tsx
+++ b/packages/qwik/src/components/form/elm-slider.tsx
@@ -1,0 +1,516 @@
+import {
+  component$,
+  type CSSProperties,
+  type JSXOutput,
+  type PropsOf,
+  type Signal,
+} from "@qwik.dev/core";
+
+import { useBindableSignal } from "../../hooks/use-bindable-signal";
+import styles from "./elm-slider.module.css";
+
+export type ElmSliderOrientation = "horizontal" | "vertical";
+
+export interface ElmSliderProps extends PropsOf<"div"> {
+  /**
+   * Lower bound of the track's full range.
+   *
+   * @defaultValue 0
+   */
+  min?: number;
+
+  /**
+   * Upper bound of the track's full range.
+   *
+   * @defaultValue 100
+   */
+  max?: number;
+
+  /**
+   * Increment the value snaps to while dragging or using the keyboard.
+   *
+   * @defaultValue 1
+   */
+  step?: number;
+
+  /**
+   * Restricts the value to an interval inside the track's full length. Must
+   * be `>= min`. The track still spans `[min, max]`, but the region below
+   * `innerMin` is shown as unreachable.
+   *
+   * @defaultValue min
+   */
+  innerMin?: number;
+
+  /**
+   * Restricts the value to an interval inside the track's full length. Must
+   * be `<= max`.
+   *
+   * @defaultValue max
+   */
+  innerMax?: number;
+
+  /**
+   * Track direction.
+   *
+   * @defaultValue "horizontal"
+   */
+  orientation?: ElmSliderOrientation;
+
+  /**
+   * Controlled value. When provided the parent owns the signal — writes go
+   * straight through to it. There is no separate `onValueChange` callback:
+   * bind a `Signal<number>` here and read/observe it on the parent side.
+   */
+  value?: Signal<number>;
+
+  /**
+   * Initial value when uncontrolled.
+   *
+   * @defaultValue the midpoint of `innerMin`/`innerMax`
+   */
+  defaultValue?: number;
+
+  /**
+   * Disables dragging, clicking, and keyboard control.
+   */
+  disabled?: boolean;
+
+  /**
+   * Draws a tick mark at every step along the track.
+   */
+  markers?: boolean;
+
+  /**
+   * Draws a text label under each tick mark.
+   */
+  markerLabels?: boolean;
+
+  /**
+   * Formats the content shown for a marker label.
+   *
+   * Intentionally a plain (non-`$`) function rather than a `QRL`: it must be
+   * invoked synchronously during render to build each `.mark-label`'s
+   * content — which is then also measured to size the vertical layout's
+   * label-reservation padding via `--elmethis-scoped-max-marker-label-chars`.
+   * `component$`'s render function (`OnRenderFn`) is typed to return
+   * `JSXOutput` synchronously — not a `Promise` — so a `QRL` (which can only
+   * be resolved with `await`) can't be threaded through this synchronous
+   * computation without reaching for `useAsync$`/`<Suspense>`, which would be
+   * a disproportionate amount of machinery for formatting a tick label. The
+   * react and vue ports keep this the same shape (a plain sync formatter) for
+   * the same reason.
+   *
+   * @defaultValue String(value)
+   */
+  formatMarkerLabel?: (value: number) => JSXOutput;
+}
+
+const clamp = (n: number, lo: number, hi: number) =>
+  Math.min(hi, Math.max(lo, n));
+
+// Rounds away float dust (e.g. 0 + 3 * 0.1 -> 0.30000000000000004).
+const preciseRound = (n: number) => Math.round(n * 1e9) / 1e9;
+
+// Guards against generating an unbounded number of DOM nodes if a caller
+// pairs a tiny `step` with a wide `[min, max]`.
+const MAX_MARKERS = 500;
+
+const ratioOf = (v: number, min: number, max: number): number =>
+  max === min ? 0 : clamp((v - min) / (max - min), 0, 1);
+
+// `step` is a granularity, not a direction — mirrors the keyboard handler's
+// `Math.abs(step)` so a negative step still quantizes (only `step === 0`
+// means "no snapping").
+const snapValue = (
+  raw: number,
+  min: number,
+  step: number,
+  innerMin: number,
+  innerMax: number,
+): number => {
+  const magnitude = Math.abs(step);
+  const stepped =
+    magnitude > 0 ? min + Math.round((raw - min) / magnitude) * magnitude : raw;
+  return clamp(preciseRound(stepped), innerMin, innerMax);
+};
+
+// Unlike `snapValue`, this does NOT re-quantize onto a grid anchored at
+// `min` — it clamps a value that has already moved by exactly one step (or
+// is a caller-supplied `value`/`defaultValue`) into the inner bounds. Used
+// for keyboard stepping (the current value may legitimately be off-grid) and
+// for seeding/displaying a possibly off-grid controlled value or
+// `defaultValue` verbatim.
+const clampToInner = (
+  raw: number,
+  innerMin: number,
+  innerMax: number,
+): number => clamp(preciseRound(raw), innerMin, innerMax);
+
+const valueFromPointer = (
+  clientX: number,
+  clientY: number,
+  rect: DOMRect,
+  isVertical: boolean,
+  min: number,
+  max: number,
+  step: number,
+  innerMin: number,
+  innerMax: number,
+): number => {
+  const ratio = isVertical
+    ? rect.height === 0
+      ? 0
+      : clamp((rect.bottom - clientY) / rect.height, 0, 1)
+    : rect.width === 0
+      ? 0
+      : clamp((clientX - rect.left) / rect.width, 0, 1);
+  return snapValue(min + ratio * (max - min), min, step, innerMin, innerMax);
+};
+
+interface Mark {
+  value: number;
+  ratio: number;
+}
+
+// Walks the real step grid up to `MAX_MARKERS`, forcing a trailing tick at
+// `max` if `step` doesn't evenly divide the range. Falls back to even
+// resampling only past `MAX_MARKERS` (cosmetic-only ticks at that point —
+// not all of them are reachable by `snapValue`, which is an acceptable
+// trade-off once there are too many real ticks to render individually).
+const buildMarks = (
+  markers: boolean | undefined,
+  markerLabels: boolean | undefined,
+  step: number,
+  min: number,
+  max: number,
+): Mark[] => {
+  if (!markers && !markerLabels) return [];
+  // `step` is a granularity, not a direction — mirror `snapValue()` and the
+  // keyboard handler's `Math.abs(step)` so a negative step still renders
+  // ticks (only `step === 0` or an empty range means "no ticks").
+  const magnitude = Math.abs(step);
+  if (magnitude <= 0 || max <= min) return [];
+  // `preciseRound` absorbs float dust in (max-min)/step (e.g. 0.3/0.1 ->
+  // 2.9999999999999996, which must count as 3) without rounding a genuine
+  // fraction up to the next integer (e.g. 10/6 -> 1.6666666666666667 must
+  // floor to 1, not round up to 2 and generate a tick beyond `max`).
+  const realCount = Math.floor(preciseRound((max - min) / magnitude));
+  const out: Mark[] = [];
+  if (realCount <= MAX_MARKERS) {
+    for (let i = 0; i <= realCount; i++) {
+      const v = preciseRound(min + i * magnitude);
+      out.push({ value: v, ratio: ratioOf(v, min, max) });
+    }
+    if (preciseRound(min + realCount * magnitude) !== preciseRound(max)) {
+      out.push({ value: max, ratio: ratioOf(max, min, max) });
+    }
+  } else {
+    const tickStep = (max - min) / MAX_MARKERS;
+    for (let i = 0; i <= MAX_MARKERS; i++) {
+      const v = i === MAX_MARKERS ? max : preciseRound(min + i * tickStep);
+      out.push({ value: v, ratio: ratioOf(v, min, max) });
+    }
+  }
+  return out;
+};
+
+// `formatMarkerLabel` is typed to return an arbitrary `JSXOutput` (elements,
+// fragments, arrays, ...), not just a string/number — so measuring its
+// length can't rely on `typeof`. Recursively concatenate the actual rendered
+// text (a node's text length is its children's, not its own) so a
+// JSX-returning formatter is measured by what it actually renders, not by a
+// `String(mark.value)` fallback that ignores the formatter entirely.
+const jsxOutputToText = (node: unknown): string => {
+  if (node === null || node === undefined || typeof node === "boolean") {
+    return "";
+  }
+  if (typeof node === "string") return node;
+  if (typeof node === "number") return String(node);
+  if (Array.isArray(node)) return node.map(jsxOutputToText).join("");
+  if (typeof node === "object" && "children" in node) {
+    return jsxOutputToText((node as { children: unknown }).children);
+  }
+  // Signals/functions/regexes and anything else we can't statically measure
+  // — better to under-report nothing extra than to throw.
+  return "";
+};
+
+export const ElmSlider = component$<ElmSliderProps>((props) => {
+  const {
+    class: className,
+    style,
+    min = 0,
+    max = 100,
+    step = 1,
+    innerMin,
+    innerMax,
+    orientation = "horizontal",
+    value,
+    defaultValue,
+    disabled,
+    markers,
+    markerLabels,
+    formatMarkerLabel,
+    ...rest
+  } = props;
+
+  const isVertical = orientation === "vertical";
+
+  // `clamp` assumes `lo <= hi`. `min`/`max` alone can't be passed straight
+  // through as `[lo, hi]` because a reversed range (`min > max`, a
+  // legitimate declining track — see `ratioOf`, which already handles it via
+  // plain interpolation) would silently force both inner bounds down to
+  // `max` instead of clamping into the declared range. Sort once so the
+  // inner bounds are always resolved against the *logical* [low, high]
+  // regardless of which of `min`/`max` is numerically larger. The *default*
+  // for an omitted innerMin/innerMax must default to this same logical
+  // [low, high] span too (not the raw `min`/`max`) — otherwise, for a
+  // reversed range, the default innerMax (raw `max`, the smaller number)
+  // sits below `rangeLow`/the default innerMin and gets clamped *up* to it
+  // instead of down to the range's actual high end, collapsing the whole
+  // track to a single point.
+  const rangeLow = Math.min(min, max);
+  const rangeHigh = Math.max(min, max);
+  const effectiveInnerMin = clamp(innerMin ?? rangeLow, rangeLow, rangeHigh);
+  const effectiveInnerMax = clamp(
+    innerMax ?? rangeHigh,
+    effectiveInnerMin,
+    rangeHigh,
+  );
+
+  const currentValue = useBindableSignal<number>({
+    signal: value,
+    // Unlike pointer/keyboard-driven moves, the initial seed is not
+    // something the user is actively snapping onto a grid — it's either a
+    // caller's explicit, possibly-off-grid `defaultValue` (e.g. a persisted
+    // preference) or the documented midpoint default. Both must be honored
+    // verbatim, exactly like a controlled `value` is preserved off-grid
+    // elsewhere — so only clamp into range here, don't `snapValue()`.
+    defaultValue: clampToInner(
+      defaultValue ?? (effectiveInnerMin + effectiveInnerMax) / 2,
+      effectiveInnerMin,
+      effectiveInnerMax,
+    ),
+  });
+
+  // A controlling parent owns `currentValue` and may pass one outside the
+  // inner range (e.g. set before `innerMin`/`innerMax` were added) — clamp
+  // only for display so `aria-valuenow` and the thumb never report/render
+  // outside the declared bounds, without writing back to the signal
+  // ourselves.
+  const displayValue = clamp(
+    currentValue.value,
+    effectiveInnerMin,
+    effectiveInnerMax,
+  );
+
+  const marks = buildMarks(markers, markerLabels, step, min, max);
+
+  // `.vertical.has-marker-labels` reserves `padding-right` to fit the tick,
+  // the gap, and the label itself — but the label's *width* scales with its
+  // character count (unlike the horizontal orientation, where the reserved
+  // `padding-block-end` only ever needs a label's roughly-constant
+  // line-height). Measure the longest rendered label so the CSS can size the
+  // reservation to it via `ch` (exact for `.mark-label`'s monospace font)
+  // instead of a fixed constant that only fits short labels. Each mark's
+  // label content is computed once here and reused for both measurement and
+  // rendering below, rather than invoking `formatMarkerLabel` twice per mark.
+  const markerLabelContents: JSXOutput[] = markerLabels
+    ? marks.map((mark) => formatMarkerLabel?.(mark.value) ?? mark.value)
+    : [];
+
+  const maxMarkerLabelChars = markerLabelContents.reduce<number>(
+    (longest, content) => {
+      const length = jsxOutputToText(content).length;
+      return length > longest ? length : longest;
+    },
+    0,
+  );
+
+  const valueRatio = ratioOf(displayValue, min, max);
+  const innerMinRatio = ratioOf(effectiveInnerMin, min, max);
+  const innerMaxRatio = ratioOf(effectiveInnerMax, min, max);
+
+  return (
+    <div
+      class={[
+        styles["elm-slider"],
+        isVertical && styles.vertical,
+        disabled && styles.disabled,
+        // `.marks`/`.mark`/`.mark-label` are `position: absolute` so they
+        // can overlay tick positions without disturbing the track's flex
+        // layout — but that also means they never contribute to `.track`'s
+        // or this element's own box size. Reserve the space explicitly so
+        // the tick and label row renders inside the slider's box instead of
+        // bleeding past its bottom (or, in vertical orientation, its
+        // inline-end) edge.
+        markers && styles["has-markers"],
+        markerLabels && styles["has-marker-labels"],
+        className,
+      ]}
+      style={
+        {
+          "--elmethis-scoped-value-ratio": valueRatio,
+          "--elmethis-scoped-inner-min-ratio": innerMinRatio,
+          "--elmethis-scoped-inner-max-ratio": innerMaxRatio,
+          "--elmethis-scoped-max-marker-label-chars": maxMarkerLabelChars,
+          ...(style as CSSProperties),
+        } as CSSProperties
+      }
+    >
+      <div
+        // `rest` (aria-label, id, data-*, tabIndex overrides, ...) belongs on
+        // the interactive element itself, not this layout wrapper — this
+        // component IS a slider, unlike e.g. ElmAudioPlayer where the root is
+        // a larger widget and the `role="slider"` seek bar is just one
+        // control in it. Explicit props are set first and `{...rest}` spreads
+        // last, so a caller-supplied `tabIndex`/`onKeyDown$`/`onPointerDown$`/
+        // `onPointerMove$` fully overrides the internal one — the same
+        // convention every other interactive component in this package
+        // follows (see elm-checkbox.tsx, elm-switch.tsx).
+        tabIndex={disabled ? -1 : 0}
+        class={styles.track}
+        role="slider"
+        aria-orientation={orientation}
+        aria-valuemin={effectiveInnerMin}
+        aria-valuemax={effectiveInnerMax}
+        aria-valuenow={displayValue}
+        aria-disabled={disabled || undefined}
+        onPointerDown$={(event: PointerEvent, el: HTMLDivElement) => {
+          // Reference `props.disabled`/`props.orientation` directly rather
+          // than the destructured `disabled`/`isVertical` locals — capturing
+          // a destructured boolean prop into this QRL closure trips
+          // `qwik/valid-lexical-scope` ("... is Symbol, which is not
+          // serializable"), a known false positive; see elm-checkbox.tsx and
+          // elm-switch.tsx for the same `props.x` convention.
+          if (props.disabled) return;
+          el.setPointerCapture(event.pointerId);
+          currentValue.value = valueFromPointer(
+            event.clientX,
+            event.clientY,
+            el.getBoundingClientRect(),
+            props.orientation === "vertical",
+            min,
+            max,
+            step,
+            effectiveInnerMin,
+            effectiveInnerMax,
+          );
+        }}
+        onPointerMove$={(event: PointerEvent, el: HTMLDivElement) => {
+          if (props.disabled) return;
+          if (!el.hasPointerCapture(event.pointerId)) return;
+          currentValue.value = valueFromPointer(
+            event.clientX,
+            event.clientY,
+            el.getBoundingClientRect(),
+            props.orientation === "vertical",
+            min,
+            max,
+            step,
+            effectiveInnerMin,
+            effectiveInnerMax,
+          );
+        }}
+        onKeyDown$={(event: KeyboardEvent) => {
+          if (props.disabled) return;
+          // `step` is a granularity, not a direction — a caller-supplied
+          // negative step must not reverse which arrow key increases the
+          // value.
+          const delta = Math.abs(step);
+          // Step relative to `displayValue` (what aria-valuenow actually
+          // reports), not the raw `currentValue.value` — a controlling
+          // parent may pass a value outside the inner range, and stepping
+          // from the raw value would silently re-absorb into the same
+          // clamped display value instead of moving by one step.
+          switch (event.key) {
+            case "ArrowRight":
+            case "ArrowUp":
+              event.preventDefault();
+              currentValue.value = clampToInner(
+                displayValue + delta,
+                effectiveInnerMin,
+                effectiveInnerMax,
+              );
+              break;
+            case "ArrowLeft":
+            case "ArrowDown":
+              event.preventDefault();
+              currentValue.value = clampToInner(
+                displayValue - delta,
+                effectiveInnerMin,
+                effectiveInnerMax,
+              );
+              break;
+            case "PageUp":
+              event.preventDefault();
+              currentValue.value = clampToInner(
+                displayValue + delta * 10,
+                effectiveInnerMin,
+                effectiveInnerMax,
+              );
+              break;
+            case "PageDown":
+              event.preventDefault();
+              currentValue.value = clampToInner(
+                displayValue - delta * 10,
+                effectiveInnerMin,
+                effectiveInnerMax,
+              );
+              break;
+            case "Home":
+              event.preventDefault();
+              currentValue.value = effectiveInnerMin;
+              break;
+            case "End":
+              event.preventDefault();
+              currentValue.value = effectiveInnerMax;
+              break;
+          }
+        }}
+        {...rest}
+      >
+        <div class={styles.rail} aria-hidden="true">
+          <div class={styles["restricted-start"]} />
+          <div class={styles.fill} />
+          <div class={styles["restricted-end"]} />
+        </div>
+
+        {marks.length > 0 && (
+          <div class={styles.marks} aria-hidden="true">
+            {marks.map((mark, index) => (
+              <span
+                key={mark.value}
+                class={[
+                  styles.mark,
+                  // The default transform centers the tick/label on the
+                  // marker's position, which pushes the first/last label
+                  // half its own width past the track's start/end edge.
+                  // Clamp those two to align inward instead of centering.
+                  index === 0 && styles["mark-start"],
+                  index === marks.length - 1 && styles["mark-end"],
+                  (mark.value < effectiveInnerMin ||
+                    mark.value > effectiveInnerMax) &&
+                    styles["mark-restricted"],
+                ]}
+                style={{
+                  "--elmethis-scoped-marker-ratio": mark.ratio,
+                }}
+              >
+                {markers && <i class={styles.tick} />}
+                {markerLabels && (
+                  <span class={styles["mark-label"]}>
+                    {markerLabelContents[index]}
+                  </span>
+                )}
+              </span>
+            ))}
+          </div>
+        )}
+
+        <span class={styles.thumb} aria-hidden="true" />
+      </div>
+    </div>
+  );
+});

--- a/packages/qwik/src/index.ts
+++ b/packages/qwik/src/index.ts
@@ -177,6 +177,11 @@ export {
   type ElmSelectOption,
   type ElmSelectProps,
 } from "./components/form/elm-select";
+export {
+  ElmSlider,
+  type ElmSliderOrientation,
+  type ElmSliderProps,
+} from "./components/form/elm-slider";
 export { ElmSwitch, type ElmSwitchProps } from "./components/form/elm-switch";
 export {
   ElmTextArea,

--- a/packages/react/src/components/form/elm-slider.browser.spec.tsx
+++ b/packages/react/src/components/form/elm-slider.browser.spec.tsx
@@ -1,0 +1,92 @@
+import { render } from "vitest-browser-react";
+import { describe, expect, test } from "vitest";
+
+import { ElmSlider } from "./elm-slider";
+
+// happy-dom has no layout engine, so `getBoundingClientRect()` always reports
+// a zero-sized box — pointer-driven dragging (ratio-from-position math) can
+// only be exercised against a real Chromium layout, hence this lives here
+// rather than in the unit spec.
+
+type Screen = Awaited<ReturnType<typeof render>>;
+const sliderEl = (screen: Screen) =>
+  screen.container.querySelector('[role="slider"]') as HTMLElement;
+
+describe("[CSR] ElmSlider pointer interaction", () => {
+  test("clicking the track sets the value proportionally to the click position", async () => {
+    const screen = await render(<ElmSlider min={0} max={100} step={1} />);
+    const el = sliderEl(screen);
+    el.style.width = "200px";
+
+    const rect = el.getBoundingClientRect();
+    el.dispatchEvent(
+      new PointerEvent("pointerdown", {
+        bubbles: true,
+        clientX: rect.left + rect.width * 0.75,
+        pointerId: 1,
+      }),
+    );
+
+    await expect
+      .poll(() => Number(el.getAttribute("aria-valuenow")))
+      .toBeGreaterThanOrEqual(70);
+  });
+
+  test("dragging past innerMax clamps the value at the inner bound", async () => {
+    const screen = await render(
+      <ElmSlider min={0} max={100} innerMin={20} innerMax={80} />,
+    );
+    const el = sliderEl(screen);
+    el.style.width = "200px";
+
+    const rect = el.getBoundingClientRect();
+    el.dispatchEvent(
+      new PointerEvent("pointerdown", {
+        bubbles: true,
+        clientX: rect.right,
+        pointerId: 1,
+      }),
+    );
+
+    await expect.poll(() => Number(el.getAttribute("aria-valuenow"))).toBe(80);
+  });
+
+  test("vertical orientation increases the value toward the top of the track", async () => {
+    const screen = await render(
+      <ElmSlider min={0} max={100} orientation="vertical" />,
+    );
+    const el = sliderEl(screen);
+    el.style.height = "200px";
+
+    const rect = el.getBoundingClientRect();
+    el.dispatchEvent(
+      new PointerEvent("pointerdown", {
+        bubbles: true,
+        clientY: rect.top + rect.height * 0.1,
+        pointerId: 1,
+      }),
+    );
+
+    await expect
+      .poll(() => Number(el.getAttribute("aria-valuenow")))
+      .toBeGreaterThanOrEqual(80);
+  });
+});
+
+// Regression test for a bug found in code review — asserts correct behavior
+// and currently FAILS: `.vertical .fill` re-unsets `left` after `inset`
+// anchors it, so the fill collapses to zero width and never renders.
+describe("[CSR] ElmSlider — known bugs (regression)", () => {
+  test("vertical: the progress fill renders with non-zero width", async () => {
+    const screen = await render(
+      <ElmSlider min={0} max={100} orientation="vertical" defaultValue={70} />,
+    );
+    const fill = screen.container.querySelector(
+      '[class*="fill"]',
+    ) as HTMLElement;
+
+    await expect
+      .poll(() => fill.getBoundingClientRect().width)
+      .toBeGreaterThan(0);
+  });
+});

--- a/packages/react/src/components/form/elm-slider.browser.spec.tsx
+++ b/packages/react/src/components/form/elm-slider.browser.spec.tsx
@@ -1,3 +1,7 @@
+// Real `@elmethis/core` tokens (incl. the monospace font stack `.mark-label`
+// uses) so label widths in this file's regression tests reflect the actual
+// rendered font metrics instead of the browser's default serif fallback.
+import "@elmethis/core/tokens.css";
 import { render } from "vitest-browser-react";
 import { describe, expect, test } from "vitest";
 
@@ -88,5 +92,168 @@ describe("[CSR] ElmSlider — known bugs (regression)", () => {
     await expect
       .poll(() => fill.getBoundingClientRect().width)
       .toBeGreaterThan(0);
+  });
+
+  test("vertical: the progress fill spans the rail's full cross-axis width", async () => {
+    const screen = await render(
+      <ElmSlider min={0} max={100} orientation="vertical" defaultValue={70} />,
+    );
+    const fill = screen.container.querySelector(
+      '[class*="fill"]',
+    ) as HTMLElement;
+    const rail = screen.container.querySelector(
+      '[class*="rail"]',
+    ) as HTMLElement;
+
+    // The vertical fill's *length* (height) represents progress, the way the
+    // horizontal fill's *length* (width) does — its cross-axis thickness
+    // (width) must match the rail's, not shrink toward 0 as value approaches
+    // innerMin.
+    await expect
+      .poll(() => fill.getBoundingClientRect().width)
+      .toBeCloseTo(rail.getBoundingClientRect().width, 1);
+  });
+
+  test("pointerdown snaps to the step grid when step is negative", async () => {
+    // Keyboard stepping treats `step` as a granularity via `Math.abs(step)`,
+    // so ArrowRight/PageUp move in multiples of 10 even when step is -10.
+    // Pointer-driven clicks must snap to the same grid; `snap()`'s
+    // `step > 0` guard currently treats a negative step as "no snapping" and
+    // returns the raw, unsnapped ratio-derived value instead.
+    const screen = await render(<ElmSlider min={0} max={100} step={-10} />);
+    const el = sliderEl(screen);
+    el.style.width = "200px";
+
+    const rect = el.getBoundingClientRect();
+    el.dispatchEvent(
+      new PointerEvent("pointerdown", {
+        bubbles: true,
+        clientX: rect.left + rect.width * 0.53,
+        pointerId: 1,
+      }),
+    );
+
+    await expect
+      .poll(() => Number(el.getAttribute("aria-valuenow")) % 10)
+      .toBe(0);
+  });
+
+  test("markerLabels: the wrapper reserves layout space so labels render inside its own box", async () => {
+    // `.track` has a fixed height with no space reserved for `.marks`, and
+    // `.marks`/`.mark`/`.mark-label` are all `position: absolute`, so they
+    // never contribute to `.track`'s or `.elm-slider`'s box size. The label
+    // row currently renders entirely below the wrapper's own bottom edge.
+    const screen = await render(
+      <ElmSlider min={0} max={100} step={25} markers markerLabels />,
+    );
+    const wrapper = screen.container.querySelector(
+      '[class*="elm-slider"]',
+    ) as HTMLElement;
+    wrapper.style.width = "300px";
+    const labels = screen.container.querySelectorAll('[class*="mark-label"]');
+    expect(labels.length).toBeGreaterThan(0);
+
+    const wrapperRect = wrapper.getBoundingClientRect();
+    for (const label of labels) {
+      const labelRect = label.getBoundingClientRect();
+      expect(labelRect.bottom).toBeLessThanOrEqual(wrapperRect.bottom);
+    }
+  });
+
+  test("vertical + markerLabels: wide (5-digit) labels still render inside the wrapper's inline-end edge", async () => {
+    // `.vertical.has-marker-labels` reserves a *fixed* `padding-inline-end`
+    // (2.5rem) sized for short labels. That budget doesn't scale with digit
+    // count, so a range whose marker labels reach 4+ digits (e.g. 25000,
+    // 100000) renders labels that spill past the wrapper's own right edge
+    // instead of staying inside the reserved space — unlike the horizontal
+    // orientation, where the reserved `padding-block-end` only needs to hold
+    // a label's line-height, which stays constant regardless of digit count.
+    const screen = await render(
+      <ElmSlider
+        orientation="vertical"
+        min={0}
+        max={100000}
+        step={25000}
+        markers
+        markerLabels
+      />,
+    );
+    const wrapper = screen.container.querySelector(
+      '[class*="elm-slider"]',
+    ) as HTMLElement;
+    const labels = screen.container.querySelectorAll('[class*="mark-label"]');
+    expect(labels.length).toBeGreaterThan(0);
+
+    const wrapperRect = wrapper.getBoundingClientRect();
+    for (const label of labels) {
+      const labelRect = label.getBoundingClientRect();
+      expect(labelRect.right).toBeLessThanOrEqual(wrapperRect.right);
+    }
+  });
+
+  test("vertical + markerLabels under dir=rtl: wide (5-digit) labels still render inside the wrapper's own edge", async () => {
+    // `.vertical.has-marker-labels` reserves its budget via the *logical*
+    // `padding-inline-end`, which the browser maps to physical `padding-left`
+    // under `dir="rtl"`. But `.vertical .mark`'s `left: 50%` +
+    // `transform: translate(0.75rem, 50%)` (and the tick/label layout that
+    // follows) are all physical, direction-agnostic positioning that keeps
+    // rendering on the physical right regardless of `dir`. So under RTL the
+    // reserved space sits uselessly on the left while the labels it was
+    // meant to protect still overflow on the physical right, past the
+    // wrapper's own right edge.
+    const screen = await render(
+      <div dir="rtl">
+        <ElmSlider
+          orientation="vertical"
+          min={0}
+          max={100000}
+          step={25000}
+          markers
+          markerLabels
+        />
+      </div>,
+    );
+    const wrapper = screen.container.querySelector(
+      '[class*="elm-slider"]',
+    ) as HTMLElement;
+    const labels = screen.container.querySelectorAll('[class*="mark-label"]');
+    expect(labels.length).toBeGreaterThan(0);
+
+    const wrapperRect = wrapper.getBoundingClientRect();
+    for (const label of labels) {
+      const labelRect = label.getBoundingClientRect();
+      expect(labelRect.right).toBeLessThanOrEqual(wrapperRect.right);
+    }
+  });
+
+  test("vertical: the max-value mark sits flush with the track's top edge", async () => {
+    // `.vertical .mark-start` cancels the default centering translate with
+    // `translate(0.75rem, 0)` so its untransformed box (already flush with
+    // the track's bottom, via `bottom: 0%`) stays flush at the bottom.
+    // `.vertical .mark-end`'s untransformed box (via `bottom: 100%`) sits one
+    // row-height above the track's top edge, so the analogous fix is a
+    // `+100%` Y-translate to bring it down flush with the top edge — not
+    // `-100%`, which shifts it a further row-height away (up).
+    const screen = await render(
+      <ElmSlider
+        orientation="vertical"
+        min={0}
+        max={10}
+        step={1}
+        markers
+        markerLabels
+      />,
+    );
+    const track = screen.container.querySelector(
+      '[class*="track"]',
+    ) as HTMLElement;
+    const markEnd = screen.container.querySelector(
+      '[class*="mark-end"]',
+    ) as HTMLElement;
+
+    const trackRect = track.getBoundingClientRect();
+    const markEndRect = markEnd.getBoundingClientRect();
+
+    expect(Math.abs(markEndRect.top - trackRect.top)).toBeLessThan(2);
   });
 });

--- a/packages/react/src/components/form/elm-slider.module.css
+++ b/packages/react/src/components/form/elm-slider.module.css
@@ -115,6 +115,7 @@
 
 .vertical .fill {
   inset: auto 0 0;
+  width: auto;
   bottom: calc(var(--elmethis-scoped-inner-min-ratio, 0) * 100%);
   height: calc(
     (
@@ -159,6 +160,74 @@
 
 /* ---- Markers ---------------------------------------------------------------- */
 
+/*
+ * `.marks` and its descendants are `position: absolute` so a tick/label can
+ * sit at an arbitrary percentage along the track without disturbing the
+ * track's own flex layout — but that also means none of it ever contributes
+ * to `.track`'s or `.elm-slider`'s box size. Reserve the extra space these
+ * rows need on the element that participates in normal flow (`.elm-slider`),
+ * sized generously enough to fit a tick, the gap, and a label's line box.
+ */
+.elm-slider.has-markers {
+  padding-block-end: 0.5rem;
+}
+
+.elm-slider.has-marker-labels {
+  padding-block-end: 1.75rem;
+}
+
+.elm-slider.vertical.has-markers {
+  padding-block-end: 0;
+
+  /*
+   * Physical, not logical: `.vertical .mark`'s `left: 50%` +
+   * `transform: translate(0.75rem, ...)` (and the tick/label layout that
+   * follows) always render on the physical right regardless of `dir` — they
+   * don't participate in the inline axis at all. A logical
+   * `padding-inline-end` would flip to physical `padding-left` under
+   * `dir="rtl"`, reserving space on the side opposite the one the marks
+   * actually occupy.
+   */
+  padding-right: 0.5rem;
+}
+
+.elm-slider.vertical.has-marker-labels {
+  padding-block-end: 0;
+
+  /*
+   * Unlike the horizontal axis (where the reserved `padding-block-end` only
+   * ever needs to hold a label's roughly-constant line-height), a vertical
+   * label's *width* scales with its character count — a fixed rem constant
+   * only fits short labels and lets 4+ digit values (or wide negative
+   * values) spill past this element's own inline-end edge.
+   *
+   * `0.75rem` covers the fixed part of the offset from the track's
+   * inline-end edge to where the label starts (the mark's own translate
+   * plus the tick + gap that precede the label in `.mark`'s row layout).
+   * The remainder scales with the longest rendered label's character count,
+   * via `1ch` — exact here because `.mark-label` uses a monospace font, so
+   * every character has the same advance width. `font-family`/`font-size`
+   * are set to match `.mark-label` so `ch` resolves against the same font
+   * metrics; this element renders no text of its own, so it doesn't leak
+   * into any child that doesn't set its own font (they all do). The extra
+   * `0.5ch` is a small rounding buffer for subpixel layout drift between
+   * this element's `ch` and the label's own rendered width.
+   *
+   * This is a physical `padding-right`, not the logical `padding-inline-end`
+   * its name suggests it should be: `.vertical .mark`'s `left: 50%` +
+   * `transform: translate(0.75rem, ...)` (and everything downstream of it —
+   * the tick, the gap, the label) render on the physical right regardless of
+   * `dir` — none of it is expressed in logical/inline terms. Reserving the
+   * space with a logical property would flip it to physical `padding-left`
+   * under `dir="rtl"`, leaving the actual marks unprotected on the right.
+   */
+  font-family: var(--elmethis-font-family-monospace);
+  font-size: 0.7rem;
+  padding-right: calc(
+    0.75rem + (var(--elmethis-scoped-max-marker-label-chars, 4) + 0.5) * 1ch
+  );
+}
+
 .marks {
   position: absolute;
   inset: 0;
@@ -182,6 +251,25 @@
   bottom: calc(var(--elmethis-scoped-marker-ratio, 0) * 100%);
   flex-direction: row;
   transform: translate(0.75rem, 50%);
+}
+
+/* The default transform centers a tick/label on its marker position, which
+   pushes the first/last mark half its own size past the track's start/end
+   edge. Align those two inward instead of centering them. */
+.mark-start {
+  transform: translate(0, 0.75rem);
+}
+
+.mark-end {
+  transform: translate(-100%, 0.75rem);
+}
+
+.vertical .mark-start {
+  transform: translate(0.75rem, 0);
+}
+
+.vertical .mark-end {
+  transform: translate(0.75rem, 100%);
 }
 
 .tick {

--- a/packages/react/src/components/form/elm-slider.module.css
+++ b/packages/react/src/components/form/elm-slider.module.css
@@ -1,0 +1,213 @@
+.elm-slider {
+  box-sizing: border-box;
+  width: 100%;
+  margin-block-start: var(--elmethis-margin-block-start);
+  user-select: none;
+}
+
+.elm-slider.vertical {
+  width: fit-content;
+  height: 12rem;
+}
+
+.elm-slider.disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+/* ---- Track ---------------------------------------------------------------- */
+
+/* A roomy hit area so the thin rail stays easy to grab/tap. */
+.track {
+  position: relative;
+  width: 100%;
+  height: 1.25rem;
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  touch-action: none;
+}
+
+.vertical .track {
+  flex-direction: column;
+  width: 1.25rem;
+  height: 100%;
+}
+
+.disabled .track {
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+.track:focus-visible {
+  outline: 2px solid var(--elmethis-color-primary);
+  outline-offset: 4px;
+  border-radius: 0.25rem;
+}
+
+.rail {
+  position: relative;
+  width: 100%;
+  height: 0.25rem;
+  border-radius: 999px;
+  background-color: var(--elmethis-color-neutral-weak);
+  overflow: hidden;
+}
+
+.vertical .rail {
+  width: 0.25rem;
+  height: 100%;
+}
+
+/* Regions of the track outside [innerMin, innerMax] — visually unreachable. */
+.restricted-start,
+.restricted-end {
+  position: absolute;
+  background-color: var(--elmethis-color-neutral-weak);
+  background-image: repeating-linear-gradient(
+    45deg,
+    color-mix(in srgb, var(--elmethis-color-neutral) 35%, transparent) 0,
+    color-mix(in srgb, var(--elmethis-color-neutral) 35%, transparent) 2px,
+    transparent 2px,
+    transparent 6px
+  );
+}
+
+.restricted-start {
+  inset: 0 auto 0 0;
+  width: calc(var(--elmethis-scoped-inner-min-ratio, 0) * 100%);
+}
+
+.restricted-end {
+  inset: 0 0 0 auto;
+  width: calc((1 - var(--elmethis-scoped-inner-max-ratio, 1)) * 100%);
+}
+
+.vertical .restricted-start,
+.vertical .restricted-end {
+  width: auto;
+}
+
+.vertical .restricted-start {
+  inset: auto 0 0;
+  height: calc(var(--elmethis-scoped-inner-min-ratio, 0) * 100%);
+}
+
+.vertical .restricted-end {
+  inset: 0 0 auto;
+  height: calc((1 - var(--elmethis-scoped-inner-max-ratio, 1)) * 100%);
+}
+
+.fill {
+  position: absolute;
+  inset: 0 auto;
+  left: calc(var(--elmethis-scoped-inner-min-ratio, 0) * 100%);
+  width: calc(
+    (
+        var(--elmethis-scoped-value-ratio, 0) -
+          var(--elmethis-scoped-inner-min-ratio, 0)
+      ) *
+      100%
+  );
+  border-radius: 999px;
+  background-color: var(--elmethis-color-primary);
+}
+
+.vertical .fill {
+  inset: auto 0 0;
+  bottom: calc(var(--elmethis-scoped-inner-min-ratio, 0) * 100%);
+  height: calc(
+    (
+        var(--elmethis-scoped-value-ratio, 0) -
+          var(--elmethis-scoped-inner-min-ratio, 0)
+      ) *
+      100%
+  );
+}
+
+/* Draggable handle. */
+.thumb {
+  position: absolute;
+  top: 50%;
+  left: calc(var(--elmethis-scoped-value-ratio, 0) * 100%);
+  width: 0.875rem;
+  height: 0.875rem;
+  border-radius: 50%;
+  background-color: var(--elmethis-color-primary-strong);
+  box-shadow: 0 0.125rem 0.375rem -0.0625rem var(--elmethis-box-shadow-color);
+  transform: translate(-50%, -50%);
+  transition: transform 140ms cubic-bezier(0.34, 1.56, 0.64, 1);
+  pointer-events: none;
+}
+
+.vertical .thumb {
+  top: auto;
+  left: 50%;
+  bottom: calc(var(--elmethis-scoped-value-ratio, 0) * 100%);
+  transform: translate(-50%, 50%);
+}
+
+.track:hover .thumb,
+.track:focus-visible .thumb {
+  transform: translate(-50%, -50%) scale(1.2);
+}
+
+.vertical .track:hover .thumb,
+.vertical .track:focus-visible .thumb {
+  transform: translate(-50%, 50%) scale(1.2);
+}
+
+/* ---- Markers ---------------------------------------------------------------- */
+
+.marks {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.mark {
+  position: absolute;
+  top: 50%;
+  left: calc(var(--elmethis-scoped-marker-ratio, 0) * 100%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+  transform: translate(-50%, 0.75rem);
+}
+
+.vertical .mark {
+  top: auto;
+  left: 50%;
+  bottom: calc(var(--elmethis-scoped-marker-ratio, 0) * 100%);
+  flex-direction: row;
+  transform: translate(0.75rem, 50%);
+}
+
+.tick {
+  width: 0.125rem;
+  height: 0.375rem;
+  border-radius: 999px;
+  background-color: var(--elmethis-color-neutral);
+  font-style: normal;
+}
+
+.vertical .tick {
+  width: 0.375rem;
+  height: 0.125rem;
+}
+
+.mark-restricted .tick {
+  background-color: var(--elmethis-color-neutral-weak);
+}
+
+.mark-label {
+  font-family: var(--elmethis-font-family-monospace);
+  font-size: 0.7rem;
+  color: var(--elmethis-color-neutral);
+  white-space: nowrap;
+}
+
+.mark-restricted .mark-label {
+  opacity: 0.6;
+}

--- a/packages/react/src/components/form/elm-slider.spec.tsx
+++ b/packages/react/src/components/form/elm-slider.spec.tsx
@@ -437,6 +437,32 @@ describe("[CSR] ElmSlider — known bugs (regression)", () => {
     expect(el.getAttribute("aria-valuemax")).toBe("100");
     expect(el.getAttribute("aria-valuenow")).toBe("30");
   });
+
+  it("still renders tick marks for a reversed range (min > max)", () => {
+    // `marks`' guard treated any `max <= min` as an empty range, silently
+    // dropping every tick/label even though a reversed range is a legitimate
+    // declining track elsewhere in this component (see the two tests above).
+    const { container } = render(
+      <ElmSlider min={100} max={0} step={10} markers markerLabels />,
+    );
+
+    const ticks = container.querySelectorAll('[class*="tick"]');
+    const labels = container.querySelectorAll('[class*="mark-label"]');
+    expect(ticks.length).toBe(11);
+    expect(Array.from(labels).map((l) => l.textContent)).toEqual([
+      "100",
+      "90",
+      "80",
+      "70",
+      "60",
+      "50",
+      "40",
+      "30",
+      "20",
+      "10",
+      "0",
+    ]);
+  });
 });
 
 describe("[SSR] ElmSlider", () => {

--- a/packages/react/src/components/form/elm-slider.spec.tsx
+++ b/packages/react/src/components/form/elm-slider.spec.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { render, fireEvent } from "@testing-library/react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { useState } from "react";
@@ -201,6 +201,31 @@ describe("[CSR] ElmSlider — known bugs (regression)", () => {
     expect(lastRatio).toBeCloseTo(1, 5);
   });
 
+  it("sizes the vertical label reservation to a JSX-returning formatMarkerLabel's rendered text, not String(value)", () => {
+    const { container } = render(
+      <ElmSlider
+        orientation="vertical"
+        min={0}
+        max={100}
+        step={25}
+        markers
+        markerLabels
+        formatMarkerLabel={(v) => <strong>{v} units of measurement</strong>}
+      />,
+    );
+    const wrapper = container.querySelector(
+      '[class*="elm-slider"]',
+    ) as HTMLElement;
+    const chars = Number(
+      wrapper.style.getPropertyValue(
+        "--elmethis-scoped-max-marker-label-chars",
+      ),
+    );
+    // "100 units of measurement" is 25 chars; falling back to String(100)
+    // (3 chars) would under-reserve the padding and let the label overflow.
+    expect(chars).toBe("100 units of measurement".length);
+  });
+
   it("ArrowRight increases the value even when step is negative", () => {
     const { container } = render(<ElmSlider defaultValue={50} step={-10} />);
     const el = slider(container);
@@ -213,6 +238,204 @@ describe("[CSR] ElmSlider — known bugs (regression)", () => {
   it("forwards aria-label to the slider element, not an outer wrapper", () => {
     const { container } = render(<ElmSlider aria-label="Volume" />);
     expect(slider(container)).toHaveAttribute("aria-label", "Volume");
+  });
+
+  it("renders tick/label values on the actual step grid, not an evenly-resampled one", () => {
+    const { container } = render(
+      <ElmSlider min={0} max={10} step={3} markers markerLabels />,
+    );
+    const labels = Array.from(
+      container.querySelectorAll('[class*="mark-label"]'),
+    ).map((el) => el.textContent);
+    // step=3 over [0, 10] only ever snaps to 0, 3, 6, 9 (plus the forced
+    // max=10); it must never render 3.3333.../6.6666... ticks the thumb
+    // can never actually reach.
+    expect(labels).toEqual(["0", "3", "6", "9", "10"]);
+  });
+
+  it("does not render an out-of-range tick when (max-min)/step rounds up", () => {
+    const { container } = render(
+      <ElmSlider min={0} max={10} step={6} markers markerLabels />,
+    );
+    const labels = Array.from(
+      container.querySelectorAll('[class*="mark-label"]'),
+    ).map((el) => el.textContent);
+    // (10-0)/6 = 1.666..., which Math.round rounds up to 2, generating a
+    // spurious "12" tick outside [min, max] that overlaps the forced max=10
+    // tick. Only the real step-ticks (0, 6) plus the forced max (10) should
+    // render.
+    expect(labels).toEqual(["0", "6", "10"]);
+  });
+
+  it("moves by exactly one step from an off-grid controlled value", () => {
+    const onValueChange = vi.fn();
+    const { container } = render(
+      <ElmSlider
+        min={0}
+        max={100}
+        step={10}
+        value={7}
+        onValueChange={onValueChange}
+      />,
+    );
+    const el = slider(container);
+
+    fireEvent.keyDown(el, { key: "ArrowRight" });
+
+    // 7 is a legitimate off-grid controlled value (e.g. a persisted user
+    // preference); a single ArrowRight must move by exactly `step` from the
+    // current value (7 + 10 = 17), not re-quantize onto a grid anchored at
+    // `min` (which would jump to 20).
+    expect(onValueChange).toHaveBeenCalledWith(17);
+  });
+
+  it("seeds the uncontrolled initial value verbatim, without re-quantizing it onto the step grid", () => {
+    // Same off-grid-preservation contract this file already enforces for a
+    // controlled `value` (see "moves by exactly one step from an off-grid
+    // controlled value") must also hold for the uncontrolled seed: an
+    // explicit, legitimately off-grid `defaultValue` (e.g. a persisted
+    // preference) must be honored as-is, not silently rewritten onto a
+    // step-10 grid anchored at `min` (which would produce 10 instead of 7).
+    const { container: withDefault } = render(
+      <ElmSlider step={10} defaultValue={7} />,
+    );
+    expect(slider(withDefault).getAttribute("aria-valuenow")).toBe("7");
+
+    // With no `defaultValue` at all, the JSDoc on `defaultValue` and the
+    // Storybook docs both promise the true midpoint of the range
+    // (100 / 2 = 50), not a value re-quantized onto a step-7 grid anchored
+    // at `min` (which would produce 49).
+    const { container: atMidpoint } = render(<ElmSlider step={7} />);
+    expect(slider(atMidpoint).getAttribute("aria-valuenow")).toBe("50");
+  });
+
+  it("moves on the first keypress from a controlled value sitting above innerMax", () => {
+    const Harness = () => {
+      const [value, setValue] = useState(95);
+      return (
+        <ElmSlider
+          min={0}
+          max={100}
+          innerMin={0}
+          innerMax={80}
+          step={1}
+          value={value}
+          onValueChange={setValue}
+        />
+      );
+    };
+
+    const { container } = render(<Harness />);
+    const el = slider(container);
+
+    // aria-valuenow is correctly clamped for display before any interaction.
+    expect(el.getAttribute("aria-valuenow")).toBe("80");
+
+    // The very first ArrowLeft must decrease the *displayed* value by one
+    // step (80 -> 79), not compute from the raw out-of-range controlled
+    // value (95 -> clampValue(94) = 80, i.e. no visible change).
+    fireEvent.keyDown(el, { key: "ArrowLeft" });
+    expect(el.getAttribute("aria-valuenow")).toBe("79");
+  });
+
+  it("composes a caller-supplied onKeyDown with the slider's own keyboard handling", () => {
+    const onKeyDownSpy = vi.fn();
+    const { container } = render(
+      <ElmSlider defaultValue={50} onKeyDown={onKeyDownSpy} />,
+    );
+    const el = slider(container);
+
+    fireEvent.keyDown(el, { key: "ArrowRight" });
+
+    // `rest` (which carries the caller's onKeyDown) is spread before the
+    // component's own onKeyDown in the same JSX element, so the caller's
+    // handler is silently overwritten instead of composed.
+    expect(onKeyDownSpy).toHaveBeenCalledTimes(1);
+    expect(Number(el.getAttribute("aria-valuenow"))).toBe(51);
+  });
+
+  it("respects a caller-supplied tabIndex instead of forcing it from `disabled`", () => {
+    const { container } = render(<ElmSlider tabIndex={-1} />);
+    const el = slider(container);
+
+    // `tabIndex={disabled ? -1 : 0}` is set on the same element after
+    // `{...rest}` is spread, so it always overwrites `rest.tabIndex` — even
+    // when the caller deliberately opts the slider out of the tab order
+    // (e.g. a roving-tabindex composite widget where a parent toolbar/group
+    // manages which control is focusable).
+    expect(el.getAttribute("tabindex")).toBe("-1");
+  });
+
+  it("still renders tick marks when step is negative", () => {
+    const { container } = render(
+      <ElmSlider min={0} max={20} step={-4} markers />,
+    );
+    // `step` is a granularity everywhere else in this component (snap() and
+    // the keyboard handler both use Math.abs(step)) — the marks memo must
+    // treat it the same way instead of early-returning `[]` for a raw
+    // negative step. Expect ticks at 0, 4, 8, 12, 16, 20.
+    const ticks = container.querySelectorAll('[class*="tick"]');
+    expect(ticks).toHaveLength(6);
+  });
+
+  it("does not invoke a caller-supplied onKeyDown when disabled", () => {
+    const onKeyDownSpy = vi.fn();
+    const { container } = render(
+      <ElmSlider disabled defaultValue={50} onKeyDown={onKeyDownSpy} />,
+    );
+    const el = slider(container);
+
+    fireEvent.keyDown(el, { key: "ArrowRight" });
+
+    // The internal handler correctly no-ops on `disabled`, but the composed
+    // handler still unconditionally calls the caller's onKeyDown afterward —
+    // a caller relying on `disabled` to fully suppress interaction (e.g.
+    // analytics, a toast) must not see it fire.
+    expect(el.getAttribute("aria-valuenow")).toBe("50");
+    expect(onKeyDownSpy).not.toHaveBeenCalled();
+  });
+
+  it("honors innerMin/innerMax/defaultValue instead of collapsing to max when min > max", () => {
+    const { container } = render(
+      <ElmSlider
+        min={100}
+        max={0}
+        innerMin={20}
+        innerMax={80}
+        defaultValue={50}
+      />,
+    );
+    const el = slider(container);
+
+    // A reversed range (min > max) is a legitimate declining track —
+    // ratioOf already treats it as a valid interpolation — so clamping the
+    // inner bounds must not assume `lo <= hi` and silently force
+    // effectiveInnerMin/effectiveInnerMax (and therefore the seeded
+    // defaultValue) down to `max` regardless of the caller's props.
+    expect(el.getAttribute("aria-valuemin")).toBe("20");
+    expect(el.getAttribute("aria-valuemax")).toBe("80");
+    expect(el.getAttribute("aria-valuenow")).toBe("50");
+
+    // The control must not be frozen: a step still moves the value.
+    fireEvent.keyDown(el, { key: "ArrowLeft" });
+    expect(el.getAttribute("aria-valuenow")).toBe("49");
+  });
+
+  it("does not collapse to a single point when min > max and innerMin/innerMax are omitted", () => {
+    const { container } = render(
+      <ElmSlider min={100} max={0} defaultValue={30} />,
+    );
+    const el = slider(container);
+
+    // With innerMin/innerMax omitted, the documented defaults ("min" /
+    // "max") must resolve against the logical [low, high] span (0, 100),
+    // not the raw, possibly-reversed `min`/`max` values themselves —
+    // otherwise the default innerMax (the raw `max`, here the smaller
+    // number) gets clamped *up* to innerMin instead of down to the
+    // range's actual high end, collapsing the whole track to one point.
+    expect(el.getAttribute("aria-valuemin")).toBe("0");
+    expect(el.getAttribute("aria-valuemax")).toBe("100");
+    expect(el.getAttribute("aria-valuenow")).toBe("30");
   });
 });
 

--- a/packages/react/src/components/form/elm-slider.spec.tsx
+++ b/packages/react/src/components/form/elm-slider.spec.tsx
@@ -1,0 +1,225 @@
+import { describe, it, expect } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { useState } from "react";
+
+import { ElmSlider } from "./elm-slider";
+
+const slider = (container: HTMLElement) =>
+  container.querySelector('[role="slider"]') as HTMLElement;
+
+describe("[CSR] ElmSlider — rendering", () => {
+  it("defaults to horizontal, min 0, max 100, midpoint value", () => {
+    const { container } = render(<ElmSlider />);
+    const el = slider(container);
+    expect(el.getAttribute("aria-orientation")).toBe("horizontal");
+    expect(el.getAttribute("aria-valuemin")).toBe("0");
+    expect(el.getAttribute("aria-valuemax")).toBe("100");
+    expect(el.getAttribute("aria-valuenow")).toBe("50");
+  });
+
+  it("renders vertical orientation", () => {
+    const { container } = render(<ElmSlider orientation="vertical" />);
+    expect(slider(container).getAttribute("aria-orientation")).toBe("vertical");
+  });
+
+  it("defaultValue seeds the uncontrolled value", () => {
+    const { container } = render(<ElmSlider defaultValue={30} />);
+    expect(slider(container).getAttribute("aria-valuenow")).toBe("30");
+  });
+
+  it("clamps aria-valuemin/max to the inner range", () => {
+    const { container } = render(
+      <ElmSlider innerMin={20} innerMax={80} defaultValue={50} />,
+    );
+    const el = slider(container);
+    expect(el.getAttribute("aria-valuemin")).toBe("20");
+    expect(el.getAttribute("aria-valuemax")).toBe("80");
+  });
+
+  it("clamps an out-of-inner-range defaultValue on mount", () => {
+    const { container } = render(
+      <ElmSlider innerMin={20} innerMax={80} defaultValue={5} />,
+    );
+    expect(slider(container).getAttribute("aria-valuenow")).toBe("20");
+  });
+
+  it("aria-disabled and tabIndex reflect the disabled prop", () => {
+    const { container } = render(<ElmSlider disabled />);
+    const el = slider(container);
+    expect(el.getAttribute("aria-disabled")).toBe("true");
+    expect(el).toHaveAttribute("tabIndex", "-1");
+  });
+
+  it("renders one tick per step when markers is set", () => {
+    const { container } = render(
+      <ElmSlider min={0} max={100} step={25} markers />,
+    );
+    // 0, 25, 50, 75, 100
+    expect(container.querySelectorAll("i")).toHaveLength(5);
+  });
+
+  it("renders marker labels with the formatted value", () => {
+    const { container } = render(
+      <ElmSlider
+        min={0}
+        max={100}
+        step={50}
+        markers
+        markerLabels
+        formatMarkerLabel={(v) => `${v}%`}
+      />,
+    );
+    expect(container.textContent).toContain("0%");
+    expect(container.textContent).toContain("50%");
+    expect(container.textContent).toContain("100%");
+  });
+});
+
+describe("[CSR] ElmSlider — keyboard interaction", () => {
+  it("ArrowRight/ArrowUp increases the value by step", () => {
+    const { container } = render(<ElmSlider defaultValue={50} step={5} />);
+    const el = slider(container);
+
+    fireEvent.keyDown(el, { key: "ArrowRight" });
+    expect(el.getAttribute("aria-valuenow")).toBe("55");
+
+    fireEvent.keyDown(el, { key: "ArrowUp" });
+    expect(el.getAttribute("aria-valuenow")).toBe("60");
+  });
+
+  it("ArrowLeft/ArrowDown decreases the value by step", () => {
+    const { container } = render(<ElmSlider defaultValue={50} step={5} />);
+    const el = slider(container);
+
+    fireEvent.keyDown(el, { key: "ArrowLeft" });
+    expect(el.getAttribute("aria-valuenow")).toBe("45");
+
+    fireEvent.keyDown(el, { key: "ArrowDown" });
+    expect(el.getAttribute("aria-valuenow")).toBe("40");
+  });
+
+  it("Home/End jump to the inner bounds", () => {
+    const { container } = render(
+      <ElmSlider innerMin={20} innerMax={80} defaultValue={50} />,
+    );
+    const el = slider(container);
+
+    fireEvent.keyDown(el, { key: "End" });
+    expect(el.getAttribute("aria-valuenow")).toBe("80");
+
+    fireEvent.keyDown(el, { key: "Home" });
+    expect(el.getAttribute("aria-valuenow")).toBe("20");
+  });
+
+  it("does not move past the inner bounds", () => {
+    const { container } = render(
+      <ElmSlider innerMin={0} innerMax={100} defaultValue={98} step={5} />,
+    );
+    const el = slider(container);
+
+    fireEvent.keyDown(el, { key: "ArrowRight" });
+    expect(el.getAttribute("aria-valuenow")).toBe("100");
+  });
+
+  it("does not respond to keyboard input when disabled", () => {
+    const { container } = render(<ElmSlider defaultValue={50} disabled />);
+    const el = slider(container);
+
+    fireEvent.keyDown(el, { key: "ArrowRight" });
+    expect(el.getAttribute("aria-valuenow")).toBe("50");
+  });
+
+  it("writes through to a bound parent value", () => {
+    const Harness = () => {
+      const [value, setValue] = useState(50);
+      return (
+        <div>
+          <output data-testid="state">{value}</output>
+          <ElmSlider value={value} onValueChange={setValue} step={10} />
+        </div>
+      );
+    };
+
+    const { container, getByTestId } = render(<Harness />);
+    fireEvent.keyDown(slider(container), { key: "ArrowRight" });
+
+    expect(getByTestId("state")).toHaveTextContent("60");
+    expect(slider(container).getAttribute("aria-valuenow")).toBe("60");
+  });
+});
+
+// Regression tests for bugs found in code review — each asserts the correct
+// behavior and currently FAILS against the present implementation.
+describe("[CSR] ElmSlider — known bugs (regression)", () => {
+  it("clamps a controlled value that falls outside the inner range", () => {
+    const { container } = render(
+      <ElmSlider
+        innerMin={20}
+        innerMax={80}
+        value={5}
+        onValueChange={() => {}}
+      />,
+    );
+    const el = slider(container);
+    expect(Number(el.getAttribute("aria-valuenow"))).toBeGreaterThanOrEqual(20);
+  });
+
+  it("formats marker labels without floating-point dust for a fractional step", () => {
+    const { container } = render(
+      <ElmSlider min={0} max={1} step={0.1} markers markerLabels />,
+    );
+    // 0 + 3*0.1 drifts to 0.30000000000000004 in JS float math.
+    expect(container.textContent).not.toMatch(/0\.30000/);
+  });
+
+  it("does not skip a tick due to floating-point step-count error", () => {
+    const { container } = render(
+      <ElmSlider min={0} max={0.3} step={0.1} markers markerLabels />,
+    );
+    const labels = Array.from(
+      container.querySelectorAll('[class*="mark-label"]'),
+    ).map((el) => el.textContent);
+    // Expect all 4 ticks: 0, 0.1, 0.2, 0.3. (0.3-0)/0.1 evaluates to
+    // 2.9999999999999996 in JS float math, so Math.floor undercounts to 2
+    // and the "0.2" tick is dropped, jumping straight from 0.1 to the
+    // forced max=0.3.
+    expect(labels).toHaveLength(4);
+  });
+
+  it("spans the full range instead of clustering near min when the tick count exceeds MAX_MARKERS", () => {
+    const { container } = render(
+      <ElmSlider min={0} max={100} step={0.01} markers />,
+    );
+    const marks = container.querySelectorAll('[class*="mark"]');
+    const last = marks[marks.length - 1] as HTMLElement;
+    const lastRatio = Number(
+      last.style.getPropertyValue("--elmethis-scoped-marker-ratio"),
+    );
+    // The capped 501 rendered ticks should still stretch across [min, max];
+    // currently the last one sits at ratio 0.05 (value 5) instead of 1 (100).
+    expect(lastRatio).toBeCloseTo(1, 5);
+  });
+
+  it("ArrowRight increases the value even when step is negative", () => {
+    const { container } = render(<ElmSlider defaultValue={50} step={-10} />);
+    const el = slider(container);
+
+    fireEvent.keyDown(el, { key: "ArrowRight" });
+
+    expect(Number(el.getAttribute("aria-valuenow"))).toBeGreaterThan(50);
+  });
+
+  it("forwards aria-label to the slider element, not an outer wrapper", () => {
+    const { container } = render(<ElmSlider aria-label="Volume" />);
+    expect(slider(container)).toHaveAttribute("aria-label", "Volume");
+  });
+});
+
+describe("[SSR] ElmSlider", () => {
+  it("renders the slider role in the server shell", () => {
+    const html = renderToStaticMarkup(<ElmSlider defaultValue={40} />);
+    expect(html).toContain('role="slider"');
+    expect(html).toContain('aria-valuenow="40"');
+  });
+});

--- a/packages/react/src/components/form/elm-slider.stories.tsx
+++ b/packages/react/src/components/form/elm-slider.stories.tsx
@@ -1,0 +1,98 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+
+import { ElmSlider } from "./elm-slider";
+
+const meta = {
+  title: "Components/Form/elm-slider",
+  component: ElmSlider,
+  tags: ["autodocs"],
+  args: {
+    min: 0,
+    max: 100,
+    step: 1,
+  },
+} satisfies Meta<typeof ElmSlider>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Uncontrolled: the slider manages its own value, starting at the midpoint.
+export const Primary: Story = {};
+
+export const Vertical: Story = {
+  args: {
+    orientation: "vertical",
+  },
+};
+
+export const WithStep: Story = {
+  args: {
+    step: 10,
+  },
+};
+
+export const WithInnerRange: Story = {
+  args: {
+    innerMin: 20,
+    innerMax: 80,
+    defaultValue: 20,
+  },
+};
+
+export const WithMarkers: Story = {
+  args: {
+    step: 10,
+    markers: true,
+  },
+};
+
+export const WithMarkerLabels: Story = {
+  args: {
+    step: 25,
+    markers: true,
+    markerLabels: true,
+  },
+};
+
+export const WithMarkersAndInnerRange: Story = {
+  args: {
+    step: 10,
+    innerMin: 20,
+    innerMax: 80,
+    defaultValue: 20,
+    markers: true,
+    markerLabels: true,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+    defaultValue: 40,
+  },
+};
+
+// Controlled: parent owns the value.
+export const Controlled: Story = {
+  render: (args) => {
+    const ControlledSlider = () => {
+      const [value, setValue] = useState(30);
+
+      return (
+        <div style={{ display: "flex", alignItems: "center", gap: "1rem" }}>
+          <ElmSlider
+            {...args}
+            style={{ maxWidth: "16rem" }}
+            value={value}
+            onValueChange={setValue}
+          />
+          <span style={{ fontFamily: "monospace" }}>value: {value}</span>
+          <button onClick={() => setValue(30)}>Reset</button>
+        </div>
+      );
+    };
+
+    return <ControlledSlider />;
+  },
+};

--- a/packages/react/src/components/form/elm-slider.tsx
+++ b/packages/react/src/components/form/elm-slider.tsx
@@ -1,0 +1,349 @@
+import {
+  useCallback,
+  useMemo,
+  useRef,
+  type ComponentPropsWithoutRef,
+  type CSSProperties,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type PointerEvent as ReactPointerEvent,
+  type ReactNode,
+} from "react";
+import { clsx } from "clsx";
+
+import { useBindableSignal } from "../../hooks/use-bindable-signal";
+import styles from "./elm-slider.module.css";
+
+export type ElmSliderOrientation = "horizontal" | "vertical";
+
+export interface ElmSliderProps extends Omit<
+  ComponentPropsWithoutRef<"div">,
+  "onChange" | "defaultValue"
+> {
+  /**
+   * Lower bound of the track's full range.
+   *
+   * @defaultValue 0
+   */
+  min?: number;
+
+  /**
+   * Upper bound of the track's full range.
+   *
+   * @defaultValue 100
+   */
+  max?: number;
+
+  /**
+   * Increment the value snaps to while dragging or using the keyboard.
+   *
+   * @defaultValue 1
+   */
+  step?: number;
+
+  /**
+   * Restricts the value to an interval inside the track's full length. Must
+   * be `>= min`. The track still spans `[min, max]`, but the region below
+   * `innerMin` is shown as unreachable.
+   *
+   * @defaultValue min
+   */
+  innerMin?: number;
+
+  /**
+   * Restricts the value to an interval inside the track's full length. Must
+   * be `<= max`.
+   *
+   * @defaultValue max
+   */
+  innerMax?: number;
+
+  /**
+   * Track direction.
+   *
+   * @defaultValue "horizontal"
+   */
+  orientation?: ElmSliderOrientation;
+
+  /**
+   * Controlled value. When provided the parent owns the value.
+   */
+  value?: number;
+
+  /**
+   * Initial value when uncontrolled.
+   *
+   * @defaultValue the midpoint of `innerMin`/`innerMax`
+   */
+  defaultValue?: number;
+
+  /**
+   * Called with the next value whenever it changes.
+   */
+  onValueChange?: (value: number) => void;
+
+  /**
+   * Disables dragging, clicking, and keyboard control.
+   */
+  disabled?: boolean;
+
+  /**
+   * Draws a tick mark at every step along the track.
+   */
+  markers?: boolean;
+
+  /**
+   * Draws a text label under each tick mark.
+   */
+  markerLabels?: boolean;
+
+  /**
+   * Formats the text shown for a marker label.
+   *
+   * @defaultValue String(value)
+   */
+  formatMarkerLabel?: (value: number) => ReactNode;
+}
+
+const clamp = (n: number, lo: number, hi: number) =>
+  Math.min(hi, Math.max(lo, n));
+
+// Rounds away float dust (e.g. 0 + 3 * 0.1 -> 0.30000000000000004).
+const preciseRound = (n: number) => Math.round(n * 1e9) / 1e9;
+
+// Guards against generating an unbounded number of DOM nodes if a caller
+// pairs a tiny `step` with a wide `[min, max]`.
+const MAX_MARKERS = 500;
+
+export const ElmSlider = ({
+  className,
+  style,
+  min = 0,
+  max = 100,
+  step = 1,
+  innerMin,
+  innerMax,
+  orientation = "horizontal",
+  value,
+  defaultValue,
+  onValueChange,
+  disabled,
+  markers,
+  markerLabels,
+  formatMarkerLabel,
+  ...rest
+}: ElmSliderProps) => {
+  const trackRef = useRef<HTMLDivElement>(null);
+  const isVertical = orientation === "vertical";
+
+  const effectiveInnerMin = clamp(innerMin ?? min, min, max);
+  const effectiveInnerMax = clamp(innerMax ?? max, effectiveInnerMin, max);
+
+  const snap = useCallback(
+    (raw: number) => {
+      const stepped =
+        step > 0 ? min + Math.round((raw - min) / step) * step : raw;
+      return clamp(preciseRound(stepped), effectiveInnerMin, effectiveInnerMax);
+    },
+    [min, step, effectiveInnerMin, effectiveInnerMax],
+  );
+
+  const [currentValue, setCurrentValue] = useBindableSignal<number>({
+    value,
+    defaultValue: snap(
+      defaultValue ?? (effectiveInnerMin + effectiveInnerMax) / 2,
+    ),
+    onChange: onValueChange,
+  });
+
+  const ratioOf = useCallback(
+    (v: number) => (max === min ? 0 : clamp((v - min) / (max - min), 0, 1)),
+    [min, max],
+  );
+
+  const valueFromPointer = useCallback(
+    (clientX: number, clientY: number): number => {
+      const el = trackRef.current;
+      if (!el) return currentValue;
+      const rect = el.getBoundingClientRect();
+      const ratio = isVertical
+        ? rect.height === 0
+          ? 0
+          : clamp((rect.bottom - clientY) / rect.height, 0, 1)
+        : rect.width === 0
+          ? 0
+          : clamp((clientX - rect.left) / rect.width, 0, 1);
+      return snap(min + ratio * (max - min));
+    },
+    [currentValue, isVertical, max, min, snap],
+  );
+
+  const handlePointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      if (disabled) return;
+      event.currentTarget.setPointerCapture(event.pointerId);
+      setCurrentValue(valueFromPointer(event.clientX, event.clientY));
+    },
+    [disabled, setCurrentValue, valueFromPointer],
+  );
+
+  const handlePointerMove = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      if (disabled) return;
+      if (!event.currentTarget.hasPointerCapture(event.pointerId)) return;
+      setCurrentValue(valueFromPointer(event.clientX, event.clientY));
+    },
+    [disabled, setCurrentValue, valueFromPointer],
+  );
+
+  const handleKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLDivElement>) => {
+      if (disabled) return;
+      // `step` is a granularity, not a direction — a caller-supplied negative
+      // step must not reverse which arrow key increases the value.
+      const delta = Math.abs(step);
+      switch (event.key) {
+        case "ArrowRight":
+        case "ArrowUp":
+          event.preventDefault();
+          setCurrentValue((prev) => snap(prev + delta));
+          break;
+        case "ArrowLeft":
+        case "ArrowDown":
+          event.preventDefault();
+          setCurrentValue((prev) => snap(prev - delta));
+          break;
+        case "PageUp":
+          event.preventDefault();
+          setCurrentValue((prev) => snap(prev + delta * 10));
+          break;
+        case "PageDown":
+          event.preventDefault();
+          setCurrentValue((prev) => snap(prev - delta * 10));
+          break;
+        case "Home":
+          event.preventDefault();
+          setCurrentValue(effectiveInnerMin);
+          break;
+        case "End":
+          event.preventDefault();
+          setCurrentValue(effectiveInnerMax);
+          break;
+      }
+    },
+    [
+      disabled,
+      effectiveInnerMin,
+      effectiveInnerMax,
+      setCurrentValue,
+      snap,
+      step,
+    ],
+  );
+
+  const marks = useMemo(() => {
+    if (!markers && !markerLabels) return [];
+    if (step <= 0 || max <= min) return [];
+    // `Math.round` (not `Math.floor`) absorbs float dust in (max-min)/step
+    // (e.g. 0.3/0.1 -> 2.9999999999999996, which must count as 3).
+    const realCount = Math.round((max - min) / step);
+    // Past MAX_MARKERS, evenly resample across the full range instead of
+    // rendering only the first MAX_MARKERS real step-ticks — otherwise a tiny
+    // step over a wide range clusters every rendered tick near `min`.
+    const count = Math.min(realCount, MAX_MARKERS);
+    const tickStep = (max - min) / count;
+    const out: { value: number; ratio: number }[] = [];
+    for (let i = 0; i <= count; i++) {
+      const v = i === count ? max : preciseRound(min + i * tickStep);
+      out.push({ value: v, ratio: ratioOf(v) });
+    }
+    return out;
+  }, [markers, markerLabels, step, min, max, ratioOf]);
+
+  // A controlling parent owns `currentValue` and may pass one outside the
+  // inner range (e.g. set before `innerMin`/`innerMax` were added) — clamp
+  // only for display so `aria-valuenow` and the thumb never report/render
+  // outside the declared bounds, without calling `onValueChange` ourselves.
+  const displayValue = clamp(
+    currentValue,
+    effectiveInnerMin,
+    effectiveInnerMax,
+  );
+  const valueRatio = ratioOf(displayValue);
+  const innerMinRatio = ratioOf(effectiveInnerMin);
+  const innerMaxRatio = ratioOf(effectiveInnerMax);
+
+  return (
+    <div
+      className={clsx(
+        styles["elm-slider"],
+        isVertical && styles.vertical,
+        disabled && styles.disabled,
+        className,
+      )}
+      style={
+        {
+          "--elmethis-scoped-value-ratio": valueRatio,
+          "--elmethis-scoped-inner-min-ratio": innerMinRatio,
+          "--elmethis-scoped-inner-max-ratio": innerMaxRatio,
+          ...style,
+        } as CSSProperties
+      }
+    >
+      <div
+        // `rest` (aria-label, id, data-*, ...) belongs on the interactive
+        // element itself, not this layout wrapper — this component IS a
+        // slider, unlike e.g. ElmAudioPlayer where the root is a larger
+        // widget and the `role="slider"` seek bar is just one control in it.
+        {...rest}
+        ref={trackRef}
+        className={styles.track}
+        role="slider"
+        tabIndex={disabled ? -1 : 0}
+        aria-orientation={orientation}
+        aria-valuemin={effectiveInnerMin}
+        aria-valuemax={effectiveInnerMax}
+        aria-valuenow={displayValue}
+        aria-disabled={disabled || undefined}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onKeyDown={handleKeyDown}
+      >
+        <div className={styles.rail} aria-hidden="true">
+          <div className={styles["restricted-start"]} />
+          <div className={styles.fill} />
+          <div className={styles["restricted-end"]} />
+        </div>
+
+        {marks.length > 0 && (
+          <div className={styles.marks} aria-hidden="true">
+            {marks.map((mark) => (
+              <span
+                key={mark.value}
+                className={clsx(
+                  styles.mark,
+                  (mark.value < effectiveInnerMin ||
+                    mark.value > effectiveInnerMax) &&
+                    styles["mark-restricted"],
+                )}
+                style={
+                  {
+                    "--elmethis-scoped-marker-ratio": mark.ratio,
+                  } as CSSProperties
+                }
+              >
+                {markers && <i className={styles.tick} />}
+                {markerLabels && (
+                  <span className={styles["mark-label"]}>
+                    {formatMarkerLabel?.(mark.value) ?? mark.value}
+                  </span>
+                )}
+              </span>
+            ))}
+          </div>
+        )}
+
+        <span className={styles.thumb} aria-hidden="true" />
+      </div>
+    </div>
+  );
+};

--- a/packages/react/src/components/form/elm-slider.tsx
+++ b/packages/react/src/components/form/elm-slider.tsx
@@ -1,4 +1,5 @@
 import {
+  isValidElement,
   useCallback,
   useMemo,
   useRef,
@@ -114,6 +115,27 @@ const preciseRound = (n: number) => Math.round(n * 1e9) / 1e9;
 // pairs a tiny `step` with a wide `[min, max]`.
 const MAX_MARKERS = 500;
 
+// `formatMarkerLabel` is typed to return an arbitrary `ReactNode` (elements,
+// fragments, arrays, ...), not just a string/number — so measuring its length
+// can't rely on `typeof`. Recursively concatenate the actual rendered text
+// (an element's text length is its children's, not its own) so a
+// JSX-returning formatter is measured by what it actually renders, not by a
+// `String(mark.value)` fallback that ignores the formatter entirely.
+const reactNodeToText = (node: ReactNode): string => {
+  if (node === null || node === undefined || typeof node === "boolean") {
+    return "";
+  }
+  if (typeof node === "string") return node;
+  if (typeof node === "number") return String(node);
+  if (Array.isArray(node)) return node.map(reactNodeToText).join("");
+  if (isValidElement(node)) {
+    return reactNodeToText((node.props as { children?: ReactNode }).children);
+  }
+  // Fragments/iterables/portals and anything else we can't statically
+  // measure — better to under-report nothing extra than to throw.
+  return "";
+};
+
 export const ElmSlider = ({
   className,
   style,
@@ -130,26 +152,72 @@ export const ElmSlider = ({
   markers,
   markerLabels,
   formatMarkerLabel,
+  onKeyDown,
+  onPointerDown,
+  onPointerMove,
   ...rest
 }: ElmSliderProps) => {
   const trackRef = useRef<HTMLDivElement>(null);
   const isVertical = orientation === "vertical";
 
-  const effectiveInnerMin = clamp(innerMin ?? min, min, max);
-  const effectiveInnerMax = clamp(innerMax ?? max, effectiveInnerMin, max);
+  // `clamp` assumes `lo <= hi`. `min`/`max` alone can't be passed straight
+  // through as `[lo, hi]` because a reversed range (`min > max`, a
+  // legitimate declining track — see `ratioOf`, which already handles it via
+  // plain interpolation) would silently force both inner bounds down to
+  // `max` instead of clamping into the declared range. Sort once so the
+  // inner bounds are always resolved against the *logical* [low, high]
+  // regardless of which of `min`/`max` is numerically larger. The *default*
+  // for an omitted innerMin/innerMax must default to this same logical
+  // [low, high] span too (not the raw `min`/`max`) — otherwise, for a
+  // reversed range, the default innerMax (raw `max`, the smaller number)
+  // sits below `rangeLow`/the default innerMin and gets clamped *up* to it
+  // instead of down to the range's actual high end, collapsing the whole
+  // track to a single point.
+  const rangeLow = Math.min(min, max);
+  const rangeHigh = Math.max(min, max);
+  const effectiveInnerMin = clamp(innerMin ?? rangeLow, rangeLow, rangeHigh);
+  const effectiveInnerMax = clamp(
+    innerMax ?? rangeHigh,
+    effectiveInnerMin,
+    rangeHigh,
+  );
 
   const snap = useCallback(
     (raw: number) => {
+      // `step` is a granularity, not a direction — mirror the keyboard
+      // handler's `Math.abs(step)` so a negative step still quantizes
+      // (only `step === 0` means "no snapping").
+      const magnitude = Math.abs(step);
       const stepped =
-        step > 0 ? min + Math.round((raw - min) / step) * step : raw;
+        magnitude > 0
+          ? min + Math.round((raw - min) / magnitude) * magnitude
+          : raw;
       return clamp(preciseRound(stepped), effectiveInnerMin, effectiveInnerMax);
     },
     [min, step, effectiveInnerMin, effectiveInnerMax],
   );
 
+  // Unlike `snap`, this does NOT re-quantize onto a grid anchored at `min` —
+  // it clamps a value that has already moved by exactly `delta` from the
+  // current value. Used for keyboard stepping, where the current value may
+  // legitimately be off-grid (a persisted preference, or an inner bound that
+  // doesn't itself sit on the step grid) and a single key press must change
+  // the value by exactly one step, not snap it onto the nearest grid line.
+  const clampValue = useCallback(
+    (raw: number) =>
+      clamp(preciseRound(raw), effectiveInnerMin, effectiveInnerMax),
+    [effectiveInnerMin, effectiveInnerMax],
+  );
+
   const [currentValue, setCurrentValue] = useBindableSignal<number>({
     value,
-    defaultValue: snap(
+    // Unlike pointer/keyboard-driven moves, the initial seed is not something
+    // the user is actively snapping onto a grid — it's either a caller's
+    // explicit, possibly-off-grid `defaultValue` (e.g. a persisted
+    // preference) or the documented midpoint default. Both must be honored
+    // verbatim, exactly like a controlled `value` is preserved off-grid
+    // elsewhere in this file — so only clamp into range here, don't `snap()`.
+    defaultValue: clampValue(
       defaultValue ?? (effectiveInnerMin + effectiveInnerMax) / 2,
     ),
     onChange: onValueChange,
@@ -195,30 +263,45 @@ export const ElmSlider = ({
     [disabled, setCurrentValue, valueFromPointer],
   );
 
+  // A controlling parent owns `currentValue` and may pass one outside the
+  // inner range (e.g. set before `innerMin`/`innerMax` were added) — clamp
+  // only for display so `aria-valuenow` and the thumb never report/render
+  // outside the declared bounds, without calling `onValueChange` ourselves.
+  const displayValue = clamp(
+    currentValue,
+    effectiveInnerMin,
+    effectiveInnerMax,
+  );
+
   const handleKeyDown = useCallback(
     (event: ReactKeyboardEvent<HTMLDivElement>) => {
       if (disabled) return;
       // `step` is a granularity, not a direction — a caller-supplied negative
       // step must not reverse which arrow key increases the value.
       const delta = Math.abs(step);
+      // Step relative to `displayValue` (what aria-valuenow actually
+      // reports), not the raw `currentValue` — a controlling parent may pass
+      // a value outside the inner range, and stepping from the raw value
+      // would silently re-absorb into the same clamped display value instead
+      // of moving by one step.
       switch (event.key) {
         case "ArrowRight":
         case "ArrowUp":
           event.preventDefault();
-          setCurrentValue((prev) => snap(prev + delta));
+          setCurrentValue(clampValue(displayValue + delta));
           break;
         case "ArrowLeft":
         case "ArrowDown":
           event.preventDefault();
-          setCurrentValue((prev) => snap(prev - delta));
+          setCurrentValue(clampValue(displayValue - delta));
           break;
         case "PageUp":
           event.preventDefault();
-          setCurrentValue((prev) => snap(prev + delta * 10));
+          setCurrentValue(clampValue(displayValue + delta * 10));
           break;
         case "PageDown":
           event.preventDefault();
-          setCurrentValue((prev) => snap(prev - delta * 10));
+          setCurrentValue(clampValue(displayValue - delta * 10));
           break;
         case "Home":
           event.preventDefault();
@@ -232,42 +315,74 @@ export const ElmSlider = ({
     },
     [
       disabled,
+      displayValue,
       effectiveInnerMin,
       effectiveInnerMax,
       setCurrentValue,
-      snap,
+      clampValue,
       step,
     ],
   );
 
   const marks = useMemo(() => {
     if (!markers && !markerLabels) return [];
-    if (step <= 0 || max <= min) return [];
-    // `Math.round` (not `Math.floor`) absorbs float dust in (max-min)/step
-    // (e.g. 0.3/0.1 -> 2.9999999999999996, which must count as 3).
-    const realCount = Math.round((max - min) / step);
-    // Past MAX_MARKERS, evenly resample across the full range instead of
-    // rendering only the first MAX_MARKERS real step-ticks — otherwise a tiny
-    // step over a wide range clusters every rendered tick near `min`.
-    const count = Math.min(realCount, MAX_MARKERS);
-    const tickStep = (max - min) / count;
+    // `step` is a granularity, not a direction — mirror `snap()` and the
+    // keyboard handler's `Math.abs(step)` so a negative step still renders
+    // ticks (only `step === 0` or an empty range means "no ticks").
+    const magnitude = Math.abs(step);
+    if (magnitude <= 0 || max <= min) return [];
+    // `preciseRound` absorbs float dust in (max-min)/step (e.g.
+    // 0.3/0.1 -> 2.9999999999999996, which must count as 3) without
+    // rounding a genuine fraction up to the next integer (e.g.
+    // 10/6 -> 1.6666666666666667 must floor to 1, not round up to 2 and
+    // generate a tick beyond `max`).
+    const realCount = Math.floor(preciseRound((max - min) / magnitude));
     const out: { value: number; ratio: number }[] = [];
-    for (let i = 0; i <= count; i++) {
-      const v = i === count ? max : preciseRound(min + i * tickStep);
-      out.push({ value: v, ratio: ratioOf(v) });
+    if (realCount <= MAX_MARKERS) {
+      // Tick every real step — these are exactly the values `snap()` can
+      // ever produce — then force a trailing tick at `max` if `step`
+      // doesn't divide `max - min` evenly.
+      for (let i = 0; i <= realCount; i++) {
+        const v = preciseRound(min + i * magnitude);
+        out.push({ value: v, ratio: ratioOf(v) });
+      }
+      if (preciseRound(min + realCount * magnitude) !== preciseRound(max)) {
+        out.push({ value: max, ratio: ratioOf(max) });
+      }
+    } else {
+      // Past MAX_MARKERS, evenly resample across the full range instead of
+      // rendering only the first MAX_MARKERS real step-ticks — otherwise a
+      // tiny step over a wide range clusters every rendered tick near
+      // `min`. These resampled ticks are cosmetic only (not all of them are
+      // reachable by `snap()`), which is an acceptable trade-off once there
+      // are too many real ticks to render individually.
+      const tickStep = (max - min) / MAX_MARKERS;
+      for (let i = 0; i <= MAX_MARKERS; i++) {
+        const v = i === MAX_MARKERS ? max : preciseRound(min + i * tickStep);
+        out.push({ value: v, ratio: ratioOf(v) });
+      }
     }
     return out;
   }, [markers, markerLabels, step, min, max, ratioOf]);
 
-  // A controlling parent owns `currentValue` and may pass one outside the
-  // inner range (e.g. set before `innerMin`/`innerMax` were added) — clamp
-  // only for display so `aria-valuenow` and the thumb never report/render
-  // outside the declared bounds, without calling `onValueChange` ourselves.
-  const displayValue = clamp(
-    currentValue,
-    effectiveInnerMin,
-    effectiveInnerMax,
-  );
+  // `.vertical.has-marker-labels` reserves `padding-right` to fit the
+  // tick, the gap, and the label itself — but the label's *width* scales
+  // with its character count (unlike the horizontal orientation, where the
+  // reserved `padding-block-end` only ever needs a label's roughly-constant
+  // line-height). Measure the longest rendered label so the CSS can size the
+  // reservation to it via `ch` (exact for `.mark-label`'s monospace font)
+  // instead of a fixed constant that only fits short labels.
+  const maxMarkerLabelChars = useMemo(() => {
+    if (!markerLabels) return 0;
+    let max = 0;
+    for (const mark of marks) {
+      const rendered = formatMarkerLabel?.(mark.value) ?? mark.value;
+      const text = reactNodeToText(rendered);
+      if (text.length > max) max = text.length;
+    }
+    return max;
+  }, [markerLabels, marks, formatMarkerLabel]);
+
   const valueRatio = ratioOf(displayValue);
   const innerMinRatio = ratioOf(effectiveInnerMin);
   const innerMaxRatio = ratioOf(effectiveInnerMax);
@@ -278,6 +393,14 @@ export const ElmSlider = ({
         styles["elm-slider"],
         isVertical && styles.vertical,
         disabled && styles.disabled,
+        // `.marks`/`.mark`/`.mark-label` are `position: absolute` so they can
+        // overlay tick positions without disturbing the track's flex layout
+        // — but that also means they never contribute to `.track`'s or this
+        // element's own box size. Reserve the space explicitly so the tick
+        // and label row renders inside the slider's box instead of bleeding
+        // past its bottom (or, in vertical orientation, its inline-end) edge.
+        markers && styles["has-markers"],
+        markerLabels && styles["has-marker-labels"],
         className,
       )}
       style={
@@ -285,6 +408,7 @@ export const ElmSlider = ({
           "--elmethis-scoped-value-ratio": valueRatio,
           "--elmethis-scoped-inner-min-ratio": innerMinRatio,
           "--elmethis-scoped-inner-max-ratio": innerMaxRatio,
+          "--elmethis-scoped-max-marker-label-chars": maxMarkerLabelChars,
           ...style,
         } as CSSProperties
       }
@@ -294,19 +418,31 @@ export const ElmSlider = ({
         // element itself, not this layout wrapper — this component IS a
         // slider, unlike e.g. ElmAudioPlayer where the root is a larger
         // widget and the `role="slider"` seek bar is just one control in it.
+        tabIndex={disabled ? -1 : 0}
         {...rest}
         ref={trackRef}
         className={styles.track}
         role="slider"
-        tabIndex={disabled ? -1 : 0}
         aria-orientation={orientation}
         aria-valuemin={effectiveInnerMin}
         aria-valuemax={effectiveInnerMax}
         aria-valuenow={displayValue}
         aria-disabled={disabled || undefined}
-        onPointerDown={handlePointerDown}
-        onPointerMove={handlePointerMove}
-        onKeyDown={handleKeyDown}
+        onPointerDown={(event) => {
+          handlePointerDown(event);
+          if (disabled) return;
+          onPointerDown?.(event);
+        }}
+        onPointerMove={(event) => {
+          handlePointerMove(event);
+          if (disabled) return;
+          onPointerMove?.(event);
+        }}
+        onKeyDown={(event) => {
+          handleKeyDown(event);
+          if (disabled) return;
+          onKeyDown?.(event);
+        }}
       >
         <div className={styles.rail} aria-hidden="true">
           <div className={styles["restricted-start"]} />
@@ -316,11 +452,17 @@ export const ElmSlider = ({
 
         {marks.length > 0 && (
           <div className={styles.marks} aria-hidden="true">
-            {marks.map((mark) => (
+            {marks.map((mark, index) => (
               <span
                 key={mark.value}
                 className={clsx(
                   styles.mark,
+                  // The default transform centers the tick/label on the
+                  // marker's position, which pushes the first/last label
+                  // half its own width past the track's start/end edge.
+                  // Clamp those two to align inward instead of centering.
+                  index === 0 && styles["mark-start"],
+                  index === marks.length - 1 && styles["mark-end"],
                   (mark.value < effectiveInnerMin ||
                     mark.value > effectiveInnerMax) &&
                     styles["mark-restricted"],

--- a/packages/react/src/components/form/elm-slider.tsx
+++ b/packages/react/src/components/form/elm-slider.tsx
@@ -330,23 +330,30 @@ export const ElmSlider = ({
     // keyboard handler's `Math.abs(step)` so a negative step still renders
     // ticks (only `step === 0` or an empty range means "no ticks").
     const magnitude = Math.abs(step);
-    if (magnitude <= 0 || max <= min) return [];
+    // `max === min` is the only genuinely empty range (mirrors `ratioOf`'s
+    // own `max === min` check) — `max < min` is a legitimate reversed/
+    // declining track (see the `rangeLow`/`rangeHigh` handling above) and
+    // must still produce ticks, just walking down from `min` to `max`.
+    if (magnitude <= 0 || max === min) return [];
+    // The real step grid walks from `min` toward `max`, so the per-tick
+    // increment must carry `max - min`'s sign, not just its magnitude.
+    const signedStep = max > min ? magnitude : -magnitude;
     // `preciseRound` absorbs float dust in (max-min)/step (e.g.
     // 0.3/0.1 -> 2.9999999999999996, which must count as 3) without
     // rounding a genuine fraction up to the next integer (e.g.
     // 10/6 -> 1.6666666666666667 must floor to 1, not round up to 2 and
     // generate a tick beyond `max`).
-    const realCount = Math.floor(preciseRound((max - min) / magnitude));
+    const realCount = Math.floor(preciseRound(Math.abs(max - min) / magnitude));
     const out: { value: number; ratio: number }[] = [];
     if (realCount <= MAX_MARKERS) {
       // Tick every real step — these are exactly the values `snap()` can
       // ever produce — then force a trailing tick at `max` if `step`
       // doesn't divide `max - min` evenly.
       for (let i = 0; i <= realCount; i++) {
-        const v = preciseRound(min + i * magnitude);
+        const v = preciseRound(min + i * signedStep);
         out.push({ value: v, ratio: ratioOf(v) });
       }
-      if (preciseRound(min + realCount * magnitude) !== preciseRound(max)) {
+      if (preciseRound(min + realCount * signedStep) !== preciseRound(max)) {
         out.push({ value: max, ratio: ratioOf(max) });
       }
     } else {

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -92,6 +92,11 @@ export {
   type ElmSelectOption,
   type ElmSelectProps,
 } from "./components/form/elm-select";
+export {
+  ElmSlider,
+  type ElmSliderOrientation,
+  type ElmSliderProps,
+} from "./components/form/elm-slider";
 export { ElmSwitch, type ElmSwitchProps } from "./components/form/elm-switch";
 export {
   ElmTextArea,

--- a/packages/vue/src/components/form/elm-slider.browser.spec.tsx
+++ b/packages/vue/src/components/form/elm-slider.browser.spec.tsx
@@ -1,0 +1,252 @@
+// Real `@elmethis/core` tokens (incl. the monospace font stack `.mark-label`
+// uses) so label widths in this file's regression tests reflect the actual
+// rendered font metrics instead of the browser's default serif fallback.
+import "@elmethis/core/tokens.css";
+import { render } from "vitest-browser-vue";
+import { defineComponent, h } from "vue";
+import { describe, expect, test } from "vitest";
+
+import { ElmSlider, type ElmSliderProps } from "./elm-slider";
+
+// happy-dom has no layout engine, so `getBoundingClientRect()` always reports
+// a zero-sized box — pointer-driven dragging (ratio-from-position math) can
+// only be exercised against a real Chromium layout, hence this lives here
+// rather than in the unit spec.
+
+const harness = (props: ElmSliderProps) =>
+  defineComponent({ setup: () => () => h(ElmSlider, props) });
+
+type Screen = ReturnType<typeof render>;
+const root = (screen: Screen) => screen.container as HTMLElement;
+const sliderEl = (screen: Screen) =>
+  root(screen).querySelector('[role="slider"]') as HTMLElement;
+
+describe("[CSR] ElmSlider pointer interaction", () => {
+  test("clicking the track sets the value proportionally to the click position", async () => {
+    const screen = render(harness({ min: 0, max: 100, step: 1 }));
+    const el = sliderEl(screen);
+    el.style.width = "200px";
+
+    const rect = el.getBoundingClientRect();
+    el.dispatchEvent(
+      new PointerEvent("pointerdown", {
+        bubbles: true,
+        clientX: rect.left + rect.width * 0.75,
+        pointerId: 1,
+      }),
+    );
+
+    await expect
+      .poll(() => Number(el.getAttribute("aria-valuenow")))
+      .toBeGreaterThanOrEqual(70);
+  });
+
+  test("dragging past innerMax clamps the value at the inner bound", async () => {
+    const screen = render(
+      harness({ min: 0, max: 100, innerMin: 20, innerMax: 80 }),
+    );
+    const el = sliderEl(screen);
+    el.style.width = "200px";
+
+    const rect = el.getBoundingClientRect();
+    el.dispatchEvent(
+      new PointerEvent("pointerdown", {
+        bubbles: true,
+        clientX: rect.right,
+        pointerId: 1,
+      }),
+    );
+
+    await expect.poll(() => Number(el.getAttribute("aria-valuenow"))).toBe(80);
+  });
+
+  test("vertical orientation increases the value toward the top of the track", async () => {
+    const screen = render(
+      harness({ min: 0, max: 100, orientation: "vertical" }),
+    );
+    const el = sliderEl(screen);
+    el.style.height = "200px";
+
+    const rect = el.getBoundingClientRect();
+    el.dispatchEvent(
+      new PointerEvent("pointerdown", {
+        bubbles: true,
+        clientY: rect.top + rect.height * 0.1,
+        pointerId: 1,
+      }),
+    );
+
+    await expect
+      .poll(() => Number(el.getAttribute("aria-valuenow")))
+      .toBeGreaterThanOrEqual(80);
+  });
+});
+
+describe("[CSR] ElmSlider — layout & CSS regressions", () => {
+  test("vertical: the progress fill renders with non-zero width", async () => {
+    const screen = render(
+      harness({ min: 0, max: 100, orientation: "vertical", defaultValue: 70 }),
+    );
+    const fill = root(screen).querySelector('[class*="fill"]') as HTMLElement;
+
+    await expect
+      .poll(() => fill.getBoundingClientRect().width)
+      .toBeGreaterThan(0);
+  });
+
+  test("vertical: the progress fill spans the rail's full cross-axis width", async () => {
+    const screen = render(
+      harness({ min: 0, max: 100, orientation: "vertical", defaultValue: 70 }),
+    );
+    const fill = root(screen).querySelector('[class*="fill"]') as HTMLElement;
+    const rail = root(screen).querySelector('[class*="rail"]') as HTMLElement;
+
+    // The vertical fill's *length* (height) represents progress, the way the
+    // horizontal fill's *length* (width) does — its cross-axis thickness
+    // (width) must match the rail's, not shrink toward 0 as value approaches
+    // innerMin.
+    await expect
+      .poll(() => fill.getBoundingClientRect().width)
+      .toBeCloseTo(rail.getBoundingClientRect().width, 1);
+  });
+
+  test("pointerdown snaps to the step grid when step is negative", async () => {
+    // Keyboard stepping treats `step` as a granularity via `Math.abs(step)`,
+    // so ArrowRight/PageUp move in multiples of 10 even when step is -10.
+    // Pointer-driven clicks must snap to the same grid.
+    const screen = render(harness({ min: 0, max: 100, step: -10 }));
+    const el = sliderEl(screen);
+    el.style.width = "200px";
+
+    const rect = el.getBoundingClientRect();
+    el.dispatchEvent(
+      new PointerEvent("pointerdown", {
+        bubbles: true,
+        clientX: rect.left + rect.width * 0.53,
+        pointerId: 1,
+      }),
+    );
+
+    await expect
+      .poll(() => Number(el.getAttribute("aria-valuenow")) % 10)
+      .toBe(0);
+  });
+
+  test("markerLabels: the wrapper reserves layout space so labels render inside its own box", async () => {
+    // `.track` has a fixed height with no space reserved for `.marks`, and
+    // `.marks`/`.mark`/`.mark-label` are all `position: absolute`, so they
+    // never contribute to `.track`'s or `.elm-slider`'s box size. The label
+    // row must render inside the wrapper's own bottom edge.
+    const screen = render(
+      harness({
+        min: 0,
+        max: 100,
+        step: 25,
+        markers: true,
+        markerLabels: true,
+      }),
+    );
+    const wrapper = root(screen).querySelector(
+      '[class*="elm-slider"]',
+    ) as HTMLElement;
+    wrapper.style.width = "300px";
+    const labels = root(screen).querySelectorAll('[class*="mark-label"]');
+    expect(labels.length).toBeGreaterThan(0);
+
+    const wrapperRect = wrapper.getBoundingClientRect();
+    for (const label of labels) {
+      const labelRect = label.getBoundingClientRect();
+      expect(labelRect.bottom).toBeLessThanOrEqual(wrapperRect.bottom);
+    }
+  });
+
+  test("vertical + markerLabels: wide (5-digit) labels still render inside the wrapper's inline-end edge", async () => {
+    // `.vertical.has-marker-labels` reserves a padding sized dynamically via
+    // `--elmethis-scoped-max-marker-label-chars`. A range whose marker labels
+    // reach 4+ digits (e.g. 25000, 100000) must still render inside the
+    // wrapper's own edge instead of spilling past it.
+    const screen = render(
+      harness({
+        orientation: "vertical",
+        min: 0,
+        max: 100000,
+        step: 25000,
+        markers: true,
+        markerLabels: true,
+      }),
+    );
+    const wrapper = root(screen).querySelector(
+      '[class*="elm-slider"]',
+    ) as HTMLElement;
+    const labels = root(screen).querySelectorAll('[class*="mark-label"]');
+    expect(labels.length).toBeGreaterThan(0);
+
+    const wrapperRect = wrapper.getBoundingClientRect();
+    for (const label of labels) {
+      const labelRect = label.getBoundingClientRect();
+      expect(labelRect.right).toBeLessThanOrEqual(wrapperRect.right);
+    }
+  });
+
+  test("vertical + markerLabels under dir=rtl: wide (5-digit) labels still render inside the wrapper's own edge", async () => {
+    // `.vertical.has-marker-labels` reserves its budget via a physical
+    // `padding-right` on purpose: `.vertical .mark`'s positioning is all
+    // physical (direction-agnostic), rendering on the physical right
+    // regardless of `dir`. Under RTL the reserved space must still protect
+    // the labels rather than sitting uselessly on the opposite side.
+    const RtlWrapper = defineComponent({
+      setup: () => () =>
+        h("div", { dir: "rtl" }, [
+          h(ElmSlider, {
+            orientation: "vertical",
+            min: 0,
+            max: 100000,
+            step: 25000,
+            markers: true,
+            markerLabels: true,
+          }),
+        ]),
+    });
+
+    const screen = render(RtlWrapper);
+    const wrapper = root(screen).querySelector(
+      '[class*="elm-slider"]',
+    ) as HTMLElement;
+    const labels = root(screen).querySelectorAll('[class*="mark-label"]');
+    expect(labels.length).toBeGreaterThan(0);
+
+    const wrapperRect = wrapper.getBoundingClientRect();
+    for (const label of labels) {
+      const labelRect = label.getBoundingClientRect();
+      expect(labelRect.right).toBeLessThanOrEqual(wrapperRect.right);
+    }
+  });
+
+  test("vertical: the max-value mark sits flush with the track's top edge", async () => {
+    // `.vertical .mark-start` cancels the default centering translate so its
+    // untransformed box (already flush with the track's bottom, via
+    // `bottom: 0%`) stays flush at the bottom. `.vertical .mark-end`'s
+    // untransformed box (via `bottom: 100%`) sits one row-height above the
+    // track's top edge, so it needs a `+100%` Y-translate to bring it down
+    // flush with the top edge.
+    const screen = render(
+      harness({
+        orientation: "vertical",
+        min: 0,
+        max: 10,
+        step: 1,
+        markers: true,
+        markerLabels: true,
+      }),
+    );
+    const track = root(screen).querySelector('[class*="track"]') as HTMLElement;
+    const markEnd = root(screen).querySelector(
+      '[class*="mark-end"]',
+    ) as HTMLElement;
+
+    const trackRect = track.getBoundingClientRect();
+    const markEndRect = markEnd.getBoundingClientRect();
+
+    expect(Math.abs(markEndRect.top - trackRect.top)).toBeLessThan(2);
+  });
+});

--- a/packages/vue/src/components/form/elm-slider.module.css
+++ b/packages/vue/src/components/form/elm-slider.module.css
@@ -1,0 +1,301 @@
+.elm-slider {
+  box-sizing: border-box;
+  width: 100%;
+  margin-block-start: var(--elmethis-margin-block-start);
+  user-select: none;
+}
+
+.elm-slider.vertical {
+  width: fit-content;
+  height: 12rem;
+}
+
+.elm-slider.disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+/* ---- Track ---------------------------------------------------------------- */
+
+/* A roomy hit area so the thin rail stays easy to grab/tap. */
+.track {
+  position: relative;
+  width: 100%;
+  height: 1.25rem;
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  touch-action: none;
+}
+
+.vertical .track {
+  flex-direction: column;
+  width: 1.25rem;
+  height: 100%;
+}
+
+.disabled .track {
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+.track:focus-visible {
+  outline: 2px solid var(--elmethis-color-primary);
+  outline-offset: 4px;
+  border-radius: 0.25rem;
+}
+
+.rail {
+  position: relative;
+  width: 100%;
+  height: 0.25rem;
+  border-radius: 999px;
+  background-color: var(--elmethis-color-neutral-weak);
+  overflow: hidden;
+}
+
+.vertical .rail {
+  width: 0.25rem;
+  height: 100%;
+}
+
+/* Regions of the track outside [innerMin, innerMax] — visually unreachable. */
+.restricted-start,
+.restricted-end {
+  position: absolute;
+  background-color: var(--elmethis-color-neutral-weak);
+  background-image: repeating-linear-gradient(
+    45deg,
+    color-mix(in srgb, var(--elmethis-color-neutral) 35%, transparent) 0,
+    color-mix(in srgb, var(--elmethis-color-neutral) 35%, transparent) 2px,
+    transparent 2px,
+    transparent 6px
+  );
+}
+
+.restricted-start {
+  inset: 0 auto 0 0;
+  width: calc(var(--elmethis-scoped-inner-min-ratio, 0) * 100%);
+}
+
+.restricted-end {
+  inset: 0 0 0 auto;
+  width: calc((1 - var(--elmethis-scoped-inner-max-ratio, 1)) * 100%);
+}
+
+.vertical .restricted-start,
+.vertical .restricted-end {
+  width: auto;
+}
+
+.vertical .restricted-start {
+  inset: auto 0 0;
+  height: calc(var(--elmethis-scoped-inner-min-ratio, 0) * 100%);
+}
+
+.vertical .restricted-end {
+  inset: 0 0 auto;
+  height: calc((1 - var(--elmethis-scoped-inner-max-ratio, 1)) * 100%);
+}
+
+.fill {
+  position: absolute;
+  inset: 0 auto;
+  left: calc(var(--elmethis-scoped-inner-min-ratio, 0) * 100%);
+  width: calc(
+    (
+        var(--elmethis-scoped-value-ratio, 0) -
+          var(--elmethis-scoped-inner-min-ratio, 0)
+      ) *
+      100%
+  );
+  border-radius: 999px;
+  background-color: var(--elmethis-color-primary);
+}
+
+.vertical .fill {
+  inset: auto 0 0;
+  width: auto;
+  bottom: calc(var(--elmethis-scoped-inner-min-ratio, 0) * 100%);
+  height: calc(
+    (
+        var(--elmethis-scoped-value-ratio, 0) -
+          var(--elmethis-scoped-inner-min-ratio, 0)
+      ) *
+      100%
+  );
+}
+
+/* Draggable handle. */
+.thumb {
+  position: absolute;
+  top: 50%;
+  left: calc(var(--elmethis-scoped-value-ratio, 0) * 100%);
+  width: 0.875rem;
+  height: 0.875rem;
+  border-radius: 50%;
+  background-color: var(--elmethis-color-primary-strong);
+  box-shadow: 0 0.125rem 0.375rem -0.0625rem var(--elmethis-box-shadow-color);
+  transform: translate(-50%, -50%);
+  transition: transform 140ms cubic-bezier(0.34, 1.56, 0.64, 1);
+  pointer-events: none;
+}
+
+.vertical .thumb {
+  top: auto;
+  left: 50%;
+  bottom: calc(var(--elmethis-scoped-value-ratio, 0) * 100%);
+  transform: translate(-50%, 50%);
+}
+
+.track:hover .thumb,
+.track:focus-visible .thumb {
+  transform: translate(-50%, -50%) scale(1.2);
+}
+
+.vertical .track:hover .thumb,
+.vertical .track:focus-visible .thumb {
+  transform: translate(-50%, 50%) scale(1.2);
+}
+
+/* ---- Markers ---------------------------------------------------------------- */
+
+/*
+ * `.marks` and its descendants are `position: absolute` so a tick/label can
+ * sit at an arbitrary percentage along the track without disturbing the
+ * track's own flex layout — but that also means none of it ever contributes
+ * to `.track`'s or `.elm-slider`'s box size. Reserve the extra space these
+ * rows need on the element that participates in normal flow (`.elm-slider`),
+ * sized generously enough to fit a tick, the gap, and a label's line box.
+ */
+.elm-slider.has-markers {
+  padding-block-end: 0.5rem;
+}
+
+.elm-slider.has-marker-labels {
+  padding-block-end: 1.75rem;
+}
+
+.elm-slider.vertical.has-markers {
+  padding-block-end: 0;
+
+  /*
+   * Physical, not logical: `.vertical .mark`'s `left: 50%` +
+   * `transform: translate(0.75rem, ...)` (and the tick/label layout that
+   * follows) always render on the physical right regardless of `dir` — they
+   * don't participate in the inline axis at all. A logical
+   * `padding-inline-end` would flip to physical `padding-left` under
+   * `dir="rtl"`, reserving space on the side opposite the one the marks
+   * actually occupy.
+   */
+  padding-right: 0.5rem;
+}
+
+.elm-slider.vertical.has-marker-labels {
+  padding-block-end: 0;
+
+  /*
+   * Unlike the horizontal axis (where the reserved `padding-block-end` only
+   * ever needs to hold a label's roughly-constant line-height), a vertical
+   * label's *width* scales with its character count — a fixed rem constant
+   * only fits short labels and lets 4+ digit values (or wide negative
+   * values) spill past this element's own inline-end edge.
+   *
+   * `0.75rem` covers the fixed part of the offset from the track's
+   * inline-end edge to where the label starts (the mark's own translate
+   * plus the tick + gap that precede the label in `.mark`'s row layout).
+   * The remainder scales with the longest rendered label's character count,
+   * via `1ch` — exact here because `.mark-label` uses a monospace font, so
+   * every character has the same advance width. `font-family`/`font-size`
+   * are set to match `.mark-label` so `ch` resolves against the same font
+   * metrics; this element renders no text of its own, so it doesn't leak
+   * into any child that doesn't set its own font (they all do). The extra
+   * `0.5ch` is a small rounding buffer for subpixel layout drift between
+   * this element's `ch` and the label's own rendered width.
+   *
+   * This is a physical `padding-right`, not the logical `padding-inline-end`
+   * its name suggests it should be: `.vertical .mark`'s `left: 50%` +
+   * `transform: translate(0.75rem, ...)` (and everything downstream of it —
+   * the tick, the gap, the label) render on the physical right regardless of
+   * `dir` — none of it is expressed in logical/inline terms. Reserving the
+   * space with a logical property would flip it to physical `padding-left`
+   * under `dir="rtl"`, leaving the actual marks unprotected on the right.
+   */
+  font-family: var(--elmethis-font-family-monospace);
+  font-size: 0.7rem;
+  padding-right: calc(
+    0.75rem + (var(--elmethis-scoped-max-marker-label-chars, 4) + 0.5) * 1ch
+  );
+}
+
+.marks {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.mark {
+  position: absolute;
+  top: 50%;
+  left: calc(var(--elmethis-scoped-marker-ratio, 0) * 100%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+  transform: translate(-50%, 0.75rem);
+}
+
+.vertical .mark {
+  top: auto;
+  left: 50%;
+  bottom: calc(var(--elmethis-scoped-marker-ratio, 0) * 100%);
+  flex-direction: row;
+  transform: translate(0.75rem, 50%);
+}
+
+/* The default transform centers a tick/label on its marker position, which
+   pushes the first/last mark half its own size past the track's start/end
+   edge. Align those two inward instead of centering them. */
+.mark-start {
+  transform: translate(0, 0.75rem);
+}
+
+.mark-end {
+  transform: translate(-100%, 0.75rem);
+}
+
+.vertical .mark-start {
+  transform: translate(0.75rem, 0);
+}
+
+.vertical .mark-end {
+  transform: translate(0.75rem, 100%);
+}
+
+.tick {
+  width: 0.125rem;
+  height: 0.375rem;
+  border-radius: 999px;
+  background-color: var(--elmethis-color-neutral);
+  font-style: normal;
+}
+
+.vertical .tick {
+  width: 0.375rem;
+  height: 0.125rem;
+}
+
+.mark-restricted .tick {
+  background-color: var(--elmethis-color-neutral-weak);
+}
+
+.mark-label {
+  font-family: var(--elmethis-font-family-monospace);
+  font-size: 0.7rem;
+  color: var(--elmethis-color-neutral);
+  white-space: nowrap;
+}
+
+.mark-restricted .mark-label {
+  opacity: 0.6;
+}

--- a/packages/vue/src/components/form/elm-slider.spec.tsx
+++ b/packages/vue/src/components/form/elm-slider.spec.tsx
@@ -285,6 +285,23 @@ describe("[CSR] ElmSlider — hardened edge cases", () => {
     expect(slider(wrapper).getAttribute("aria-label")).toBe("Volume");
   });
 
+  it("applies a caller-supplied class/style to the outer wrapper, not the inner track", () => {
+    const wrapper = mount(ElmSlider, {
+      attrs: { class: "my-class", style: { margin: "1rem" } },
+    });
+    const outer = wrapper.find('[class*="elm-slider"]').element as HTMLElement;
+    const track = slider(wrapper);
+
+    // Mirrors the React port: `className`/`style` land on the outer
+    // `.elm-slider` wrapper, exactly like `rest` (aria-label, data-*, ...)
+    // lands on the inner track.
+    expect(outer.classList.contains("my-class")).toBe(true);
+    expect(outer.style.margin).toBe("1rem");
+
+    expect(track.classList.contains("my-class")).toBe(false);
+    expect(track.style.margin).toBe("");
+  });
+
   it("renders tick/label values on the actual step grid, not an evenly-resampled one", () => {
     const wrapper = mount(ElmSlider, {
       props: { min: 0, max: 10, step: 3, markers: true, markerLabels: true },
@@ -387,6 +404,24 @@ describe("[CSR] ElmSlider — hardened edge cases", () => {
     expect(el.getAttribute("aria-valuenow")).toBe("79");
   });
 
+  it("does not let a caller-supplied aria-valuenow (via attrs) override the slider's own computed value", () => {
+    // `attrs` (aria-valuenow, role, aria-orientation, aria-valuemin/max,
+    // aria-disabled, ...) is fallthrough content spread onto the track
+    // element — it must never be able to overwrite the slider's own
+    // internally-computed ARIA state, which is what actually reflects the
+    // real, current value/orientation/bounds.
+    const wrapper = mount(ElmSlider, {
+      props: { defaultValue: 50 },
+      attrs: { "aria-valuenow": 999, role: "button" },
+    });
+    const el = wrapper.element.querySelector(
+      "[aria-orientation]",
+    ) as HTMLElement;
+
+    expect(el.getAttribute("role")).toBe("slider");
+    expect(el.getAttribute("aria-valuenow")).toBe("50");
+  });
+
   it("respects a caller-supplied tabindex instead of forcing it from `disabled`", () => {
     const wrapper = mount(ElmSlider, { attrs: { tabindex: -1 } });
     const el = slider(wrapper);
@@ -420,12 +455,13 @@ describe("[CSR] ElmSlider — hardened edge cases", () => {
     expect(el.getAttribute("aria-valuenow")).toBe("51");
   });
 
-  it("still invokes a caller-supplied onKeydown (via attrs) when disabled, but the internal step stays gated", async () => {
-    // `mergeProps` composes independent handlers — the internal handler's
-    // own `if (disabled) return` guard has no way to suppress a *different*,
-    // caller-supplied function in the merged array. This mirrors
-    // elm-checkbox's own disabled + attrs-onClick behavior: the internal
-    // action stays gated, but an externally attached handler still fires.
+  it("does not invoke a caller-supplied onKeydown (via attrs) when disabled", async () => {
+    // Mirrors the React port's contract (elm-slider.spec.tsx, "does not
+    // invoke a caller-supplied onKeyDown when disabled"): `disabled` must
+    // fully suppress interaction, including a caller-attached handler that
+    // `mergeProps` would otherwise compose in unconditionally. A caller
+    // relying on `disabled` to suppress interaction (e.g. analytics, a
+    // toast) must not see it fire.
     const onKeydownSpy = vi.fn();
     const wrapper = mount(ElmSlider, {
       props: { defaultValue: 50, disabled: true },
@@ -437,7 +473,7 @@ describe("[CSR] ElmSlider — hardened edge cases", () => {
       new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }),
     );
 
-    expect(onKeydownSpy).toHaveBeenCalledTimes(1);
+    expect(onKeydownSpy).not.toHaveBeenCalled();
     expect(el.getAttribute("aria-valuenow")).toBe("50");
   });
 

--- a/packages/vue/src/components/form/elm-slider.spec.tsx
+++ b/packages/vue/src/components/form/elm-slider.spec.tsx
@@ -1,0 +1,504 @@
+import { describe, it, expect, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import { createSSRApp, defineComponent, h, ref } from "vue";
+import { renderToString } from "vue/server-renderer";
+
+import { ElmSlider } from "./elm-slider";
+
+const slider = (wrapper: { element: Element }) =>
+  wrapper.element.querySelector('[role="slider"]') as HTMLElement;
+
+describe("[CSR] ElmSlider — rendering", () => {
+  it("defaults to horizontal, min 0, max 100, midpoint value", () => {
+    const wrapper = mount(ElmSlider);
+    const el = slider(wrapper);
+    expect(el.getAttribute("aria-orientation")).toBe("horizontal");
+    expect(el.getAttribute("aria-valuemin")).toBe("0");
+    expect(el.getAttribute("aria-valuemax")).toBe("100");
+    expect(el.getAttribute("aria-valuenow")).toBe("50");
+  });
+
+  it("renders vertical orientation", () => {
+    const wrapper = mount(ElmSlider, {
+      props: { orientation: "vertical" },
+    });
+    expect(slider(wrapper).getAttribute("aria-orientation")).toBe("vertical");
+  });
+
+  it("defaultValue seeds the uncontrolled value", () => {
+    const wrapper = mount(ElmSlider, { props: { defaultValue: 30 } });
+    expect(slider(wrapper).getAttribute("aria-valuenow")).toBe("30");
+  });
+
+  it("clamps aria-valuemin/max to the inner range", () => {
+    const wrapper = mount(ElmSlider, {
+      props: { innerMin: 20, innerMax: 80, defaultValue: 50 },
+    });
+    const el = slider(wrapper);
+    expect(el.getAttribute("aria-valuemin")).toBe("20");
+    expect(el.getAttribute("aria-valuemax")).toBe("80");
+  });
+
+  it("clamps an out-of-inner-range defaultValue on mount", () => {
+    const wrapper = mount(ElmSlider, {
+      props: { innerMin: 20, innerMax: 80, defaultValue: 5 },
+    });
+    expect(slider(wrapper).getAttribute("aria-valuenow")).toBe("20");
+  });
+
+  it("aria-disabled and tabindex reflect the disabled prop", () => {
+    const wrapper = mount(ElmSlider, { props: { disabled: true } });
+    const el = slider(wrapper);
+    expect(el.getAttribute("aria-disabled")).toBe("true");
+    expect(el.getAttribute("tabindex")).toBe("-1");
+  });
+
+  it("renders one tick per step when markers is set", () => {
+    const wrapper = mount(ElmSlider, {
+      props: { min: 0, max: 100, step: 25, markers: true },
+    });
+    // 0, 25, 50, 75, 100
+    expect(wrapper.findAll("i")).toHaveLength(5);
+  });
+
+  it("renders marker labels with the formatted value", () => {
+    const wrapper = mount(ElmSlider, {
+      props: {
+        min: 0,
+        max: 100,
+        step: 50,
+        markers: true,
+        markerLabels: true,
+        formatMarkerLabel: (v: number) => `${v}%`,
+      },
+    });
+    expect(wrapper.text()).toContain("0%");
+    expect(wrapper.text()).toContain("50%");
+    expect(wrapper.text()).toContain("100%");
+  });
+});
+
+describe("[CSR] ElmSlider — keyboard interaction", () => {
+  it("ArrowRight/ArrowUp increases the value by step", async () => {
+    const wrapper = mount(ElmSlider, {
+      props: { defaultValue: 50, step: 5 },
+    });
+    const el = slider(wrapper);
+
+    await el.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }),
+    );
+    expect(el.getAttribute("aria-valuenow")).toBe("55");
+
+    await el.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "ArrowUp", bubbles: true }),
+    );
+    expect(el.getAttribute("aria-valuenow")).toBe("60");
+  });
+
+  it("ArrowLeft/ArrowDown decreases the value by step", async () => {
+    const wrapper = mount(ElmSlider, {
+      props: { defaultValue: 50, step: 5 },
+    });
+    const el = slider(wrapper);
+
+    await el.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "ArrowLeft", bubbles: true }),
+    );
+    expect(el.getAttribute("aria-valuenow")).toBe("45");
+
+    await el.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }),
+    );
+    expect(el.getAttribute("aria-valuenow")).toBe("40");
+  });
+
+  it("Home/End jump to the inner bounds", async () => {
+    const wrapper = mount(ElmSlider, {
+      props: { innerMin: 20, innerMax: 80, defaultValue: 50 },
+    });
+    const el = slider(wrapper);
+
+    await el.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "End", bubbles: true }),
+    );
+    expect(el.getAttribute("aria-valuenow")).toBe("80");
+
+    await el.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Home", bubbles: true }),
+    );
+    expect(el.getAttribute("aria-valuenow")).toBe("20");
+  });
+
+  it("does not move past the inner bounds", async () => {
+    const wrapper = mount(ElmSlider, {
+      props: { innerMin: 0, innerMax: 100, defaultValue: 98, step: 5 },
+    });
+    const el = slider(wrapper);
+
+    await el.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }),
+    );
+    expect(el.getAttribute("aria-valuenow")).toBe("100");
+  });
+
+  it("does not respond to keyboard input when disabled", async () => {
+    const wrapper = mount(ElmSlider, {
+      props: { defaultValue: 50, disabled: true },
+    });
+    const el = slider(wrapper);
+
+    await el.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }),
+    );
+    expect(el.getAttribute("aria-valuenow")).toBe("50");
+  });
+
+  it("writes through to a bound parent value (v-model round trip)", async () => {
+    const Harness = defineComponent({
+      setup() {
+        const value = ref(50);
+        return () =>
+          h("div", [
+            h("output", String(value.value)),
+            h(ElmSlider, {
+              value: value.value,
+              step: 10,
+              "onUpdate:value": (v: number) => (value.value = v),
+            }),
+          ]);
+      },
+    });
+
+    const wrapper = mount(Harness);
+    const el = slider(wrapper);
+
+    await el.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }),
+    );
+
+    expect(wrapper.find("output").text()).toBe("60");
+    expect(el.getAttribute("aria-valuenow")).toBe("60");
+  });
+});
+
+describe("[CSR] ElmSlider — hardened edge cases", () => {
+  it("clamps a controlled value that falls outside the inner range", () => {
+    const wrapper = mount(ElmSlider, {
+      props: {
+        innerMin: 20,
+        innerMax: 80,
+        value: 5,
+        "onUpdate:value": () => {},
+      },
+    });
+    const el = slider(wrapper);
+    expect(Number(el.getAttribute("aria-valuenow"))).toBeGreaterThanOrEqual(20);
+  });
+
+  it("formats marker labels without floating-point dust for a fractional step", () => {
+    const wrapper = mount(ElmSlider, {
+      props: { min: 0, max: 1, step: 0.1, markers: true, markerLabels: true },
+    });
+    // 0 + 3*0.1 drifts to 0.30000000000000004 in JS float math.
+    expect(wrapper.text()).not.toMatch(/0\.30000/);
+  });
+
+  it("does not skip a tick due to floating-point step-count error", () => {
+    const wrapper = mount(ElmSlider, {
+      props: {
+        min: 0,
+        max: 0.3,
+        step: 0.1,
+        markers: true,
+        markerLabels: true,
+      },
+    });
+    const labels = wrapper
+      .findAll('[class*="mark-label"]')
+      .map((el) => el.text());
+    // Expect all 4 ticks: 0, 0.1, 0.2, 0.3. (0.3-0)/0.1 evaluates to
+    // 2.9999999999999996 in JS float math, so Math.floor would undercount
+    // to 2 and drop the "0.2" tick, jumping straight from 0.1 to the forced
+    // max=0.3.
+    expect(labels).toHaveLength(4);
+  });
+
+  it("spans the full range instead of clustering near min when the tick count exceeds MAX_MARKERS", () => {
+    const wrapper = mount(ElmSlider, {
+      props: { min: 0, max: 100, step: 0.01, markers: true },
+    });
+    const marks = wrapper.findAll('[class*="mark"]');
+    const last = marks[marks.length - 1];
+    const lastRatio = Number(
+      (last.element as HTMLElement).style.getPropertyValue(
+        "--elmethis-scoped-marker-ratio",
+      ),
+    );
+    // The capped 501 rendered ticks should still stretch across [min, max].
+    expect(lastRatio).toBeCloseTo(1, 5);
+  });
+
+  it("sizes the vertical label reservation to a vnode-returning formatMarkerLabel's rendered text, not String(value)", () => {
+    const wrapper = mount(ElmSlider, {
+      props: {
+        orientation: "vertical",
+        min: 0,
+        max: 100,
+        step: 25,
+        markers: true,
+        markerLabels: true,
+        formatMarkerLabel: (v: number) => (
+          <strong>{v} units of measurement</strong>
+        ),
+      },
+    });
+    const wrapperEl = wrapper.find('[class*="elm-slider"]')
+      .element as HTMLElement;
+    const chars = Number(
+      wrapperEl.style.getPropertyValue(
+        "--elmethis-scoped-max-marker-label-chars",
+      ),
+    );
+    // "100 units of measurement" is 25 chars; falling back to String(100)
+    // (3 chars) would under-reserve the padding and let the label overflow.
+    expect(chars).toBe("100 units of measurement".length);
+  });
+
+  it("ArrowRight increases the value even when step is negative", async () => {
+    const wrapper = mount(ElmSlider, {
+      props: { defaultValue: 50, step: -10 },
+    });
+    const el = slider(wrapper);
+
+    await el.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }),
+    );
+
+    expect(Number(el.getAttribute("aria-valuenow"))).toBeGreaterThan(50);
+  });
+
+  it("forwards aria-label to the slider element, not an outer wrapper", () => {
+    const wrapper = mount(ElmSlider, {
+      attrs: { "aria-label": "Volume" },
+    });
+    expect(slider(wrapper).getAttribute("aria-label")).toBe("Volume");
+  });
+
+  it("renders tick/label values on the actual step grid, not an evenly-resampled one", () => {
+    const wrapper = mount(ElmSlider, {
+      props: { min: 0, max: 10, step: 3, markers: true, markerLabels: true },
+    });
+    const labels = wrapper
+      .findAll('[class*="mark-label"]')
+      .map((el) => el.text());
+    // step=3 over [0, 10] only ever snaps to 0, 3, 6, 9 (plus the forced
+    // max=10); it must never render 3.3333.../6.6666... ticks the thumb
+    // can never actually reach.
+    expect(labels).toEqual(["0", "3", "6", "9", "10"]);
+  });
+
+  it("does not render an out-of-range tick when (max-min)/step rounds up", () => {
+    const wrapper = mount(ElmSlider, {
+      props: { min: 0, max: 10, step: 6, markers: true, markerLabels: true },
+    });
+    const labels = wrapper
+      .findAll('[class*="mark-label"]')
+      .map((el) => el.text());
+    // (10-0)/6 = 1.666..., which Math.round rounds up to 2, generating a
+    // spurious "12" tick outside [min, max] that overlaps the forced max=10
+    // tick. Only the real step-ticks (0, 6) plus the forced max (10) should
+    // render.
+    expect(labels).toEqual(["0", "6", "10"]);
+  });
+
+  it("moves by exactly one step from an off-grid controlled value", async () => {
+    const onUpdate = vi.fn();
+    const wrapper = mount(ElmSlider, {
+      props: {
+        min: 0,
+        max: 100,
+        step: 10,
+        value: 7,
+        "onUpdate:value": onUpdate,
+      },
+    });
+    const el = slider(wrapper);
+
+    await el.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }),
+    );
+
+    // 7 is a legitimate off-grid controlled value (e.g. a persisted user
+    // preference); a single ArrowRight must move by exactly `step` from the
+    // current value (7 + 10 = 17), not re-quantize onto a grid anchored at
+    // `min` (which would jump to 20).
+    expect(onUpdate).toHaveBeenCalledWith(17);
+  });
+
+  it("seeds the uncontrolled initial value verbatim, without re-quantizing it onto the step grid", () => {
+    // Same off-grid-preservation contract already enforced above for a
+    // controlled `value` must also hold for the uncontrolled seed: an
+    // explicit, legitimately off-grid `defaultValue` (e.g. a persisted
+    // preference) must be honored as-is, not silently rewritten onto a
+    // step-10 grid anchored at `min` (which would produce 10 instead of 7).
+    const withDefault = mount(ElmSlider, {
+      props: { step: 10, defaultValue: 7 },
+    });
+    expect(slider(withDefault).getAttribute("aria-valuenow")).toBe("7");
+
+    // With no `defaultValue` at all, the JSDoc on `defaultValue` and the
+    // Storybook docs both promise the true midpoint of the range
+    // (100 / 2 = 50), not a value re-quantized onto a step-7 grid anchored
+    // at `min` (which would produce 49).
+    const atMidpoint = mount(ElmSlider, { props: { step: 7 } });
+    expect(slider(atMidpoint).getAttribute("aria-valuenow")).toBe("50");
+  });
+
+  it("moves on the first keypress from a controlled value sitting above innerMax", async () => {
+    const Harness = defineComponent({
+      setup() {
+        const value = ref(95);
+        return () =>
+          h(ElmSlider, {
+            min: 0,
+            max: 100,
+            innerMin: 0,
+            innerMax: 80,
+            step: 1,
+            value: value.value,
+            "onUpdate:value": (v: number) => (value.value = v),
+          });
+      },
+    });
+
+    const wrapper = mount(Harness);
+    const el = slider(wrapper);
+
+    // aria-valuenow is correctly clamped for display before any interaction.
+    expect(el.getAttribute("aria-valuenow")).toBe("80");
+
+    // The very first ArrowLeft must decrease the *displayed* value by one
+    // step (80 -> 79), not compute from the raw out-of-range controlled
+    // value (95 -> clampValue(94) = 80, i.e. no visible change).
+    await el.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "ArrowLeft", bubbles: true }),
+    );
+    expect(el.getAttribute("aria-valuenow")).toBe("79");
+  });
+
+  it("respects a caller-supplied tabindex instead of forcing it from `disabled`", () => {
+    const wrapper = mount(ElmSlider, { attrs: { tabindex: -1 } });
+    const el = slider(wrapper);
+
+    // `attrs` is spread onto the track element after its explicit
+    // `tabindex={disabled ? -1 : 0}`, so a caller-supplied `tabindex`
+    // overrides it — even when the caller deliberately opts the slider out
+    // of the tab order (e.g. a roving-tabindex composite widget).
+    expect(el.getAttribute("tabindex")).toBe("-1");
+  });
+
+  it("composes a caller-supplied onKeydown (via attrs) with the slider's own keyboard handling", async () => {
+    // `inheritAttrs: false` + spreading `{...rest}` on the interactive
+    // element, combined with a JSX literal `onKeydown` on the same element,
+    // compiles to Vue's `mergeProps` (see elm-checkbox.tsx / elm-switch.tsx
+    // for the same pattern) — same-named event handlers are *composed*
+    // (both invoked), not silently replaced, unlike plain object-spread
+    // overwrite semantics.
+    const onKeydownSpy = vi.fn();
+    const wrapper = mount(ElmSlider, {
+      props: { defaultValue: 50 },
+      attrs: { onKeydown: onKeydownSpy },
+    });
+    const el = slider(wrapper);
+
+    await el.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }),
+    );
+
+    expect(onKeydownSpy).toHaveBeenCalledTimes(1);
+    expect(el.getAttribute("aria-valuenow")).toBe("51");
+  });
+
+  it("still invokes a caller-supplied onKeydown (via attrs) when disabled, but the internal step stays gated", async () => {
+    // `mergeProps` composes independent handlers — the internal handler's
+    // own `if (disabled) return` guard has no way to suppress a *different*,
+    // caller-supplied function in the merged array. This mirrors
+    // elm-checkbox's own disabled + attrs-onClick behavior: the internal
+    // action stays gated, but an externally attached handler still fires.
+    const onKeydownSpy = vi.fn();
+    const wrapper = mount(ElmSlider, {
+      props: { defaultValue: 50, disabled: true },
+      attrs: { onKeydown: onKeydownSpy },
+    });
+    const el = slider(wrapper);
+
+    await el.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }),
+    );
+
+    expect(onKeydownSpy).toHaveBeenCalledTimes(1);
+    expect(el.getAttribute("aria-valuenow")).toBe("50");
+  });
+
+  it("still renders tick marks when step is negative", () => {
+    const wrapper = mount(ElmSlider, {
+      props: { min: 0, max: 20, step: -4, markers: true },
+    });
+    // `step` is a granularity everywhere else in this component (snap() and
+    // the keyboard handler both use Math.abs(step)) — the marks computed
+    // must treat it the same way instead of early-returning `[]` for a raw
+    // negative step. Expect ticks at 0, 4, 8, 12, 16, 20.
+    const ticks = wrapper.findAll('[class*="tick"]');
+    expect(ticks).toHaveLength(6);
+  });
+
+  it("honors innerMin/innerMax/defaultValue instead of collapsing to max when min > max", async () => {
+    const wrapper = mount(ElmSlider, {
+      props: { min: 100, max: 0, innerMin: 20, innerMax: 80, defaultValue: 50 },
+    });
+    const el = slider(wrapper);
+
+    // A reversed range (min > max) is a legitimate declining track —
+    // ratioOf already treats it as a valid interpolation — so clamping the
+    // inner bounds must not assume `lo <= hi` and silently force
+    // effectiveInnerMin/effectiveInnerMax (and therefore the seeded
+    // defaultValue) down to `max` regardless of the caller's props.
+    expect(el.getAttribute("aria-valuemin")).toBe("20");
+    expect(el.getAttribute("aria-valuemax")).toBe("80");
+    expect(el.getAttribute("aria-valuenow")).toBe("50");
+
+    // The control must not be frozen: a step still moves the value.
+    await el.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "ArrowLeft", bubbles: true }),
+    );
+    expect(el.getAttribute("aria-valuenow")).toBe("49");
+  });
+
+  it("does not collapse to a single point when min > max and innerMin/innerMax are omitted", () => {
+    const wrapper = mount(ElmSlider, {
+      props: { min: 100, max: 0, defaultValue: 30 },
+    });
+    const el = slider(wrapper);
+
+    // With innerMin/innerMax omitted, the documented defaults ("min" /
+    // "max") must resolve against the logical [low, high] span (0, 100),
+    // not the raw, possibly-reversed `min`/`max` values themselves —
+    // otherwise the default innerMax (the raw `max`, here the smaller
+    // number) gets clamped *up* to innerMin instead of down to the range's
+    // actual high end, collapsing the whole track to one point.
+    expect(el.getAttribute("aria-valuemin")).toBe("0");
+    expect(el.getAttribute("aria-valuemax")).toBe("100");
+    expect(el.getAttribute("aria-valuenow")).toBe("30");
+  });
+});
+
+describe("[SSR] ElmSlider", () => {
+  it("renders the slider role in the server shell", async () => {
+    const html = await renderToString(
+      createSSRApp({ render: () => h(ElmSlider, { defaultValue: 40 }) }),
+    );
+    expect(html).toContain('role="slider"');
+    expect(html).toContain('aria-valuenow="40"');
+  });
+});

--- a/packages/vue/src/components/form/elm-slider.stories.tsx
+++ b/packages/vue/src/components/form/elm-slider.stories.tsx
@@ -1,0 +1,94 @@
+import type { Meta, StoryObj } from "@storybook/vue3-vite";
+import { ref } from "vue";
+
+import { ElmSlider } from "./elm-slider";
+
+const meta = {
+  title: "Components/Form/elm-slider",
+  component: ElmSlider,
+  tags: ["autodocs"],
+  args: {
+    min: 0,
+    max: 100,
+    step: 1,
+  },
+} satisfies Meta<typeof ElmSlider>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Uncontrolled: the slider manages its own value, starting at the midpoint.
+export const Primary: Story = {};
+
+export const Vertical: Story = {
+  args: {
+    orientation: "vertical",
+  },
+};
+
+export const WithStep: Story = {
+  args: {
+    step: 10,
+  },
+};
+
+export const WithInnerRange: Story = {
+  args: {
+    innerMin: 20,
+    innerMax: 80,
+    defaultValue: 20,
+  },
+};
+
+export const WithMarkers: Story = {
+  args: {
+    step: 10,
+    markers: true,
+  },
+};
+
+export const WithMarkerLabels: Story = {
+  args: {
+    step: 25,
+    markers: true,
+    markerLabels: true,
+  },
+};
+
+export const WithMarkersAndInnerRange: Story = {
+  args: {
+    step: 10,
+    innerMin: 20,
+    innerMax: 80,
+    defaultValue: 20,
+    markers: true,
+    markerLabels: true,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+    defaultValue: 40,
+  },
+};
+
+// Controlled: parent owns the value via `v-model:value`.
+export const Controlled: Story = {
+  render: (args) => ({
+    components: { ElmSlider },
+    setup() {
+      const value = ref(30);
+      return { args, value };
+    },
+    template: `
+      <div style="display: flex; align-items: center; gap: 1rem;">
+        <div style="max-width: 16rem; flex: 1;">
+          <ElmSlider v-bind="args" v-model:value="value" />
+        </div>
+        <span style="font-family: monospace;">value: {{ value }}</span>
+        <button @click="value = 30">Reset</button>
+      </div>
+    `,
+  }),
+};

--- a/packages/vue/src/components/form/elm-slider.tsx
+++ b/packages/vue/src/components/form/elm-slider.tsx
@@ -1,0 +1,486 @@
+import {
+  computed,
+  defineComponent,
+  isVNode,
+  ref,
+  type CSSProperties,
+  type HTMLAttributes,
+  type PropType,
+  type VNodeChild,
+} from "vue";
+import { clsx } from "clsx";
+
+import { useBindableSignal } from "../../hooks/use-bindable-signal";
+import styles from "./elm-slider.module.css";
+
+export type ElmSliderOrientation = "horizontal" | "vertical";
+
+export interface ElmSliderProps extends Omit<HTMLAttributes, "onChange"> {
+  /**
+   * Lower bound of the track's full range.
+   *
+   * @defaultValue 0
+   */
+  min?: number;
+
+  /**
+   * Upper bound of the track's full range.
+   *
+   * @defaultValue 100
+   */
+  max?: number;
+
+  /**
+   * Increment the value snaps to while dragging or using the keyboard.
+   *
+   * @defaultValue 1
+   */
+  step?: number;
+
+  /**
+   * Restricts the value to an interval inside the track's full length. Must
+   * be `>= min`. The track still spans `[min, max]`, but the region below
+   * `innerMin` is shown as unreachable.
+   *
+   * @defaultValue min
+   */
+  innerMin?: number;
+
+  /**
+   * Restricts the value to an interval inside the track's full length. Must
+   * be `<= max`.
+   *
+   * @defaultValue max
+   */
+  innerMax?: number;
+
+  /**
+   * Track direction.
+   *
+   * @defaultValue "horizontal"
+   */
+  orientation?: ElmSliderOrientation;
+
+  /**
+   * Controlled value. Bind with `v-model:value`; when provided the parent
+   * owns the value (prop `value` + `update:value` event).
+   */
+  value?: number;
+
+  /**
+   * Initial value when uncontrolled.
+   *
+   * @defaultValue the midpoint of `innerMin`/`innerMax`
+   */
+  defaultValue?: number;
+
+  /**
+   * Disables dragging, clicking, and keyboard control.
+   */
+  disabled?: boolean;
+
+  /**
+   * Draws a tick mark at every step along the track.
+   */
+  markers?: boolean;
+
+  /**
+   * Draws a text label under each tick mark.
+   */
+  markerLabels?: boolean;
+
+  /**
+   * Formats the text shown for a marker label.
+   *
+   * @defaultValue String(value)
+   */
+  formatMarkerLabel?: (value: number) => VNodeChild;
+}
+
+const clamp = (n: number, lo: number, hi: number) =>
+  Math.min(hi, Math.max(lo, n));
+
+// Rounds away float dust (e.g. 0 + 3 * 0.1 -> 0.30000000000000004).
+const preciseRound = (n: number) => Math.round(n * 1e9) / 1e9;
+
+// Guards against generating an unbounded number of DOM nodes if a caller
+// pairs a tiny `step` with a wide `[min, max]`.
+const MAX_MARKERS = 500;
+
+// `formatMarkerLabel` is typed to return an arbitrary `VNodeChild` (vnodes,
+// arrays, primitives, ...), not just a string/number — so measuring its
+// length can't rely on `typeof`. Recursively concatenate the actual rendered
+// text (a vnode's text length is its children's, not its own) so a
+// JSX-returning formatter is measured by what it actually renders, not by a
+// `String(mark.value)` fallback that ignores the formatter entirely.
+const nodeToText = (node: unknown): string => {
+  if (node === null || node === undefined || typeof node === "boolean") {
+    return "";
+  }
+  if (typeof node === "string") return node;
+  if (typeof node === "number") return String(node);
+  if (Array.isArray(node)) return node.map(nodeToText).join("");
+  if (isVNode(node)) return nodeToText(node.children);
+  // Fragments/slots/anything else we can't statically measure — better to
+  // under-report nothing extra than to throw.
+  return "";
+};
+
+export const ElmSlider = defineComponent({
+  name: "ElmSlider",
+  // `rest`/`attrs` (aria-label, id, data-*, tabindex overrides, ...) belongs
+  // on the interactive element itself (the `role="slider"` track), not the
+  // outer wrapper — the wrapper only exists to carry the CSS custom
+  // properties. This component IS a slider, unlike e.g. ElmAudioPlayer where
+  // the root is a larger widget and the seek bar is just one control in it.
+  inheritAttrs: false,
+  props: {
+    min: { type: Number, default: 0 },
+    max: { type: Number, default: 100 },
+    step: { type: Number, default: 1 },
+    innerMin: { type: Number, default: undefined },
+    innerMax: { type: Number, default: undefined },
+    orientation: {
+      type: String as PropType<ElmSliderOrientation>,
+      default: "horizontal",
+    },
+    // Must default to `undefined` so an unbound slider is distinguishable
+    // from one explicitly bound to `0` (see `useBindableSignal`).
+    value: { type: Number, default: undefined },
+    defaultValue: { type: Number, default: undefined },
+    disabled: { type: Boolean, default: undefined },
+    markers: { type: Boolean, default: undefined },
+    markerLabels: { type: Boolean, default: undefined },
+    formatMarkerLabel: {
+      type: Function as PropType<(value: number) => VNodeChild>,
+      default: undefined,
+    },
+  },
+  emits: ["update:value"],
+  setup(props, { attrs, emit }) {
+    const trackRef = ref<HTMLDivElement | null>(null);
+    const isVertical = computed(() => props.orientation === "vertical");
+
+    // `clamp` assumes `lo <= hi`. `min`/`max` alone can't be passed straight
+    // through as `[lo, hi]` because a reversed range (`min > max`, a
+    // legitimate declining track — see `ratioOf`, which already handles it
+    // via plain interpolation) would silently force both inner bounds down
+    // to `max` instead of clamping into the declared range. Sort once so the
+    // inner bounds are always resolved against the *logical* [low, high]
+    // regardless of which of `min`/`max` is numerically larger. The
+    // *default* for an omitted innerMin/innerMax must default to this same
+    // logical [low, high] span too (not the raw `min`/`max`) — otherwise,
+    // for a reversed range, the default innerMax (raw `max`, the smaller
+    // number) sits below `rangeLow`/the default innerMin and gets clamped
+    // *up* to it instead of down to the range's actual high end, collapsing
+    // the whole track to a single point.
+    const rangeLow = computed(() => Math.min(props.min, props.max));
+    const rangeHigh = computed(() => Math.max(props.min, props.max));
+    const effectiveInnerMin = computed(() =>
+      clamp(props.innerMin ?? rangeLow.value, rangeLow.value, rangeHigh.value),
+    );
+    const effectiveInnerMax = computed(() =>
+      clamp(
+        props.innerMax ?? rangeHigh.value,
+        effectiveInnerMin.value,
+        rangeHigh.value,
+      ),
+    );
+
+    const snap = (raw: number): number => {
+      // `step` is a granularity, not a direction — mirror the keyboard
+      // handler's `Math.abs(step)` so a negative step still quantizes (only
+      // `step === 0` means "no snapping").
+      const magnitude = Math.abs(props.step);
+      const stepped =
+        magnitude > 0
+          ? props.min + Math.round((raw - props.min) / magnitude) * magnitude
+          : raw;
+      return clamp(
+        preciseRound(stepped),
+        effectiveInnerMin.value,
+        effectiveInnerMax.value,
+      );
+    };
+
+    // Unlike `snap`, this does NOT re-quantize onto a grid anchored at
+    // `min` — it clamps a value that has already moved by exactly `delta`
+    // from the current value. Used for keyboard stepping, where the current
+    // value may legitimately be off-grid (a persisted preference, or an
+    // inner bound that doesn't itself sit on the step grid) and a single key
+    // press must change the value by exactly one step, not snap it onto the
+    // nearest grid line.
+    const clampValue = (raw: number): number =>
+      clamp(
+        preciseRound(raw),
+        effectiveInnerMin.value,
+        effectiveInnerMax.value,
+      );
+
+    // Unlike pointer/keyboard-driven moves, the initial seed is not something
+    // the user is actively snapping onto a grid — it's either a caller's
+    // explicit, possibly-off-grid `defaultValue` (e.g. a persisted
+    // preference) or the documented midpoint default. Both must be honored
+    // verbatim, exactly like a controlled `value` is preserved off-grid
+    // elsewhere in this file — so only clamp into range here, don't `snap()`.
+    const currentValue = useBindableSignal({
+      props,
+      key: "value",
+      emit,
+      defaultValue: clampValue(
+        props.defaultValue ??
+          (effectiveInnerMin.value + effectiveInnerMax.value) / 2,
+      ),
+    });
+
+    const ratioOf = (v: number): number =>
+      props.max === props.min
+        ? 0
+        : clamp((v - props.min) / (props.max - props.min), 0, 1);
+
+    const valueFromPointer = (clientX: number, clientY: number): number => {
+      const el = trackRef.value;
+      if (!el) return currentValue.value;
+      const rect = el.getBoundingClientRect();
+      const ratio = isVertical.value
+        ? rect.height === 0
+          ? 0
+          : clamp((rect.bottom - clientY) / rect.height, 0, 1)
+        : rect.width === 0
+          ? 0
+          : clamp((clientX - rect.left) / rect.width, 0, 1);
+      return snap(props.min + ratio * (props.max - props.min));
+    };
+
+    const handlePointerDown = (event: PointerEvent): void => {
+      if (props.disabled) return;
+      (event.currentTarget as HTMLElement).setPointerCapture(event.pointerId);
+      currentValue.value = valueFromPointer(event.clientX, event.clientY);
+    };
+
+    const handlePointerMove = (event: PointerEvent): void => {
+      if (props.disabled) return;
+      if (
+        !(event.currentTarget as HTMLElement).hasPointerCapture(event.pointerId)
+      ) {
+        return;
+      }
+      currentValue.value = valueFromPointer(event.clientX, event.clientY);
+    };
+
+    // A controlling parent owns `currentValue` and may pass one outside the
+    // inner range (e.g. set before `innerMin`/`innerMax` were added) — clamp
+    // only for display so `aria-valuenow` and the thumb never report/render
+    // outside the declared bounds, without emitting `update:value` ourselves.
+    const displayValue = computed(() =>
+      clamp(
+        currentValue.value,
+        effectiveInnerMin.value,
+        effectiveInnerMax.value,
+      ),
+    );
+
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if (props.disabled) return;
+      // `step` is a granularity, not a direction — a caller-supplied
+      // negative step must not reverse which arrow key increases the value.
+      const delta = Math.abs(props.step);
+      // Step relative to `displayValue` (what aria-valuenow actually
+      // reports), not the raw `currentValue` — a controlling parent may
+      // pass a value outside the inner range, and stepping from the raw
+      // value would silently re-absorb into the same clamped display value
+      // instead of moving by one step.
+      switch (event.key) {
+        case "ArrowRight":
+        case "ArrowUp":
+          event.preventDefault();
+          currentValue.value = clampValue(displayValue.value + delta);
+          break;
+        case "ArrowLeft":
+        case "ArrowDown":
+          event.preventDefault();
+          currentValue.value = clampValue(displayValue.value - delta);
+          break;
+        case "PageUp":
+          event.preventDefault();
+          currentValue.value = clampValue(displayValue.value + delta * 10);
+          break;
+        case "PageDown":
+          event.preventDefault();
+          currentValue.value = clampValue(displayValue.value - delta * 10);
+          break;
+        case "Home":
+          event.preventDefault();
+          currentValue.value = effectiveInnerMin.value;
+          break;
+        case "End":
+          event.preventDefault();
+          currentValue.value = effectiveInnerMax.value;
+          break;
+      }
+    };
+
+    const marks = computed(() => {
+      if (!props.markers && !props.markerLabels) return [];
+      // `step` is a granularity, not a direction — mirror `snap()` and the
+      // keyboard handler's `Math.abs(step)` so a negative step still renders
+      // ticks (only `step === 0` or an empty range means "no ticks").
+      const magnitude = Math.abs(props.step);
+      if (magnitude <= 0 || props.max <= props.min) return [];
+      // `preciseRound` absorbs float dust in (max-min)/step (e.g.
+      // 0.3/0.1 -> 2.9999999999999996, which must count as 3) without
+      // rounding a genuine fraction up to the next integer (e.g.
+      // 10/6 -> 1.6666666666666667 must floor to 1, not round up to 2 and
+      // generate a tick beyond `max`).
+      const realCount = Math.floor(
+        preciseRound((props.max - props.min) / magnitude),
+      );
+      const out: { value: number; ratio: number }[] = [];
+      if (realCount <= MAX_MARKERS) {
+        // Tick every real step — these are exactly the values `snap()` can
+        // ever produce — then force a trailing tick at `max` if `step`
+        // doesn't divide `max - min` evenly.
+        for (let i = 0; i <= realCount; i++) {
+          const v = preciseRound(props.min + i * magnitude);
+          out.push({ value: v, ratio: ratioOf(v) });
+        }
+        if (
+          preciseRound(props.min + realCount * magnitude) !==
+          preciseRound(props.max)
+        ) {
+          out.push({ value: props.max, ratio: ratioOf(props.max) });
+        }
+      } else {
+        // Past MAX_MARKERS, evenly resample across the full range instead of
+        // rendering only the first MAX_MARKERS real step-ticks — otherwise a
+        // tiny step over a wide range clusters every rendered tick near
+        // `min`. These resampled ticks are cosmetic only (not all of them
+        // are reachable by `snap()`), which is an acceptable trade-off once
+        // there are too many real ticks to render individually.
+        const tickStep = (props.max - props.min) / MAX_MARKERS;
+        for (let i = 0; i <= MAX_MARKERS; i++) {
+          const v =
+            i === MAX_MARKERS
+              ? props.max
+              : preciseRound(props.min + i * tickStep);
+          out.push({ value: v, ratio: ratioOf(v) });
+        }
+      }
+      return out;
+    });
+
+    // `.vertical.has-marker-labels` reserves `padding-right` to fit the
+    // tick, the gap, and the label itself — but the label's *width* scales
+    // with its character count (unlike the horizontal orientation, where
+    // the reserved `padding-block-end` only ever needs a label's
+    // roughly-constant line-height). Measure the longest rendered label so
+    // the CSS can size the reservation to it via `ch` (exact for
+    // `.mark-label`'s monospace font) instead of a fixed constant that only
+    // fits short labels.
+    const maxMarkerLabelChars = computed(() => {
+      if (!props.markerLabels) return 0;
+      let maxChars = 0;
+      for (const mark of marks.value) {
+        const rendered = props.formatMarkerLabel?.(mark.value) ?? mark.value;
+        const text = nodeToText(rendered);
+        if (text.length > maxChars) maxChars = text.length;
+      }
+      return maxChars;
+    });
+
+    return () => {
+      const { class: attrClass, ...rest } = attrs as Record<string, unknown>;
+
+      const valueRatio = ratioOf(displayValue.value);
+      const innerMinRatio = ratioOf(effectiveInnerMin.value);
+      const innerMaxRatio = ratioOf(effectiveInnerMax.value);
+
+      return (
+        <div
+          class={clsx(
+            styles["elm-slider"],
+            isVertical.value && styles.vertical,
+            props.disabled && styles.disabled,
+            // `.marks`/`.mark`/`.mark-label` are `position: absolute` so
+            // they can overlay tick positions without disturbing the
+            // track's flex layout — but that also means they never
+            // contribute to `.track`'s or this element's own box size.
+            // Reserve the space explicitly so the tick and label row
+            // renders inside the slider's box instead of bleeding past its
+            // bottom (or, in vertical orientation, its inline-end) edge.
+            props.markers && styles["has-markers"],
+            props.markerLabels && styles["has-marker-labels"],
+          )}
+          style={
+            {
+              "--elmethis-scoped-value-ratio": valueRatio,
+              "--elmethis-scoped-inner-min-ratio": innerMinRatio,
+              "--elmethis-scoped-inner-max-ratio": innerMaxRatio,
+              "--elmethis-scoped-max-marker-label-chars":
+                maxMarkerLabelChars.value,
+            } as CSSProperties
+          }
+        >
+          <div
+            ref={trackRef}
+            class={clsx(styles.track, attrClass as string | undefined)}
+            role="slider"
+            aria-orientation={props.orientation}
+            aria-valuemin={effectiveInnerMin.value}
+            aria-valuemax={effectiveInnerMax.value}
+            aria-valuenow={displayValue.value}
+            aria-disabled={props.disabled || undefined}
+            tabindex={props.disabled ? -1 : 0}
+            onPointerdown={handlePointerDown}
+            onPointermove={handlePointerMove}
+            onKeydown={handleKeyDown}
+            {...rest}
+          >
+            <div class={styles.rail} aria-hidden="true">
+              <div class={styles["restricted-start"]} />
+              <div class={styles.fill} />
+              <div class={styles["restricted-end"]} />
+            </div>
+
+            {marks.value.length > 0 && (
+              <div class={styles.marks} aria-hidden="true">
+                {marks.value.map((mark, index) => (
+                  <span
+                    key={mark.value}
+                    class={clsx(
+                      styles.mark,
+                      // The default transform centers the tick/label on the
+                      // marker's position, which pushes the first/last
+                      // label half its own width past the track's
+                      // start/end edge. Clamp those two to align inward
+                      // instead of centering.
+                      index === 0 && styles["mark-start"],
+                      index === marks.value.length - 1 && styles["mark-end"],
+                      (mark.value < effectiveInnerMin.value ||
+                        mark.value > effectiveInnerMax.value) &&
+                        styles["mark-restricted"],
+                    )}
+                    style={
+                      {
+                        "--elmethis-scoped-marker-ratio": mark.ratio,
+                      } as CSSProperties
+                    }
+                  >
+                    {props.markers && <i class={styles.tick} />}
+                    {props.markerLabels && (
+                      <span class={styles["mark-label"]}>
+                        {props.formatMarkerLabel?.(mark.value) ?? mark.value}
+                      </span>
+                    )}
+                  </span>
+                ))}
+              </div>
+            )}
+
+            <span class={styles.thumb} aria-hidden="true" />
+          </div>
+        </div>
+      );
+    };
+  },
+});

--- a/packages/vue/src/components/form/elm-slider.tsx
+++ b/packages/vue/src/components/form/elm-slider.tsx
@@ -128,11 +128,14 @@ const nodeToText = (node: unknown): string => {
 
 export const ElmSlider = defineComponent({
   name: "ElmSlider",
-  // `rest`/`attrs` (aria-label, id, data-*, tabindex overrides, ...) belongs
-  // on the interactive element itself (the `role="slider"` track), not the
-  // outer wrapper — the wrapper only exists to carry the CSS custom
-  // properties. This component IS a slider, unlike e.g. ElmAudioPlayer where
-  // the root is a larger widget and the seek bar is just one control in it.
+  // `rest` (aria-label, id, data-*, tabindex overrides, ...) belongs on the
+  // interactive element itself (the `role="slider"` track), not the outer
+  // wrapper — the wrapper only exists to carry the CSS custom properties.
+  // This component IS a slider, unlike e.g. ElmAudioPlayer where the root is
+  // a larger widget and the seek bar is just one control in it. `class`/
+  // `style` are the one exception: like the React port, they're pulled out
+  // of `attrs` and applied to the outer wrapper instead of `rest`'s default
+  // destination.
   inheritAttrs: false,
   props: {
     min: { type: Number, default: 0 },
@@ -389,7 +392,19 @@ export const ElmSlider = defineComponent({
     });
 
     return () => {
-      const { class: attrClass, ...rest } = attrs as Record<string, unknown>;
+      // `onKeydown` is pulled out of `rest` (rather than left to spread
+      // verbatim) so it isn't composed in unconditionally by Vue's
+      // `mergeProps` — spreading it alongside the JSX-literal `onKeydown`
+      // below would let a caller-supplied handler fire even while
+      // `disabled`, bypassing the `if (props.disabled) return` guard that
+      // only gates the internal handler. Composing it manually lets
+      // `disabled` suppress both, mirroring the React port's contract.
+      const {
+        class: attrClass,
+        style: attrStyle,
+        onKeydown: attrsOnKeydown,
+        ...rest
+      } = attrs as Record<string, unknown>;
 
       const valueRatio = ratioOf(displayValue.value);
       const innerMinRatio = ratioOf(effectiveInnerMin.value);
@@ -410,6 +425,7 @@ export const ElmSlider = defineComponent({
             // bottom (or, in vertical orientation, its inline-end) edge.
             props.markers && styles["has-markers"],
             props.markerLabels && styles["has-marker-labels"],
+            attrClass as string | undefined,
           )}
           style={
             {
@@ -418,23 +434,39 @@ export const ElmSlider = defineComponent({
               "--elmethis-scoped-inner-max-ratio": innerMaxRatio,
               "--elmethis-scoped-max-marker-label-chars":
                 maxMarkerLabelChars.value,
+              ...(attrStyle as CSSProperties | undefined),
             } as CSSProperties
           }
         >
           <div
             ref={trackRef}
-            class={clsx(styles.track, attrClass as string | undefined)}
+            class={styles.track}
+            tabindex={props.disabled ? -1 : 0}
+            onPointerdown={handlePointerDown}
+            onPointermove={handlePointerMove}
+            onKeydown={(event: KeyboardEvent) => {
+              handleKeyDown(event);
+              if (props.disabled) return;
+              (
+                attrsOnKeydown as ((event: KeyboardEvent) => void) | undefined
+              )?.(event);
+            }}
+            {...rest}
+            // `role`/`aria-*` are written *after* `{...rest}` on purpose:
+            // the JSX compiles to `mergeProps({...}, rest)`, and for plain
+            // (non-class/style/on*) keys mergeProps lets the later object
+            // win. Placing these after `rest` means the slider's own
+            // computed ARIA state always wins over a same-named, type-legal
+            // attr a caller passes through — mirroring the React port,
+            // where these are written after `{...rest}` for the same
+            // reason. `tabindex` intentionally stays before `rest` so a
+            // caller can still override it (e.g. opt out of tab order).
             role="slider"
             aria-orientation={props.orientation}
             aria-valuemin={effectiveInnerMin.value}
             aria-valuemax={effectiveInnerMax.value}
             aria-valuenow={displayValue.value}
             aria-disabled={props.disabled || undefined}
-            tabindex={props.disabled ? -1 : 0}
-            onPointerdown={handlePointerDown}
-            onPointermove={handlePointerMove}
-            onKeydown={handleKeyDown}
-            {...rest}
           >
             <div class={styles.rail} aria-hidden="true">
               <div class={styles["restricted-start"]} />

--- a/packages/vue/src/hooks/use-bindable-signal.ts
+++ b/packages/vue/src/hooks/use-bindable-signal.ts
@@ -42,7 +42,15 @@ export function useBindableSignal<P extends object, K extends keyof P>(args: {
   emit: (event: `update:${string & K}`, ...payload: unknown[]) => void;
   /** Initial value for the internal state when unbound. */
   defaultValue: NonNullable<P[K]>;
-}): Ref<UnwrapRef<P[K]>> {
+}): Ref<NonNullable<UnwrapRef<P[K]>>> {
   const { props, key, emit, defaultValue } = args;
-  return useVModel(props, key, emit, { passive: true, defaultValue });
+  // `useVModel`'s own return type is `Ref<UnwrapRef<P[K]>>` (which still
+  // carries the prop's optional `| undefined`, since a model prop must
+  // default to `undefined` to be distinguishable from "unbound") — but a
+  // required `defaultValue` guarantees the ref is never actually undefined
+  // at runtime (unbound reads fall back to it, and the JSDoc above promises
+  // callers a `Ref<T>`, not `Ref<T | undefined>`). Narrow the type to match.
+  return useVModel(props, key, emit, { passive: true, defaultValue }) as Ref<
+    NonNullable<UnwrapRef<P[K]>>
+  >;
 }

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -102,6 +102,11 @@ export {
   type ElmSelectOption,
   type ElmSelectProps,
 } from "./components/form/elm-select";
+export {
+  ElmSlider,
+  type ElmSliderOrientation,
+  type ElmSliderProps,
+} from "./components/form/elm-slider";
 export { ElmSwitch, type ElmSwitchProps } from "./components/form/elm-switch";
 export {
   ElmTextArea,

--- a/packages/vue/src/styles/_component-vars.css
+++ b/packages/vue/src/styles/_component-vars.css
@@ -34,6 +34,13 @@
   --elmethis-scoped-size: initial;
   --elmethis-scoped-width: initial;
 
+  /* elm-slider knobs */
+  --elmethis-scoped-value-ratio: initial;
+  --elmethis-scoped-inner-min-ratio: initial;
+  --elmethis-scoped-inner-max-ratio: initial;
+  --elmethis-scoped-marker-ratio: initial;
+  --elmethis-scoped-max-marker-label-chars: initial;
+
   /* Animation timing knobs */
   --elmethis-scoped-delay: initial;
   --elmethis-scoped-duration: initial;


### PR DESCRIPTION
## Summary
- Adds a new `ElmSlider` component: horizontal (default) and vertical orientation, inner-min/inner-max range restriction, step support, and step markers with marker labels.
- Piloted in React first, then ported to Qwik and Vue, each translated into the framework's own controllable-state idiom (React: `value`/`onValueChange`; Qwik: `Signal<number>`; Vue: `v-model:value`).
- Ran an iterative multi-lens review/reproduce/fix loop against all three implementations; fixed 16 bugs in React and 6 more surfaced during the Qwik/Vue port (reversed-range marker generation, disabled-state keyboard bypass, Vue attrs/class/style routing).

## Commits
- `feat(react): add ElmSlider component`
- `fix(react): fix 16 ElmSlider bugs found via multi-lens review loop`
- `Port ElmSlider to Qwik and Vue`
- `Fix ElmSlider bugs found in qwik/vue port review`

## Test plan
- [x] `pnpm run check` green in `packages/react`, `packages/qwik`, `packages/vue`
- [x] Unit suites: React 465/465, Qwik 533/533, Vue 419/419
- [x] Browser suites: React 10/10 (slider) + full suite green, Qwik 75/75, Vue 56/56
- [x] Reversed-range (min > max) marker generation verified fixed in React, Qwik, and Vue
- [x] Disabled-state keyboard bypass verified fixed in Qwik; Vue's fallthrough-attrs ordering/class-style routing/disabled-onKeydown gating verified fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)