### PR TITLE
Replace margin-block-start spacing with a gap-based stack model

### DIFF
--- a/packages/core/src/style/token-vars.spec.ts
+++ b/packages/core/src/style/token-vars.spec.ts
@@ -24,7 +24,7 @@ describe("tokenVars", () => {
 
   it("prefixes the flat semantic key with --elmethis-", () => {
     expect(tokenVars["--elmethis-color-accent-link-visited"]).toBeDefined();
-    expect(tokenVars["--elmethis-margin-block-start"]).toBe("2rem");
+    expect(tokenVars["--elmethis-stack-gap"]).toBe("2rem");
   });
 
   it("emits the font-family stacks (DM Sans / DM Mono primary)", () => {

--- a/packages/core/src/style/token.ts
+++ b/packages/core/src/style/token.ts
@@ -127,7 +127,16 @@ const { color, font } = primitive;
  * primitive layer are symbolic (`PrimitiveToken.ref`), never resolved values.
  */
 export const semanticTokens = {
-  "margin-block-start": common("2rem"),
+  /**
+   * Vertical rhythm between stacked blocks. Applied as `gap` on an explicit
+   * flex-column "stack" container (e.g. each framework's `ElmA2ui` surface,
+   * `ElmMarkdown`, and container child slots like Callout/BlockQuote/Toggle/
+   * TabPanel) — never as a leading margin on individual leaf components.
+   * `gap` only ever applies between items, so there's no first-child case to
+   * special-case and no risk of a standalone/nested component floating an
+   * unexplained gap above it.
+   */
+  "stack-gap": common("2rem"),
 
   "font-family-sans": common(font.family.sans),
   "font-family-monospace": common(font.family.monospace),

--- a/packages/qwik/src/components/a2ui/catalog/basic-catalog.spec.tsx
+++ b/packages/qwik/src/components/a2ui/catalog/basic-catalog.spec.tsx
@@ -16,6 +16,7 @@ import {
 
 import { type RenderArgs } from "./catalog";
 import { basicCatalog } from "./basic-catalog";
+import styles from "../elm-a2ui.module.css";
 
 const CATALOG_ID = "https://a2ui.org/specification/v0_9/basic_catalog.json";
 
@@ -410,13 +411,13 @@ describe("basicCatalog: containers & leaves", () => {
     expect(html).toContain('data-icon="star"');
   });
 
-  test("Column wraps each child and applies its block-margin var", async () => {
+  test("Column wraps each child and spaces them with the shared stack gap", async () => {
     const html = await renderArgs(
       buildArgs({ component: "Column", id: "col", children: ["a", "b"] }),
       "Column",
     );
     expect(html).toContain('data-child-id="a"');
     expect(html).toContain('data-child-id="b"');
-    expect(html.replace(/\s/g, "")).toContain("--margin-block:2rem");
+    expect(html).toContain(`class="${styles.column}"`);
   });
 });

--- a/packages/qwik/src/components/a2ui/catalog/basic-catalog.tsx
+++ b/packages/qwik/src/components/a2ui/catalog/basic-catalog.tsx
@@ -96,7 +96,7 @@ export const basicCatalog: CatalogRenderer = new CatalogRenderer([
   )),
 
   defineRenderer(ColumnApi, ({ props, childRefs, renderChild }) => (
-    <div class={styles.column} style={{ "--margin-block": "2rem" }}>
+    <div class={styles.column}>
       {childRefs(props.children).map(({ id, path }, i) => (
         <span key={`${id}:${i}`} class={styles["child-wrap"]}>
           {renderChild(id, path, i)}

--- a/packages/qwik/src/components/a2ui/catalog/block-catalog.spec.tsx
+++ b/packages/qwik/src/components/a2ui/catalog/block-catalog.spec.tsx
@@ -250,19 +250,19 @@ describe("blockCatalog: layout", () => {
     expect(html.replace(/\s/g, "")).toContain("flex:2");
   });
 
-  test("Column suppresses top margin when it is the first child", async () => {
-    const args = buildArgs({
-      component: "Column",
-      id: "c",
-      children: ["a"],
-    });
-    // simulate "first child" — buildArgs uses index: 0 by default
-    expect(args.index).toBe(0);
-    const html = await renderArgs(args, "Column");
-    // First child suppresses its top margin by setting `margin-block-start: 0`
-    // directly (NOT the inheriting `--elmethis-margin-block-start` custom
-    // property, which would cascade into nested blocks). See firstChildMargin.
-    expect(html.replace(/\s/g, "")).toContain("margin-block-start:0");
+  test("Column spaces its children with the shared stack gap", async () => {
+    const html = await renderArgs(
+      buildArgs({
+        component: "Column",
+        id: "c",
+        children: ["a"],
+      }),
+      "Column",
+    );
+    // Spacing between stacked children comes from `gap` on the flex
+    // container, not a per-child leading margin — so there's no first-child
+    // case to special-case (unlike the old firstChildMargin() mechanism).
+    expect(html.replace(/\s/g, "")).toContain("gap:var(--elmethis-stack-gap)");
   });
 });
 

--- a/packages/qwik/src/components/a2ui/catalog/block-catalog.tsx
+++ b/packages/qwik/src/components/a2ui/catalog/block-catalog.tsx
@@ -37,11 +37,7 @@ import {
 import { ElmUnsupportedBlock } from "../../fallback/elm-unsupported-block";
 
 import { CatalogRenderer, defineRenderer } from "./catalog";
-import {
-  alignItemsMap,
-  firstChildMargin,
-  justifyContentMap,
-} from "./catalog-utils";
+import { alignItemsMap, justifyContentMap } from "./catalog-utils";
 import { basicCatalog } from "./basic-catalog";
 import {
   AudioApi,
@@ -140,7 +136,7 @@ export const blockCatalog: CatalogRenderer = basicCatalog.extend(
   // Layout (overrides Column from basicCatalog with widthRatio support)
   // -------------------------------------------------------------------------
 
-  defineRenderer(ColumnApi, ({ props, index, childRefs, renderChild }) => (
+  defineRenderer(ColumnApi, ({ props, childRefs, renderChild }) => (
     <div
       style={{
         display: "flex",
@@ -150,7 +146,7 @@ export const blockCatalog: CatalogRenderer = basicCatalog.extend(
         flex: props.widthRatio != null ? String(props.widthRatio) : undefined,
         boxSizing: "border-box",
         padding: "0.125rem",
-        ...firstChildMargin(index),
+        gap: "var(--elmethis-stack-gap)",
       }}
     >
       {childRefs(props.children).map(({ id, path }, i) => (
@@ -159,8 +155,8 @@ export const blockCatalog: CatalogRenderer = basicCatalog.extend(
     </div>
   )),
 
-  defineRenderer(ColumnListApi, ({ props, index, childRefs, renderChild }) => (
-    <div style={{ ...columnListStyle, ...firstChildMargin(index) }}>
+  defineRenderer(ColumnListApi, ({ props, childRefs, renderChild }) => (
+    <div style={columnListStyle}>
       {childRefs(props.children).map(({ id, path }, i) => (
         <Fragment key={`${id}:${i}`}>{renderChild(id, path, i)}</Fragment>
       ))}
@@ -171,31 +167,24 @@ export const blockCatalog: CatalogRenderer = basicCatalog.extend(
   // Block typography
   // -------------------------------------------------------------------------
 
-  defineRenderer(HeadingApi, ({ props, index, childRefs, renderChild }) => (
-    <ElmHeading level={props.level} style={firstChildMargin(index)}>
+  defineRenderer(HeadingApi, ({ props, childRefs, renderChild }) => (
+    <ElmHeading level={props.level}>
       {childRefs(props.children).map(({ id, path }, i) => (
         <Fragment key={`${id}:${i}`}>{renderChild(id, path, i)}</Fragment>
       ))}
     </ElmHeading>
   )),
 
-  defineRenderer(ParagraphApi, ({ props, index, childRefs, renderChild }) => (
-    <ElmParagraph
-      color={props.color}
-      backgroundColor={props.backgroundColor}
-      style={firstChildMargin(index)}
-    >
+  defineRenderer(ParagraphApi, ({ props, childRefs, renderChild }) => (
+    <ElmParagraph color={props.color} backgroundColor={props.backgroundColor}>
       {childRefs(props.children).map(({ id, path }, i) => (
         <span key={`${id}:${i}`}>{renderChild(id, path, i)}</span>
       ))}
     </ElmParagraph>
   )),
 
-  defineRenderer(ListApi, ({ props, index, childRefs, renderChild }) => (
-    <ElmList
-      listStyle={props.style ?? "unordered"}
-      style={firstChildMargin(index)}
-    >
+  defineRenderer(ListApi, ({ props, childRefs, renderChild }) => (
+    <ElmList listStyle={props.style ?? "unordered"}>
       {childRefs(props.children).map(({ id, path }, i) => (
         <li key={`${id}:${i}`}>{renderChild(id, path, i)}</li>
       ))}
@@ -210,28 +199,26 @@ export const blockCatalog: CatalogRenderer = basicCatalog.extend(
     </>
   )),
 
-  defineRenderer(BlockQuoteApi, ({ props, index, childRefs, renderChild }) => (
-    <ElmBlockQuote cite={props.cite} style={firstChildMargin(index)}>
+  defineRenderer(BlockQuoteApi, ({ props, childRefs, renderChild }) => (
+    <ElmBlockQuote cite={props.cite}>
       {childRefs(props.children).map(({ id, path }, i) => (
         <Fragment key={`${id}:${i}`}>{renderChild(id, path, i)}</Fragment>
       ))}
     </ElmBlockQuote>
   )),
 
-  defineRenderer(CalloutApi, ({ props, index, childRefs, renderChild }) => (
-    <ElmCallout type={props.type} style={firstChildMargin(index)}>
+  defineRenderer(CalloutApi, ({ props, childRefs, renderChild }) => (
+    <ElmCallout type={props.type}>
       {childRefs(props.children).map(({ id, path }, i) => (
         <Fragment key={`${id}:${i}`}>{renderChild(id, path, i)}</Fragment>
       ))}
     </ElmCallout>
   )),
 
-  defineRenderer(DividerApi, ({ index }) => (
-    <ElmDivider style={firstChildMargin(index)} />
-  )),
+  defineRenderer(DividerApi, () => <ElmDivider />),
 
-  defineRenderer(ToggleApi, ({ props, index, childRefs, renderChild }) => (
-    <ElmToggle style={firstChildMargin(index)}>
+  defineRenderer(ToggleApi, ({ props, childRefs, renderChild }) => (
+    <ElmToggle>
       <div q:slot="summary">
         {childRefs(props.summary).map(({ id, path }, i) => (
           <span key={`${id}:${i}`}>{renderChild(id, path, i)}</span>
@@ -247,25 +234,23 @@ export const blockCatalog: CatalogRenderer = basicCatalog.extend(
   // Media / embed
   // -------------------------------------------------------------------------
 
-  defineRenderer(BookmarkApi, ({ props, index, resolve }) => (
+  defineRenderer(BookmarkApi, ({ props, resolve }) => (
     <ElmBookmark
       url={resolve(props.url)}
       title={props.title ? resolve(props.title) : undefined}
       description={props.description ? resolve(props.description) : undefined}
       image={props.image ? resolve(props.image) : undefined}
-      style={firstChildMargin(index)}
     />
   )),
 
-  defineRenderer(FileApi, ({ props, index, resolve }) => (
+  defineRenderer(FileApi, ({ props, resolve }) => (
     <ElmFile
       src={resolve(props.src)}
       name={props.name ? resolve(props.name) : undefined}
-      style={firstChildMargin(index)}
     />
   )),
 
-  defineRenderer(AudioApi, ({ props, index, resolve }) => (
+  defineRenderer(AudioApi, ({ props, resolve }) => (
     <ElmAudioPlayer
       src={resolve(props.src)}
       title={props.title ? resolve(props.title) : undefined}
@@ -273,14 +258,13 @@ export const blockCatalog: CatalogRenderer = basicCatalog.extend(
       seekStep={props.seekStep}
       loop={props.loop}
       autoPlay={props.autoPlay}
-      style={firstChildMargin(index)}
     />
   )),
 
-  defineRenderer(VideoApi, ({ props, index, resolve }) => {
+  defineRenderer(VideoApi, ({ props, resolve }) => {
     const caption = props.caption ? resolve(props.caption) : undefined;
     return (
-      <figure style={{ ...firstChildMargin(index), margin: 0 }}>
+      <figure style={{ margin: 0 }}>
         <video
           src={resolve(props.src)}
           poster={props.poster ? resolve(props.poster) : undefined}
@@ -298,7 +282,7 @@ export const blockCatalog: CatalogRenderer = basicCatalog.extend(
     );
   }),
 
-  defineRenderer(BlockImageApi, ({ props, index, resolve }) => (
+  defineRenderer(BlockImageApi, ({ props, resolve }) => (
     <ElmBlockImage
       src={resolve(props.src)}
       alt={props.alt ? resolve(props.alt) : undefined}
@@ -308,7 +292,6 @@ export const blockCatalog: CatalogRenderer = basicCatalog.extend(
       sizes={props.sizes ? resolve(props.sizes) : undefined}
       caption={props.caption ? resolve(props.caption) : undefined}
       enableModal={true}
-      style={firstChildMargin(index)}
     />
   )),
 
@@ -316,32 +299,23 @@ export const blockCatalog: CatalogRenderer = basicCatalog.extend(
   // Code / math / diagram
   // -------------------------------------------------------------------------
 
-  defineRenderer(CodeBlockApi, ({ props, index, resolve }) => (
+  defineRenderer(CodeBlockApi, ({ props, resolve }) => (
     <ElmCodeBlock
       code={resolve(props.code)}
       language={props.language ? resolve(props.language) : undefined}
       caption={props.caption ? resolve(props.caption) : undefined}
-      style={firstChildMargin(index)}
     />
   )),
 
-  defineRenderer(KatexApi, ({ props, index, resolve }) => (
-    <ElmKatex
-      expression={resolve(props.expression)}
-      block={true}
-      style={firstChildMargin(index)}
-    />
+  defineRenderer(KatexApi, ({ props, resolve }) => (
+    <ElmKatex expression={resolve(props.expression)} block={true} />
   )),
 
   // Mermaid is rendered as a syntax-highlighted code block — no dedicated
   // Mermaid renderer in this package. The diagram source is preserved so a
   // host application can post-process if needed.
-  defineRenderer(MermaidApi, ({ props, index, resolve }) => (
-    <ElmCodeBlock
-      code={resolve(props.code)}
-      language="mermaid"
-      style={firstChildMargin(index)}
-    />
+  defineRenderer(MermaidApi, ({ props, resolve }) => (
+    <ElmCodeBlock code={resolve(props.code)} language="mermaid" />
   )),
 
   // -------------------------------------------------------------------------
@@ -351,7 +325,7 @@ export const blockCatalog: CatalogRenderer = basicCatalog.extend(
 
   defineRenderer(ContentTabApi, () => null),
 
-  defineRenderer(ContentTabsApi, ({ props, index, surface, renderChild }) => {
+  defineRenderer(ContentTabsApi, ({ props, surface, renderChild }) => {
     const tabIds = Array.isArray(props.children) ? props.children : [];
     const tabs = tabIds.map((tabId) => {
       const tabModel = surface.componentsModel.get(tabId);
@@ -362,7 +336,7 @@ export const blockCatalog: CatalogRenderer = basicCatalog.extend(
       };
     });
     return (
-      <ElmTabs defaultValue="0" style={firstChildMargin(index)}>
+      <ElmTabs defaultValue="0">
         <ElmTabList>
           {tabs.map(({ tabId, labelIds }, idx) => (
             <ElmTab key={tabId} value={String(idx)}>
@@ -391,11 +365,10 @@ export const blockCatalog: CatalogRenderer = basicCatalog.extend(
   // Table
   // -------------------------------------------------------------------------
 
-  defineRenderer(TableApi, ({ props, index, childRefs, renderChild }) => (
+  defineRenderer(TableApi, ({ props, childRefs, renderChild }) => (
     <ElmTable
       caption={props.caption ? String(props.caption) : undefined}
       hasRowHeader={props.hasRowHeader}
-      style={firstChildMargin(index)}
     >
       {props.header && props.header.length > 0 && (
         <ElmTableHeader>
@@ -420,6 +393,9 @@ export const blockCatalog: CatalogRenderer = basicCatalog.extend(
     </ElmTableRow>
   )),
 
+  // `index` is threaded through as `columnIndex` here — unrelated to margin
+  // spacing, drives row-header (<th scope="row">) promotion for the first
+  // column when `hasRowHeader` is set. See elm-table-cell.tsx.
   defineRenderer(TableCellApi, ({ props, index, childRefs, renderChild }) => (
     <ElmTableCell isHeader={props.isHeader} columnIndex={index}>
       {childRefs(props.children).map(({ id, path }, i) => (
@@ -432,14 +408,13 @@ export const blockCatalog: CatalogRenderer = basicCatalog.extend(
   // Fallback
   // -------------------------------------------------------------------------
 
-  defineRenderer(UnsupportedApi, ({ props, index }) => (
+  defineRenderer(UnsupportedApi, ({ props }) => (
     <ElmUnsupportedBlock
       details={
         props.details
           ? `Unsupported component type: ${String(props.details)}`
           : "Unsupported component type"
       }
-      style={firstChildMargin(index)}
     />
   )),
 );

--- a/packages/qwik/src/components/a2ui/catalog/catalog-utils.ts
+++ b/packages/qwik/src/components/a2ui/catalog/catalog-utils.ts
@@ -30,17 +30,3 @@ export const objectFitMap: Record<string, CSSProperties["objectFit"]> = {
   none: "none",
   scaleDown: "scale-down",
 };
-
-/**
- * When applied to the first child in a flow, suppresses the top margin so
- * vertical rhythm doesn't add unwanted space above the leading block.
- * Reusable across every block-level renderer.
- *
- * Sets `margin-block-start` directly instead of the `--elmethis-margin-block-start`
- * custom property: the variable inherits, so on container renderers (Column,
- * ColumnList, Callout, Toggle, Tabs, …) the override would cascade into every
- * nested block and zero out all top margins.
- */
-export function firstChildMargin(index: number): CSSProperties | undefined {
-  return index === 0 ? { marginBlockStart: 0 } : undefined;
-}

--- a/packages/qwik/src/components/a2ui/catalog/catalog.ts
+++ b/packages/qwik/src/components/a2ui/catalog/catalog.ts
@@ -35,7 +35,13 @@ export interface ChildRef {
 export interface RenderArgs<TProps = Record<string, unknown>> {
   /** Unique component id within the surface. */
   componentId: string;
-  /** Zero-based index among siblings (used for first-child margin overrides). */
+  /**
+   * Zero-based index among siblings. Vertical spacing between stacked
+   * blocks is handled by `gap` on the parent flex container (see
+   * elm-a2ui.module.css's `.surface`), not by this index — the one
+   * remaining consumer is `TableCellApi`, which forwards it as
+   * `columnIndex` for row-header promotion.
+   */
   index: number;
   /** Typed properties as declared on the component's schema. */
   props: TProps;

--- a/packages/qwik/src/components/a2ui/elm-a2ui.module.css
+++ b/packages/qwik/src/components/a2ui/elm-a2ui.module.css
@@ -2,8 +2,23 @@
   display: contents;
 }
 
+/*
+ * Real flex container, not `display: contents` — `gap` needs a layout box
+ * to attach to. `gap` only ever applies between flex items, so the first
+ * block in the surface never floats an unexplained margin above it and
+ * nothing needs a first-child override (the old margin-based approach this
+ * replaced needed exactly that, via firstChildMargin() — see catalog-utils.ts
+ * history / block-catalog.tsx).
+ *
+ * ComponentHost wraps each rendered child in a `<span style="display:
+ * contents">` (see component-host.tsx) — that wrapper is transparent to the
+ * flex layout algorithm, so `gap` reaches each real block's root element
+ * with no extra plumbing.
+ */
 .surface {
-  display: contents;
+  display: flex;
+  flex-direction: column;
+  gap: var(--elmethis-stack-gap);
 }
 
 /* ---- text ---- */

--- a/packages/qwik/src/components/a2ui/elm-a2ui.module.css
+++ b/packages/qwik/src/components/a2ui/elm-a2ui.module.css
@@ -68,7 +68,7 @@
 .column {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--elmethis-stack-gap);
 }
 
 /* child-wrap lets Row/Column children participate in flex without extra styles */

--- a/packages/qwik/src/components/a2ui/elm-a2ui.tsx
+++ b/packages/qwik/src/components/a2ui/elm-a2ui.tsx
@@ -103,10 +103,7 @@ export const A2uiSurface = component$<A2uiSurfaceProps>((props) => {
   useContextProvider(A2uiAncestorContext, []);
 
   return (
-    <div
-      class={styles.surface}
-      style={{ "--elmethis-margin-block-start": "2rem" }}
-    >
+    <div class={styles.surface}>
       <ComponentHost id={ROOT_COMPONENT_ID} basePath="/" />
     </div>
   );
@@ -122,10 +119,7 @@ const SurfaceView = component$<{
   useContextProvider(A2uiAncestorContext, []);
 
   return (
-    <div
-      class={styles.surface}
-      style={{ "--elmethis-margin-block-start": "2rem" }}
-    >
+    <div class={styles.surface}>
       <ComponentHost id={ROOT_COMPONENT_ID} basePath="/" />
     </div>
   );

--- a/packages/qwik/src/components/ag-ui-client/components/elm-ag-ui-agent.tsx
+++ b/packages/qwik/src/components/ag-ui-client/components/elm-ag-ui-agent.tsx
@@ -161,10 +161,7 @@ export const ElmAgUiAgent = component$<ElmAgUiAgentProps>((props) => {
         ...style,
       }}
     >
-      <div
-        class={styles["agent-container"]}
-        style={{ "--elmethis-margin-block-start": "0" }}
-      >
+      <div class={styles["agent-container"]}>
         <div class={styles["messages"]}>
           <ElmAgUiMessageRenderer
             isRunning={state.isRunning}

--- a/packages/qwik/src/components/code/elm-code-block.module.css
+++ b/packages/qwik/src/components/code/elm-code-block.module.css
@@ -7,7 +7,6 @@
   box-sizing: border-box;
   width: 100%;
   margin: 0;
-  margin-block-start: var(--elmethis-margin-block-start);
   padding: 0.25rem;
   border-radius: 0.25rem;
   background-color: var(--elmethis-color-surface-raised);

--- a/packages/qwik/src/components/code/elm-html-viewer.module.css
+++ b/packages/qwik/src/components/code/elm-html-viewer.module.css
@@ -6,7 +6,6 @@
   box-sizing: border-box;
   width: 100%;
   margin: 0;
-  margin-block-start: var(--elmethis-margin-block-start);
   padding: 0.25rem;
   border-radius: 0.25rem;
   background-color: var(--elmethis-color-surface-raised);

--- a/packages/qwik/src/components/code/elm-katex.module.css
+++ b/packages/qwik/src/components/code/elm-katex.module.css
@@ -1,3 +1,6 @@
+/* Block-mode marker class — no rules of its own today; kept as a stable CSS
+   Modules hook so `block ? styles["elm-katex"] : undefined` in elm-katex.tsx
+   still distinguishes block vs. inline mode for consumers/future styling. */
+/* stylelint-disable-next-line block-no-empty */
 .elm-katex {
-  margin-block-start: var(--elmethis-margin-block-start);
 }

--- a/packages/qwik/src/components/containments/elm-tabs.module.css
+++ b/packages/qwik/src/components/containments/elm-tabs.module.css
@@ -1,5 +1,4 @@
 .elm-tabs {
-  margin-block-start: var(--elmethis-margin-block-start);
   display: flex;
   flex-direction: column;
   gap: 0;
@@ -57,5 +56,8 @@
 
 .tab-content-inner {
   box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: var(--elmethis-stack-gap);
   padding: 1em;
 }

--- a/packages/qwik/src/components/containments/elm-toggle.module.css
+++ b/packages/qwik/src/components/containments/elm-toggle.module.css
@@ -1,5 +1,4 @@
 .elm-toggle {
-  margin-block-start: var(--elmethis-margin-block-start);
   box-sizing: border-box;
   display: grid;
   grid-template: "summary summary" 2rem "border content" 0fr / 1px 1fr;
@@ -85,6 +84,9 @@
 .content {
   grid-area: content;
   box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: var(--elmethis-stack-gap);
   overflow: hidden;
   transition: padding 200ms;
   transition-timing-function: steps(1, jump-end);

--- a/packages/qwik/src/components/fallback/elm-unsupported-block.module.css
+++ b/packages/qwik/src/components/fallback/elm-unsupported-block.module.css
@@ -1,7 +1,6 @@
 .elm-unsupported-block {
   box-sizing: border-box;
   padding: 4rem;
-  margin-block-start: var(--elmethis-margin-block-start);
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/packages/qwik/src/components/form/elm-slider.module.css
+++ b/packages/qwik/src/components/form/elm-slider.module.css
@@ -1,7 +1,6 @@
 .elm-slider {
   box-sizing: border-box;
   width: 100%;
-  margin-block-start: var(--elmethis-margin-block-start);
   user-select: none;
 }
 

--- a/packages/qwik/src/components/media/elm-audio-player.module.css
+++ b/packages/qwik/src/components/media/elm-audio-player.module.css
@@ -1,7 +1,6 @@
 .elm-audio-player {
   box-sizing: border-box;
   width: 100%;
-  margin-block-start: var(--elmethis-margin-block-start);
   padding: 0.875rem 1.5rem;
   display: flex;
   flex-direction: column;

--- a/packages/qwik/src/components/media/elm-block-image.module.css
+++ b/packages/qwik/src/components/media/elm-block-image.module.css
@@ -1,5 +1,4 @@
 .elm-block-image {
-  margin-block-start: var(--elmethis-margin-block-start);
   margin-inline: 0;
   display: flex;
   justify-content: center;

--- a/packages/qwik/src/components/media/elm-file.module.css
+++ b/packages/qwik/src/components/media/elm-file.module.css
@@ -1,5 +1,4 @@
 .elm-file {
-  margin-block-start: var(--elmethis-margin-block-start);
   padding: 1rem;
   display: grid;
   grid-template-columns: 1.5rem 1fr 1fr 1.5rem;

--- a/packages/qwik/src/components/navigation/elm-bookmark.module.css
+++ b/packages/qwik/src/components/navigation/elm-bookmark.module.css
@@ -5,7 +5,6 @@
   border-radius: 0.25rem;
   box-shadow: 0 0 0.125rem rgb(0 0 0 / 10%);
   overflow: hidden;
-  margin-block-start: var(--elmethis-margin-block-start);
   transition:
     background-color 200ms,
     transform 200ms;

--- a/packages/qwik/src/components/others/elm-markdown.module.css
+++ b/packages/qwik/src/components/others/elm-markdown.module.css
@@ -1,3 +1,14 @@
 .elm-markdown {
   all: inherit;
+
+  /* Rendered markdown is a real stack of blocks (ElmHeading, ElmParagraph,
+     ElmList, ...). It renders through its own renderByToken recursion, not
+     the A2UI catalog renderer, but it's still just a stack — same flex+gap
+     treatment as elm-a2ui.module.css's .surface, and for the same reason:
+     gap only ever applies between items, so there's no first block to
+     special-case. `all: inherit` still applies to every other property;
+     `display` is overridden explicitly below. */
+  display: flex;
+  flex-direction: column;
+  gap: var(--elmethis-stack-gap);
 }

--- a/packages/qwik/src/components/table/elm-table.module.css
+++ b/packages/qwik/src/components/table/elm-table.module.css
@@ -3,7 +3,6 @@
 .elm-table-frame {
   position: relative;
   width: 100%;
-  margin-block-start: var(--elmethis-margin-block-start);
 }
 
 .elm-table-frame::before,

--- a/packages/qwik/src/components/typography/elm-block-quote.module.css
+++ b/packages/qwik/src/components/typography/elm-block-quote.module.css
@@ -1,7 +1,6 @@
 .elm-block-quote {
   box-sizing: border-box;
   width: 100%;
-  margin-block-start: var(--elmethis-margin-block-start);
   margin-inline: 0;
   background-color: oklch(from var(--elmethis-color-neutral) l c h / 12.5%);
   position: relative;
@@ -19,6 +18,9 @@
 
 .body {
   box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: var(--elmethis-stack-gap);
   padding: 2rem 1.5rem;
 }
 

--- a/packages/qwik/src/components/typography/elm-callout.module.css
+++ b/packages/qwik/src/components/typography/elm-callout.module.css
@@ -1,7 +1,6 @@
 .elm-callout {
   position: relative;
   padding: 1rem;
-  margin-block-start: var(--elmethis-margin-block-start);
 
   &::after {
     position: absolute;
@@ -34,6 +33,9 @@
   }
 
   .content {
+    display: flex;
+    flex-direction: column;
+    gap: var(--elmethis-stack-gap);
     padding-block: 1rem 0.25rem;
   }
 

--- a/packages/qwik/src/components/typography/elm-divider.module.css
+++ b/packages/qwik/src/components/typography/elm-divider.module.css
@@ -1,5 +1,4 @@
 .elm-divider {
-  margin-block-start: var(--elmethis-margin-block-start);
   width: 100%;
   border: none;
   border-bottom: dashed 1px var(--elmethis-color-primary);

--- a/packages/qwik/src/components/typography/elm-heading.module.css
+++ b/packages/qwik/src/components/typography/elm-heading.module.css
@@ -4,7 +4,6 @@
   font-size: var(--elmethis-scoped-font-size);
   line-height: var(--elmethis-scoped-font-size);
   opacity: var(--elmethis-scoped-opacity);
-  margin-block-start: var(--elmethis-margin-block-start);
   transition:
     color 400ms,
     opacity 800ms;

--- a/packages/qwik/src/components/typography/elm-list.module.css
+++ b/packages/qwik/src/components/typography/elm-list.module.css
@@ -1,5 +1,4 @@
 .elm-list {
-  margin-block-start: var(--elmethis-margin-block-start);
   opacity: var(--elmethis-scoped-opacity);
   transition: opacity 800ms;
   box-sizing: border-box;

--- a/packages/qwik/src/components/typography/elm-paragraph.module.css
+++ b/packages/qwik/src/components/typography/elm-paragraph.module.css
@@ -4,7 +4,6 @@
   color: var(--elmethis-scoped-color, var(--elmethis-color-neutral));
   background-color: var(--elmethis-scoped-background-color, inherit);
   margin: 0;
-  margin-block-start: var(--elmethis-margin-block-start);
 
   &::selection {
     color: var(--elmethis-color-surface-raised);

--- a/packages/react/src/components/a2ui/catalog/block-catalog.tsx
+++ b/packages/react/src/components/a2ui/catalog/block-catalog.tsx
@@ -156,6 +156,7 @@ const blockImplementations: ReactComponentImplementation[] = [
         flex: props.widthRatio != null ? String(props.widthRatio) : undefined,
         boxSizing: "border-box",
         padding: "0.125rem",
+        gap: "var(--elmethis-stack-gap)",
       }}
     >
       {renderChildList(props.children, buildChild)}

--- a/packages/react/src/components/a2ui/elm-a2ui.module.css
+++ b/packages/react/src/components/a2ui/elm-a2ui.module.css
@@ -2,8 +2,20 @@
   display: contents;
 }
 
-/* `display: contents` keeps the wrapper invisible to layout while still
-   letting `--elmethis-margin-block-start` inherit into the rendered surface. */
+/*
+ * Real flex container, not `display: contents` — `gap` needs a layout box
+ * to attach to. `gap` only ever applies between flex items, so the first
+ * block in the surface never floats an unexplained margin above it and
+ * nothing needs a first-child override (compare the old margin-based
+ * approach this replaced, which needed exactly that override here).
+ *
+ * The official `@a2ui/react` binder inserts no wrapper around a resolved
+ * child (see block-catalog.tsx's top comment), so each rendered block's
+ * real root element becomes a direct flex item of `.surface` — `gap`
+ * reaches it with no extra plumbing.
+ */
 .surface {
-  display: contents;
+  display: flex;
+  flex-direction: column;
+  gap: var(--elmethis-stack-gap);
 }

--- a/packages/react/src/components/a2ui/elm-a2ui.tsx
+++ b/packages/react/src/components/a2ui/elm-a2ui.tsx
@@ -18,7 +18,6 @@ import {
   useRef,
   useState,
   type ComponentPropsWithoutRef,
-  type CSSProperties,
 } from "react";
 import clsx from "clsx";
 import { marked } from "marked";
@@ -53,10 +52,6 @@ const renderMarkdown = async (markdown: string): Promise<string> => {
   const html = marked.parse(markdown, { async: false, gfm: true });
   return DOMPurify.sanitize(html);
 };
-
-const surfaceStyle = {
-  "--elmethis-margin-block-start": "2rem",
-} as CSSProperties;
 
 export interface ElmA2uiProps extends Omit<
   ComponentPropsWithoutRef<"div">,
@@ -251,7 +246,7 @@ export const ElmA2ui = ({
     >
       <MarkdownContext.Provider value={renderMarkdown}>
         {surfaces.map((surface) => (
-          <div key={surface.id} className={styles.surface} style={surfaceStyle}>
+          <div key={surface.id} className={styles.surface}>
             <A2uiSurface surface={surface} />
           </div>
         ))}

--- a/packages/react/src/components/code/elm-code-block.module.css
+++ b/packages/react/src/components/code/elm-code-block.module.css
@@ -7,7 +7,6 @@
   box-sizing: border-box;
   width: 100%;
   margin: 0;
-  margin-block-start: var(--elmethis-margin-block-start);
   padding: 0.25rem;
   border-radius: 0.25rem;
   background-color: var(--elmethis-color-surface-raised);

--- a/packages/react/src/components/code/elm-html-viewer.module.css
+++ b/packages/react/src/components/code/elm-html-viewer.module.css
@@ -6,7 +6,6 @@
   box-sizing: border-box;
   width: 100%;
   margin: 0;
-  margin-block-start: var(--elmethis-margin-block-start);
   padding: 0.25rem;
   border-radius: 0.25rem;
   background-color: var(--elmethis-color-surface-raised);

--- a/packages/react/src/components/code/elm-katex.module.css
+++ b/packages/react/src/components/code/elm-katex.module.css
@@ -1,3 +1,6 @@
+/* Block-mode marker class — no rules of its own today; kept as a stable CSS
+   Modules hook so `block ? styles["elm-katex"] : undefined` in elm-katex.tsx
+   still distinguishes block vs. inline mode for consumers/future styling. */
+/* stylelint-disable-next-line block-no-empty */
 .elm-katex {
-  margin-block-start: var(--elmethis-margin-block-start);
 }

--- a/packages/react/src/components/containments/elm-tabs.module.css
+++ b/packages/react/src/components/containments/elm-tabs.module.css
@@ -1,5 +1,4 @@
 .elm-tabs {
-  margin-block-start: var(--elmethis-margin-block-start);
   display: flex;
   flex-direction: column;
   gap: 0;
@@ -57,5 +56,8 @@
 
 .tab-content-inner {
   box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: var(--elmethis-stack-gap);
   padding: 1em;
 }

--- a/packages/react/src/components/containments/elm-toggle.module.css
+++ b/packages/react/src/components/containments/elm-toggle.module.css
@@ -1,5 +1,4 @@
 .elm-toggle {
-  margin-block-start: var(--elmethis-margin-block-start);
   box-sizing: border-box;
   display: grid;
   grid-template: "summary summary" 2rem "border content" 0fr / 1px 1fr;
@@ -85,6 +84,9 @@
 .content {
   grid-area: content;
   box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: var(--elmethis-stack-gap);
   overflow: hidden;
   transition: padding 200ms;
   transition-timing-function: steps(1, jump-end);

--- a/packages/react/src/components/fallback/elm-unsupported-block.module.css
+++ b/packages/react/src/components/fallback/elm-unsupported-block.module.css
@@ -1,7 +1,6 @@
 .elm-unsupported-block {
   box-sizing: border-box;
   padding: 4rem;
-  margin-block-start: var(--elmethis-margin-block-start);
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/packages/react/src/components/form/elm-slider.module.css
+++ b/packages/react/src/components/form/elm-slider.module.css
@@ -1,7 +1,6 @@
 .elm-slider {
   box-sizing: border-box;
   width: 100%;
-  margin-block-start: var(--elmethis-margin-block-start);
   user-select: none;
 }
 

--- a/packages/react/src/components/media/elm-audio-player.module.css
+++ b/packages/react/src/components/media/elm-audio-player.module.css
@@ -1,7 +1,6 @@
 .elm-audio-player {
   box-sizing: border-box;
   width: 100%;
-  margin-block-start: var(--elmethis-margin-block-start);
   padding: 0.875rem 1.5rem;
   display: flex;
   flex-direction: column;

--- a/packages/react/src/components/media/elm-block-image.module.css
+++ b/packages/react/src/components/media/elm-block-image.module.css
@@ -1,5 +1,4 @@
 .elm-block-image {
-  margin-block-start: var(--elmethis-margin-block-start);
   margin-inline: 0;
   display: flex;
   justify-content: center;

--- a/packages/react/src/components/media/elm-file.module.css
+++ b/packages/react/src/components/media/elm-file.module.css
@@ -1,5 +1,4 @@
 .elm-file {
-  margin-block-start: var(--elmethis-margin-block-start);
   padding: 1rem;
   display: grid;
   grid-template-columns: 1.5rem 1fr 1fr 1.5rem;

--- a/packages/react/src/components/navigation/elm-bookmark.module.css
+++ b/packages/react/src/components/navigation/elm-bookmark.module.css
@@ -5,7 +5,6 @@
   border-radius: 0.25rem;
   box-shadow: 0 0 0.125rem rgb(0 0 0 / 10%);
   overflow: hidden;
-  margin-block-start: var(--elmethis-margin-block-start);
   transition:
     background-color 200ms,
     transform 200ms;

--- a/packages/react/src/components/others/elm-markdown.module.css
+++ b/packages/react/src/components/others/elm-markdown.module.css
@@ -1,3 +1,14 @@
 .elm-markdown {
   all: inherit;
+
+  /* Rendered markdown is a real stack of blocks (ElmHeading, ElmParagraph,
+     ElmList, ...). It renders through its own renderByToken recursion, not
+     the A2UI catalog binder, but it's still just a stack — same flex+gap
+     treatment as elm-a2ui.module.css's .surface, and for the same reason:
+     gap only ever applies between items, so there's no first block to
+     special-case. `all: inherit` still applies to every other property;
+     `display` is overridden explicitly below. */
+  display: flex;
+  flex-direction: column;
+  gap: var(--elmethis-stack-gap);
 }

--- a/packages/react/src/components/table/elm-table.module.css
+++ b/packages/react/src/components/table/elm-table.module.css
@@ -3,7 +3,6 @@
 .elm-table-frame {
   position: relative;
   width: 100%;
-  margin-block-start: var(--elmethis-margin-block-start);
 }
 
 .elm-table-frame::before,

--- a/packages/react/src/components/typography/elm-block-quote.module.css
+++ b/packages/react/src/components/typography/elm-block-quote.module.css
@@ -1,7 +1,6 @@
 .elm-block-quote {
   box-sizing: border-box;
   width: 100%;
-  margin-block-start: var(--elmethis-margin-block-start);
   margin-inline: 0;
   background-color: oklch(from var(--elmethis-color-neutral) l c h / 12.5%);
   position: relative;
@@ -19,6 +18,9 @@
 
 .body {
   box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: var(--elmethis-stack-gap);
   padding: 2rem 1.5rem;
 }
 

--- a/packages/react/src/components/typography/elm-callout.module.css
+++ b/packages/react/src/components/typography/elm-callout.module.css
@@ -1,7 +1,6 @@
 .elm-callout {
   position: relative;
   padding: 1rem;
-  margin-block-start: var(--elmethis-margin-block-start);
 
   &::after {
     position: absolute;
@@ -34,6 +33,9 @@
   }
 
   .content {
+    display: flex;
+    flex-direction: column;
+    gap: var(--elmethis-stack-gap);
     padding-block: 1rem 0.25rem;
   }
 

--- a/packages/react/src/components/typography/elm-divider.module.css
+++ b/packages/react/src/components/typography/elm-divider.module.css
@@ -1,5 +1,4 @@
 .elm-divider {
-  margin-block-start: var(--elmethis-margin-block-start);
   width: 100%;
   border: none;
   border-bottom: dashed 1px var(--elmethis-color-primary);

--- a/packages/react/src/components/typography/elm-heading.module.css
+++ b/packages/react/src/components/typography/elm-heading.module.css
@@ -4,7 +4,6 @@
   font-size: var(--elmethis-scoped-font-size);
   line-height: var(--elmethis-scoped-font-size);
   opacity: var(--elmethis-scoped-opacity);
-  margin-block-start: var(--elmethis-margin-block-start);
   transition:
     color 400ms,
     opacity 800ms;

--- a/packages/react/src/components/typography/elm-list.module.css
+++ b/packages/react/src/components/typography/elm-list.module.css
@@ -1,5 +1,4 @@
 .elm-list {
-  margin-block-start: var(--elmethis-margin-block-start);
   opacity: var(--elmethis-scoped-opacity);
   transition: opacity 800ms;
   box-sizing: border-box;

--- a/packages/react/src/components/typography/elm-paragraph.module.css
+++ b/packages/react/src/components/typography/elm-paragraph.module.css
@@ -4,7 +4,6 @@
   color: var(--elmethis-scoped-color, var(--elmethis-color-neutral));
   background-color: var(--elmethis-scoped-background-color, inherit);
   margin: 0;
-  margin-block-start: var(--elmethis-margin-block-start);
 
   &::selection {
     color: var(--elmethis-color-surface-raised);

--- a/packages/vue/src/components/a2ui/catalog/basic-catalog.tsx
+++ b/packages/vue/src/components/a2ui/catalog/basic-catalog.tsx
@@ -9,7 +9,6 @@
  * coupling. (Vue has no QRL boundary, so these are plain functions — unlike the
  * qwik lead's `setBinding$` / `dispatchAction$` QRLs.)
  */
-import { type CSSProperties } from "vue";
 import { clsx } from "clsx";
 
 import {
@@ -100,10 +99,7 @@ export const basicCatalog: CatalogRenderer = new CatalogRenderer([
   )),
 
   defineRenderer(ColumnApi, ({ props, childRefs, renderChild }) => (
-    <div
-      class={styles.column}
-      style={{ "--margin-block": "2rem" } as CSSProperties}
-    >
+    <div class={styles.column}>
       {childRefs(props.children).map(({ id, path }, i) => (
         <span key={`${id}:${i}`} class={styles["child-wrap"]}>
           {renderChild(id, path, i)}

--- a/packages/vue/src/components/a2ui/catalog/block-catalog.tsx
+++ b/packages/vue/src/components/a2ui/catalog/block-catalog.tsx
@@ -37,11 +37,7 @@ import {
 import { ElmUnsupportedBlock } from "../../fallback/elm-unsupported-block";
 
 import { CatalogRenderer, defineRenderer } from "./catalog";
-import {
-  alignItemsMap,
-  firstChildMargin,
-  justifyContentMap,
-} from "./catalog-utils";
+import { alignItemsMap, justifyContentMap } from "./catalog-utils";
 import { basicCatalog } from "./basic-catalog";
 import {
   AudioApi,
@@ -140,7 +136,7 @@ export const blockCatalog: CatalogRenderer = basicCatalog.extend(
   // Layout (overrides Column from basicCatalog with widthRatio support)
   // -------------------------------------------------------------------------
 
-  defineRenderer(ColumnApi, ({ props, index, childRefs, renderChild }) => (
+  defineRenderer(ColumnApi, ({ props, childRefs, renderChild }) => (
     <div
       style={{
         display: "flex",
@@ -150,7 +146,7 @@ export const blockCatalog: CatalogRenderer = basicCatalog.extend(
         flex: props.widthRatio != null ? String(props.widthRatio) : undefined,
         boxSizing: "border-box",
         padding: "0.125rem",
-        ...firstChildMargin(index),
+        gap: "var(--elmethis-stack-gap)",
       }}
     >
       {childRefs(props.children).map(({ id, path }, i) => (
@@ -159,8 +155,8 @@ export const blockCatalog: CatalogRenderer = basicCatalog.extend(
     </div>
   )),
 
-  defineRenderer(ColumnListApi, ({ props, index, childRefs, renderChild }) => (
-    <div style={{ ...columnListStyle, ...firstChildMargin(index) }}>
+  defineRenderer(ColumnListApi, ({ props, childRefs, renderChild }) => (
+    <div style={columnListStyle}>
       {childRefs(props.children).map(({ id, path }, i) => (
         <Fragment key={`${id}:${i}`}>{renderChild(id, path, i)}</Fragment>
       ))}
@@ -171,31 +167,24 @@ export const blockCatalog: CatalogRenderer = basicCatalog.extend(
   // Block typography
   // -------------------------------------------------------------------------
 
-  defineRenderer(HeadingApi, ({ props, index, childRefs, renderChild }) => (
-    <ElmHeading level={props.level} style={firstChildMargin(index)}>
+  defineRenderer(HeadingApi, ({ props, childRefs, renderChild }) => (
+    <ElmHeading level={props.level}>
       {childRefs(props.children).map(({ id, path }, i) => (
         <Fragment key={`${id}:${i}`}>{renderChild(id, path, i)}</Fragment>
       ))}
     </ElmHeading>
   )),
 
-  defineRenderer(ParagraphApi, ({ props, index, childRefs, renderChild }) => (
-    <ElmParagraph
-      color={props.color}
-      backgroundColor={props.backgroundColor}
-      style={firstChildMargin(index)}
-    >
+  defineRenderer(ParagraphApi, ({ props, childRefs, renderChild }) => (
+    <ElmParagraph color={props.color} backgroundColor={props.backgroundColor}>
       {childRefs(props.children).map(({ id, path }, i) => (
         <span key={`${id}:${i}`}>{renderChild(id, path, i)}</span>
       ))}
     </ElmParagraph>
   )),
 
-  defineRenderer(ListApi, ({ props, index, childRefs, renderChild }) => (
-    <ElmList
-      listStyle={props.style ?? "unordered"}
-      style={firstChildMargin(index)}
-    >
+  defineRenderer(ListApi, ({ props, childRefs, renderChild }) => (
+    <ElmList listStyle={props.style ?? "unordered"}>
       {childRefs(props.children).map(({ id, path }, i) => (
         <li key={`${id}:${i}`}>{renderChild(id, path, i)}</li>
       ))}
@@ -210,30 +199,28 @@ export const blockCatalog: CatalogRenderer = basicCatalog.extend(
     </>
   )),
 
-  defineRenderer(BlockQuoteApi, ({ props, index, childRefs, renderChild }) => (
+  defineRenderer(BlockQuoteApi, ({ props, childRefs, renderChild }) => (
     // `cite` is a native <blockquote> attribute forwarded via fallthrough; vue's
     // ElmBlockQuote doesn't declare it, so it's passed as a spread attr.
-    <ElmBlockQuote {...{ cite: props.cite }} style={firstChildMargin(index)}>
+    <ElmBlockQuote {...{ cite: props.cite }}>
       {childRefs(props.children).map(({ id, path }, i) => (
         <Fragment key={`${id}:${i}`}>{renderChild(id, path, i)}</Fragment>
       ))}
     </ElmBlockQuote>
   )),
 
-  defineRenderer(CalloutApi, ({ props, index, childRefs, renderChild }) => (
-    <ElmCallout type={props.type} style={firstChildMargin(index)}>
+  defineRenderer(CalloutApi, ({ props, childRefs, renderChild }) => (
+    <ElmCallout type={props.type}>
       {childRefs(props.children).map(({ id, path }, i) => (
         <Fragment key={`${id}:${i}`}>{renderChild(id, path, i)}</Fragment>
       ))}
     </ElmCallout>
   )),
 
-  defineRenderer(DividerApi, ({ index }) => (
-    <ElmDivider style={firstChildMargin(index)} />
-  )),
+  defineRenderer(DividerApi, () => <ElmDivider />),
 
-  defineRenderer(ToggleApi, ({ props, index, childRefs, renderChild }) => (
-    <ElmToggle style={firstChildMargin(index)}>
+  defineRenderer(ToggleApi, ({ props, childRefs, renderChild }) => (
+    <ElmToggle>
       {{
         summary: () =>
           childRefs(props.summary).map(({ id, path }, i) => (
@@ -251,25 +238,23 @@ export const blockCatalog: CatalogRenderer = basicCatalog.extend(
   // Media / embed
   // -------------------------------------------------------------------------
 
-  defineRenderer(BookmarkApi, ({ props, index, resolve }) => (
+  defineRenderer(BookmarkApi, ({ props, resolve }) => (
     <ElmBookmark
       url={resolve(props.url)}
       title={props.title ? resolve(props.title) : undefined}
       description={props.description ? resolve(props.description) : undefined}
       image={props.image ? resolve(props.image) : undefined}
-      style={firstChildMargin(index)}
     />
   )),
 
-  defineRenderer(FileApi, ({ props, index, resolve }) => (
+  defineRenderer(FileApi, ({ props, resolve }) => (
     <ElmFile
       src={resolve(props.src)}
       name={props.name ? resolve(props.name) : undefined}
-      style={firstChildMargin(index)}
     />
   )),
 
-  defineRenderer(AudioApi, ({ props, index, resolve }) => (
+  defineRenderer(AudioApi, ({ props, resolve }) => (
     <ElmAudioPlayer
       src={resolve(props.src)}
       title={props.title ? resolve(props.title) : undefined}
@@ -277,14 +262,13 @@ export const blockCatalog: CatalogRenderer = basicCatalog.extend(
       seekStep={props.seekStep}
       loop={props.loop}
       autoplay={props.autoPlay}
-      style={firstChildMargin(index)}
     />
   )),
 
-  defineRenderer(VideoApi, ({ props, index, resolve }) => {
+  defineRenderer(VideoApi, ({ props, resolve }) => {
     const caption = props.caption ? resolve(props.caption) : undefined;
     return (
-      <figure style={{ ...firstChildMargin(index), margin: 0 }}>
+      <figure style={{ margin: 0 }}>
         <video
           src={resolve(props.src)}
           poster={props.poster ? resolve(props.poster) : undefined}
@@ -302,7 +286,7 @@ export const blockCatalog: CatalogRenderer = basicCatalog.extend(
     );
   }),
 
-  defineRenderer(BlockImageApi, ({ props, index, resolve }) => (
+  defineRenderer(BlockImageApi, ({ props, resolve }) => (
     <ElmBlockImage
       src={resolve(props.src)}
       alt={props.alt ? resolve(props.alt) : undefined}
@@ -312,7 +296,6 @@ export const blockCatalog: CatalogRenderer = basicCatalog.extend(
       sizes={props.sizes ? resolve(props.sizes) : undefined}
       caption={props.caption ? resolve(props.caption) : undefined}
       enableModal={true}
-      style={firstChildMargin(index)}
     />
   )),
 
@@ -320,32 +303,23 @@ export const blockCatalog: CatalogRenderer = basicCatalog.extend(
   // Code / math / diagram
   // -------------------------------------------------------------------------
 
-  defineRenderer(CodeBlockApi, ({ props, index, resolve }) => (
+  defineRenderer(CodeBlockApi, ({ props, resolve }) => (
     <ElmCodeBlock
       code={resolve(props.code)}
       language={props.language ? resolve(props.language) : undefined}
       caption={props.caption ? resolve(props.caption) : undefined}
-      style={firstChildMargin(index)}
     />
   )),
 
-  defineRenderer(KatexApi, ({ props, index, resolve }) => (
-    <ElmKatex
-      expression={resolve(props.expression)}
-      block={true}
-      style={firstChildMargin(index)}
-    />
+  defineRenderer(KatexApi, ({ props, resolve }) => (
+    <ElmKatex expression={resolve(props.expression)} block={true} />
   )),
 
   // Mermaid is rendered as a syntax-highlighted code block — no dedicated
   // Mermaid renderer in this package. The diagram source is preserved so a
   // host application can post-process if needed.
-  defineRenderer(MermaidApi, ({ props, index, resolve }) => (
-    <ElmCodeBlock
-      code={resolve(props.code)}
-      language="mermaid"
-      style={firstChildMargin(index)}
-    />
+  defineRenderer(MermaidApi, ({ props, resolve }) => (
+    <ElmCodeBlock code={resolve(props.code)} language="mermaid" />
   )),
 
   // -------------------------------------------------------------------------
@@ -355,7 +329,7 @@ export const blockCatalog: CatalogRenderer = basicCatalog.extend(
 
   defineRenderer(ContentTabApi, () => null),
 
-  defineRenderer(ContentTabsApi, ({ props, index, surface, renderChild }) => {
+  defineRenderer(ContentTabsApi, ({ props, surface, renderChild }) => {
     const tabIds = Array.isArray(props.children) ? props.children : [];
     const tabs = tabIds.map((tabId) => {
       const tabModel = surface.componentsModel.get(tabId);
@@ -366,7 +340,7 @@ export const blockCatalog: CatalogRenderer = basicCatalog.extend(
       };
     });
     return (
-      <ElmTabs defaultValue="0" style={firstChildMargin(index)}>
+      <ElmTabs defaultValue="0">
         <ElmTabList>
           {tabs.map(({ tabId, labelIds }, idx) => (
             <ElmTab key={tabId} value={String(idx)}>
@@ -395,11 +369,10 @@ export const blockCatalog: CatalogRenderer = basicCatalog.extend(
   // Table
   // -------------------------------------------------------------------------
 
-  defineRenderer(TableApi, ({ props, index, childRefs, renderChild }) => (
+  defineRenderer(TableApi, ({ props, childRefs, renderChild }) => (
     <ElmTable
       caption={props.caption ? String(props.caption) : undefined}
       hasRowHeader={props.hasRowHeader}
-      style={firstChildMargin(index)}
     >
       {props.header && props.header.length > 0 && (
         <ElmTableHeader>
@@ -424,6 +397,9 @@ export const blockCatalog: CatalogRenderer = basicCatalog.extend(
     </ElmTableRow>
   )),
 
+  // `index` is threaded through as `columnIndex` here — unrelated to margin
+  // spacing, drives row-header (<th scope="row">) promotion for the first
+  // column when `hasRowHeader` is set. See elm-table-cell.tsx.
   defineRenderer(TableCellApi, ({ props, index, childRefs, renderChild }) => (
     <ElmTableCell isHeader={props.isHeader} columnIndex={index}>
       {childRefs(props.children).map(({ id, path }, i) => (
@@ -436,14 +412,13 @@ export const blockCatalog: CatalogRenderer = basicCatalog.extend(
   // Fallback
   // -------------------------------------------------------------------------
 
-  defineRenderer(UnsupportedApi, ({ props, index }) => (
+  defineRenderer(UnsupportedApi, ({ props }) => (
     <ElmUnsupportedBlock
       details={
         props.details
           ? `Unsupported component type: ${String(props.details)}`
           : "Unsupported component type"
       }
-      style={firstChildMargin(index)}
     />
   )),
 );

--- a/packages/vue/src/components/a2ui/catalog/catalog-utils.ts
+++ b/packages/vue/src/components/a2ui/catalog/catalog-utils.ts
@@ -30,17 +30,3 @@ export const objectFitMap: Record<string, CSSProperties["objectFit"]> = {
   none: "none",
   scaleDown: "scale-down",
 };
-
-/**
- * When applied to the first child in a flow, suppresses the top margin so
- * vertical rhythm doesn't add unwanted space above the leading block.
- * Reusable across every block-level renderer.
- *
- * Sets `margin-block-start` directly instead of the `--elmethis-margin-block-start`
- * custom property: the variable inherits, so on container renderers (Column,
- * ColumnList, Callout, Toggle, Tabs, …) the override would cascade into every
- * nested block and zero out all top margins.
- */
-export function firstChildMargin(index: number): CSSProperties | undefined {
-  return index === 0 ? { marginBlockStart: 0 } : undefined;
-}

--- a/packages/vue/src/components/a2ui/catalog/catalog.ts
+++ b/packages/vue/src/components/a2ui/catalog/catalog.ts
@@ -39,7 +39,13 @@ export interface ChildRef {
 export interface RenderArgs<TProps = Record<string, unknown>> {
   /** Unique component id within the surface. */
   componentId: string;
-  /** Zero-based index among siblings (used for first-child margin overrides). */
+  /**
+   * Zero-based index among siblings. Vertical spacing between stacked
+   * blocks is handled by `gap` on the parent flex container (see
+   * elm-a2ui.module.css's `.surface`), not by this index — the one
+   * remaining consumer is `TableCellApi`, which forwards it as
+   * `columnIndex` for row-header promotion.
+   */
   index: number;
   /** Typed properties as declared on the component's schema. */
   props: TProps;

--- a/packages/vue/src/components/a2ui/elm-a2ui.module.css
+++ b/packages/vue/src/components/a2ui/elm-a2ui.module.css
@@ -2,8 +2,23 @@
   display: contents;
 }
 
+/*
+ * Real flex container, not `display: contents` — `gap` needs a layout box
+ * to attach to. `gap` only ever applies between flex items, so the first
+ * block in the surface never floats an unexplained margin above it and
+ * nothing needs a first-child override (the old margin-based approach this
+ * replaced needed exactly that, via firstChildMargin() — see catalog-utils.ts
+ * history / block-catalog.tsx).
+ *
+ * ComponentHost wraps each rendered child in a `<span style="display:
+ * contents">` (see component-host.tsx) — that wrapper is transparent to the
+ * flex layout algorithm, so `gap` reaches each real block's root element
+ * with no extra plumbing.
+ */
 .surface {
-  display: contents;
+  display: flex;
+  flex-direction: column;
+  gap: var(--elmethis-stack-gap);
 }
 
 /* ---- text ---- */

--- a/packages/vue/src/components/a2ui/elm-a2ui.module.css
+++ b/packages/vue/src/components/a2ui/elm-a2ui.module.css
@@ -68,7 +68,7 @@
 .column {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--elmethis-stack-gap);
 }
 
 /* child-wrap lets Row/Column children participate in flex without extra styles */

--- a/packages/vue/src/components/a2ui/elm-a2ui.tsx
+++ b/packages/vue/src/components/a2ui/elm-a2ui.tsx
@@ -85,10 +85,7 @@ const SurfaceView = defineComponent({
     provide(A2uiAncestorContext, []);
 
     return () => (
-      <div
-        class={styles.surface}
-        style={{ "--elmethis-margin-block-start": "2rem" }}
-      >
+      <div class={styles.surface}>
         <ComponentHost id={ROOT_COMPONENT_ID} basePath="/" />
       </div>
     );
@@ -128,10 +125,7 @@ export const A2uiSurface = defineComponent({
     provide(A2uiAncestorContext, []);
 
     return () => (
-      <div
-        class={styles.surface}
-        style={{ "--elmethis-margin-block-start": "2rem" }}
-      >
+      <div class={styles.surface}>
         <ComponentHost id={ROOT_COMPONENT_ID} basePath="/" />
       </div>
     );

--- a/packages/vue/src/components/code/elm-code-block.module.css
+++ b/packages/vue/src/components/code/elm-code-block.module.css
@@ -7,7 +7,6 @@
   box-sizing: border-box;
   width: 100%;
   margin: 0;
-  margin-block-start: var(--elmethis-margin-block-start);
   padding: 0.25rem;
   border-radius: 0.25rem;
   background-color: var(--elmethis-color-surface-raised);

--- a/packages/vue/src/components/code/elm-html-viewer.module.css
+++ b/packages/vue/src/components/code/elm-html-viewer.module.css
@@ -6,7 +6,6 @@
   box-sizing: border-box;
   width: 100%;
   margin: 0;
-  margin-block-start: var(--elmethis-margin-block-start);
   padding: 0.25rem;
   border-radius: 0.25rem;
   background-color: var(--elmethis-color-surface-raised);

--- a/packages/vue/src/components/code/elm-katex.module.css
+++ b/packages/vue/src/components/code/elm-katex.module.css
@@ -1,3 +1,6 @@
+/* Block-mode marker class — no rules of its own today; kept as a stable CSS
+   Modules hook so `block ? styles["elm-katex"] : undefined` in elm-katex.tsx
+   still distinguishes block vs. inline mode for consumers/future styling. */
+/* stylelint-disable-next-line block-no-empty */
 .elm-katex {
-  margin-block-start: var(--elmethis-margin-block-start);
 }

--- a/packages/vue/src/components/containments/elm-tabs.module.css
+++ b/packages/vue/src/components/containments/elm-tabs.module.css
@@ -1,5 +1,4 @@
 .elm-tabs {
-  margin-block-start: var(--elmethis-margin-block-start);
   display: flex;
   flex-direction: column;
   gap: 0;
@@ -57,5 +56,8 @@
 
 .tab-content-inner {
   box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: var(--elmethis-stack-gap);
   padding: 1em;
 }

--- a/packages/vue/src/components/containments/elm-toggle.module.css
+++ b/packages/vue/src/components/containments/elm-toggle.module.css
@@ -1,5 +1,4 @@
 .elm-toggle {
-  margin-block-start: var(--elmethis-margin-block-start);
   box-sizing: border-box;
   display: grid;
   grid-template: "summary summary" 2rem "border content" 0fr / 1px 1fr;
@@ -85,6 +84,9 @@
 .content {
   grid-area: content;
   box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: var(--elmethis-stack-gap);
   overflow: hidden;
   transition: padding 200ms;
   transition-timing-function: steps(1, jump-end);

--- a/packages/vue/src/components/fallback/elm-unsupported-block.module.css
+++ b/packages/vue/src/components/fallback/elm-unsupported-block.module.css
@@ -1,7 +1,6 @@
 .elm-unsupported-block {
   box-sizing: border-box;
   padding: 4rem;
-  margin-block-start: var(--elmethis-margin-block-start);
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/packages/vue/src/components/form/elm-slider.module.css
+++ b/packages/vue/src/components/form/elm-slider.module.css
@@ -1,7 +1,6 @@
 .elm-slider {
   box-sizing: border-box;
   width: 100%;
-  margin-block-start: var(--elmethis-margin-block-start);
   user-select: none;
 }
 

--- a/packages/vue/src/components/media/elm-audio-player.module.css
+++ b/packages/vue/src/components/media/elm-audio-player.module.css
@@ -1,7 +1,6 @@
 .elm-audio-player {
   box-sizing: border-box;
   width: 100%;
-  margin-block-start: var(--elmethis-margin-block-start);
   padding: 0.875rem 1.5rem;
   display: flex;
   flex-direction: column;

--- a/packages/vue/src/components/media/elm-block-image.module.css
+++ b/packages/vue/src/components/media/elm-block-image.module.css
@@ -1,5 +1,4 @@
 .elm-block-image {
-  margin-block-start: var(--elmethis-margin-block-start);
   margin-inline: 0;
   display: flex;
   justify-content: center;

--- a/packages/vue/src/components/media/elm-file.module.css
+++ b/packages/vue/src/components/media/elm-file.module.css
@@ -1,5 +1,4 @@
 .elm-file {
-  margin-block-start: var(--elmethis-margin-block-start);
   padding: 1rem;
   display: grid;
   grid-template-columns: 1.5rem 1fr 1fr 1.5rem;

--- a/packages/vue/src/components/navigation/elm-bookmark.module.css
+++ b/packages/vue/src/components/navigation/elm-bookmark.module.css
@@ -5,7 +5,6 @@
   border-radius: 0.25rem;
   box-shadow: 0 0 0.125rem rgb(0 0 0 / 10%);
   overflow: hidden;
-  margin-block-start: var(--elmethis-margin-block-start);
   transition:
     background-color 200ms,
     transform 200ms;

--- a/packages/vue/src/components/others/elm-markdown.module.css
+++ b/packages/vue/src/components/others/elm-markdown.module.css
@@ -1,3 +1,14 @@
 .elm-markdown {
   all: inherit;
+
+  /* Rendered markdown is a real stack of blocks (ElmHeading, ElmParagraph,
+     ElmList, ...). It renders through its own renderByToken recursion, not
+     the A2UI catalog renderer, but it's still just a stack — same flex+gap
+     treatment as elm-a2ui.module.css's .surface, and for the same reason:
+     gap only ever applies between items, so there's no first block to
+     special-case. `all: inherit` still applies to every other property;
+     `display` is overridden explicitly below. */
+  display: flex;
+  flex-direction: column;
+  gap: var(--elmethis-stack-gap);
 }

--- a/packages/vue/src/components/table/elm-table.module.css
+++ b/packages/vue/src/components/table/elm-table.module.css
@@ -3,7 +3,6 @@
 .elm-table-frame {
   position: relative;
   width: 100%;
-  margin-block-start: var(--elmethis-margin-block-start);
 }
 
 .elm-table-frame::before,

--- a/packages/vue/src/components/typography/elm-block-quote.module.css
+++ b/packages/vue/src/components/typography/elm-block-quote.module.css
@@ -1,7 +1,6 @@
 .elm-block-quote {
   box-sizing: border-box;
   width: 100%;
-  margin-block-start: var(--elmethis-margin-block-start);
   margin-inline: 0;
   background-color: oklch(from var(--elmethis-color-neutral) l c h / 12.5%);
   position: relative;
@@ -19,6 +18,9 @@
 
 .body {
   box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: var(--elmethis-stack-gap);
   padding: 2rem 1.5rem;
 }
 

--- a/packages/vue/src/components/typography/elm-callout.module.css
+++ b/packages/vue/src/components/typography/elm-callout.module.css
@@ -1,7 +1,6 @@
 .elm-callout {
   position: relative;
   padding: 1rem;
-  margin-block-start: var(--elmethis-margin-block-start);
 
   &::after {
     position: absolute;
@@ -34,6 +33,9 @@
   }
 
   .content {
+    display: flex;
+    flex-direction: column;
+    gap: var(--elmethis-stack-gap);
     padding-block: 1rem 0.25rem;
   }
 

--- a/packages/vue/src/components/typography/elm-divider.module.css
+++ b/packages/vue/src/components/typography/elm-divider.module.css
@@ -1,5 +1,4 @@
 .elm-divider {
-  margin-block-start: var(--elmethis-margin-block-start);
   width: 100%;
   border: none;
   border-bottom: dashed 1px var(--elmethis-color-primary);

--- a/packages/vue/src/components/typography/elm-heading.module.css
+++ b/packages/vue/src/components/typography/elm-heading.module.css
@@ -4,7 +4,6 @@
   font-size: var(--elmethis-scoped-font-size);
   line-height: var(--elmethis-scoped-font-size);
   opacity: var(--elmethis-scoped-opacity);
-  margin-block-start: var(--elmethis-margin-block-start);
   transition:
     color 400ms,
     opacity 800ms;

--- a/packages/vue/src/components/typography/elm-list.module.css
+++ b/packages/vue/src/components/typography/elm-list.module.css
@@ -1,5 +1,4 @@
 .elm-list {
-  margin-block-start: var(--elmethis-margin-block-start);
   opacity: var(--elmethis-scoped-opacity);
   transition: opacity 800ms;
   box-sizing: border-box;

--- a/packages/vue/src/components/typography/elm-paragraph.module.css
+++ b/packages/vue/src/components/typography/elm-paragraph.module.css
@@ -4,7 +4,6 @@
   color: var(--elmethis-scoped-color, var(--elmethis-color-neutral));
   background-color: var(--elmethis-scoped-background-color, inherit);
   margin: 0;
-  margin-block-start: var(--elmethis-margin-block-start);
 
   &::selection {
     color: var(--elmethis-color-surface-raised);


### PR DESCRIPTION
## Summary
- Replace the `--elmethis-margin-block-start` CSS token with `--elmethis-stack-gap` (2rem) across react/qwik/vue, moving vertical spacing between stacked components from `margin-block-start` to flex `gap`.
- Fix a regression found while validating the migration: qwik/vue's `basicCatalog` (the default A2UI catalog used whenever a consumer doesn't pass `catalog={blockCatalog}`) still had its own un-migrated `ColumnApi`, with a hardcoded `8px` gap and a dead `--margin-block` inline style. This made basic-catalog-rendered content (e.g. most Storybook A2UI demo stories) look noticeably denser than block-catalog content. React was unaffected since it merges both catalogs into one.

## Test plan
- [x] `pnpm --filter @elmethis/qwik run check` and `test.unit` (533/533 passing)
- [x] `pnpm --filter @elmethis/vue run check` and `test.unit` (419/419 passing)
- [x] Verified in Storybook (computed styles + bounding-rect deltas) that qwik/vue A2UI Column spacing now matches the shared stack gap