### PR TITLE
Add Html block stories for qwik, react, and vue

### DIFF
--- a/packages/qwik/src/components/a2ui/catalog/block-catalog.stories.tsx
+++ b/packages/qwik/src/components/a2ui/catalog/block-catalog.stories.tsx
@@ -624,6 +624,34 @@ export const BlockImage: Story = {
 };
 
 // ---------------------------------------------------------------------------
+// Html
+// ---------------------------------------------------------------------------
+
+export const Html: Story = {
+  args: {
+    messages: [
+      {
+        version: "v0.9",
+        createSurface: { surfaceId: "html", catalogId: CATALOG_ID },
+      },
+      {
+        version: "v0.9",
+        updateComponents: {
+          surfaceId: "html",
+          components: [
+            {
+              component: "Html",
+              id: "root",
+              html: '<!doctype html><html><body style="font-family: sans-serif; margin: 0; padding: 1rem;"><h1>Hello from an iframe</h1><p>This markup is rendered inside a sandboxed <code>&lt;iframe&gt;</code>.</p></body></html>',
+            },
+          ],
+        },
+      },
+    ],
+  },
+};
+
+// ---------------------------------------------------------------------------
 // CodeBlock
 // ---------------------------------------------------------------------------
 

--- a/packages/react/src/components/a2ui/elm-a2ui.stories.tsx
+++ b/packages/react/src/components/a2ui/elm-a2ui.stories.tsx
@@ -352,6 +352,42 @@ export const BlockCatalog: Story = {
   ),
 };
 
+export const Html: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The `Html` block renders raw markup inside a sandboxed `<iframe>` " +
+          "via `ElmHtml` — useful for embedding a Claude-authored artifact or " +
+          "a Notion page export.",
+      },
+    },
+  },
+  render: () => (
+    <ElmA2ui
+      messages={[
+        {
+          version: "v0.9",
+          createSurface: { surfaceId: "html", catalogId: CATALOG_ID },
+        },
+        {
+          version: "v0.9",
+          updateComponents: {
+            surfaceId: "html",
+            components: [
+              {
+                component: "Html",
+                id: "root",
+                html: '<!doctype html><html><body style="font-family: sans-serif; margin: 0; padding: 1rem;"><h1>Hello from an iframe</h1><p>This markup is rendered inside a sandboxed <code>&lt;iframe&gt;</code>.</p></body></html>',
+              },
+            ],
+          },
+        },
+      ]}
+    />
+  ),
+};
+
 // ---------------------------------------------------------------------------
 // Streaming stories — progressive message delivery
 // ---------------------------------------------------------------------------

--- a/packages/vue/src/components/a2ui/catalog/block-catalog.stories.tsx
+++ b/packages/vue/src/components/a2ui/catalog/block-catalog.stories.tsx
@@ -118,6 +118,18 @@ export const Video: Story = {
   },
 };
 
+export const Html: Story = {
+  args: {
+    messages: surface([
+      {
+        component: "Html",
+        id: "root",
+        html: '<!doctype html><html><body style="font-family: sans-serif; margin: 0; padding: 1rem;"><h1>Hello from an iframe</h1><p>This markup is rendered inside a sandboxed <code>&lt;iframe&gt;</code>.</p></body></html>',
+      },
+    ]),
+  },
+};
+
 export const Table: Story = {
   args: {
     messages: surface([


### PR DESCRIPTION
## Summary
- Add a `Html` Storybook story to qwik's and vue's dedicated `block-catalog.stories.tsx` files, matching the per-block-type story convention used for the other Media/embed blocks (`BlockImage`, `Video`, etc.)
- Add a `Html` story to react's `elm-a2ui.stories.tsx` (react has no separate per-block catalog stories file)
- All three demonstrate the `Html` block added in #1731, rendering sandboxed iframe markup via `ElmHtml`

## Test plan
- [x] `pnpm --filter @elmethis/qwik run check`
- [x] `pnpm --filter @elmethis/react run check`
- [x] `pnpm --filter @elmethis/vue run check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)