### PR TITLE
Add remote src support to A2UI Html component (qwik/react/vue)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elmethis/core",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "author": {
     "name": "Ikuma Yamashita",
     "url": "https://www.ikuma.cloud/"

--- a/packages/core/src/a2ui/v0_9/block-catalog.ts
+++ b/packages/core/src/a2ui/v0_9/block-catalog.ts
@@ -502,8 +502,10 @@ export const BlockImageApi = {
 } satisfies ComponentApi;
 
 /**
- * Sandboxed raw-HTML embed. Renders `html` inside an iframe (e.g. a
- * Claude-authored artifact or a Notion page export).
+ * Sandboxed HTML embed, rendered inside an iframe. Provide exactly one of
+ * `html` (inline markup, e.g. a Claude-authored artifact or a Notion page
+ * export) or `src` (a remote document URL) — this catalog doesn't validate
+ * cross-field constraints, so the contract is documentation-only.
  */
 export const HtmlApi = {
   name: "Html",
@@ -512,11 +514,20 @@ export const HtmlApi = {
       ...CommonProps,
       html: z
         .string()
-        .describe("Raw HTML markup to render inside a sandboxed iframe."),
+        .describe(
+          "Raw HTML markup to render inside a sandboxed iframe. Mutually exclusive with `src` — provide exactly one of the two.",
+        )
+        .optional(),
+      src: z
+        .string()
+        .describe(
+          "URL of a remote document to render inside the iframe instead of inline `html` (e.g. a presigned, time-limited link). Mutually exclusive with `html` — provide exactly one of the two. `autoHeight` doesn't apply here since cross-origin content can't be measured, and a time-limited URL isn't refreshed automatically — the caller is responsible for keeping it current.",
+        )
+        .optional(),
       autoHeight: z
         .boolean()
         .describe(
-          "Stretch the iframe to fit its content height. Defaults to true.",
+          "Stretch the iframe to fit its content height. Defaults to true. Only takes effect for `html`-rendered content.",
         )
         .optional(),
     })

--- a/packages/qwik/package.json
+++ b/packages/qwik/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elmethis/qwik",
-  "version": "1.0.0-alpha.38",
+  "version": "1.0.0-alpha.39",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/qwik/src/components/a2ui/catalog/block-catalog.spec.tsx
+++ b/packages/qwik/src/components/a2ui/catalog/block-catalog.spec.tsx
@@ -376,6 +376,21 @@ describe("blockCatalog: media and embed", () => {
     expect(html.toLowerCase()).toContain("<iframe");
     expect(html).toContain('srcdoc="<p>hello</p>"');
   });
+
+  test("Html renders a remote src iframe with no-referrer hardening", async () => {
+    const html = await renderArgs(
+      buildArgs({
+        component: "Html",
+        id: "e",
+        src: "https://example.com/doc.html?token=secret",
+      }),
+      "Html",
+    );
+    expect(html.toLowerCase()).toContain("<iframe");
+    expect(html).toContain('src="https://example.com/doc.html?token=secret"');
+    expect(html).not.toContain("srcdoc=");
+    expect(html).toContain('referrerpolicy="no-referrer"');
+  });
 });
 
 describe("blockCatalog: code and math", () => {

--- a/packages/qwik/src/components/a2ui/catalog/block-catalog.tsx
+++ b/packages/qwik/src/components/a2ui/catalog/block-catalog.tsx
@@ -312,7 +312,11 @@ export const blockCatalog: CatalogRenderer = basicCatalog.extend(
   )),
 
   defineRenderer(HtmlApi, ({ props, resolve }) => (
-    <ElmHtml html={resolve(props.html)} autoHeight={props.autoHeight} />
+    <ElmHtml
+      html={props.html ? resolve(props.html) : undefined}
+      src={props.src ? resolve(props.src) : undefined}
+      autoHeight={props.autoHeight}
+    />
   )),
 
   // -------------------------------------------------------------------------

--- a/packages/qwik/src/components/code/elm-html.browser.spec.tsx
+++ b/packages/qwik/src/components/code/elm-html.browser.spec.tsx
@@ -150,6 +150,31 @@ describe("[CSR] ElmHtml — ResizeObserver keeps tracking real content", () => {
 // module's top-level `describe(...)` calls. Splitting the file sidesteps it;
 // see that file's header comment for the full story.
 
+describe("[CSR] ElmHtml — remote src", () => {
+  // A `data:` URL gets a unique opaque origin per navigation — the same
+  // cross-origin protection a real https:// src would get — so it exercises
+  // the "contentDocument is inaccessible" path without a network dependency.
+  const OPAQUE_ORIGIN_SRC =
+    "data:text/html,<div style=%22height:900px%22></div>";
+
+  test("navigates the iframe without crashing and never measures a height", async () => {
+    const screen = await render(
+      <ElmHtml src={OPAQUE_ORIGIN_SRC} autoHeight={true} height={200} />,
+    );
+    const iframe = screen.container.querySelector("iframe")!;
+
+    await vi.waitFor(() => {
+      expect(iframe.getAttribute("src")).toBe(OPAQUE_ORIGIN_SRC);
+    });
+
+    // Give any (incorrect) measurement attempt a chance to fire, then assert
+    // it never did: contentHeight stays unset, so the explicit `height` prop
+    // — not a measured value — is still what's applied.
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    expect(iframe.getAttribute("height")).toBe("200");
+  });
+});
+
 describe("[CSR] ElmHtml — layout defaults", () => {
   test("fills its container width by default", async () => {
     const screen = await render(

--- a/packages/qwik/src/components/code/elm-html.spec.tsx
+++ b/packages/qwik/src/components/code/elm-html.spec.tsx
@@ -153,3 +153,71 @@ describe("[CSR] ElmHtml — sandboxing correctness", () => {
     );
   });
 });
+
+describe("[CSR] ElmHtml — remote src", () => {
+  test("renders the iframe's src attribute and omits srcdoc", async () => {
+    const iframe = await renderIframe(
+      <ElmHtml src="https://example.com/doc.html" />,
+    );
+
+    expect(iframe.getAttribute("src")).toBe("https://example.com/doc.html");
+    expect(iframe.hasAttribute("srcdoc")).toBe(false);
+  });
+
+  test("html mode omits the src attribute", async () => {
+    const iframe = await renderIframe(<ElmHtml html="<p>hi</p>" />);
+
+    expect(iframe.hasAttribute("src")).toBe(false);
+    expect(iframe.getAttribute("srcdoc")).toBe("<p>hi</p>");
+  });
+
+  test("src wins when both html and src are supplied", async () => {
+    const props = {
+      html: "<p>trusted</p>",
+      src: "https://example.com/doc.html",
+    } as unknown as ElmHtmlProps;
+    const iframe = await renderIframe(<ElmHtml {...props} />);
+
+    expect(iframe.getAttribute("src")).toBe("https://example.com/doc.html");
+    expect(iframe.hasAttribute("srcdoc")).toBe(false);
+  });
+
+  test("forces referrerPolicy=no-referrer so a presigned URL's query string can't leak via Referer", async () => {
+    const iframe = await renderIframe(
+      <ElmHtml src="https://example.com/doc.html?token=secret" />,
+    );
+
+    expect(iframe.getAttribute("referrerpolicy")).toBe("no-referrer");
+  });
+
+  // BUG-shaped regression: a differently-cased `referrerpolicy` (matching the
+  // HTML attribute spelling rather than the `referrerPolicy` IDL name)
+  // smuggled through a loosely-typed props bag must not be able to weaken
+  // the no-referrer hardening — same defect class as the Sandbox/Srcdoc
+  // casing bugs above.
+  test("a smuggled differently-cased referrerpolicy cannot override the forced no-referrer", async () => {
+    const props = {
+      src: "https://example.com/doc.html?token=secret",
+      referrerpolicy: "unsafe-url",
+    } as unknown as ElmHtmlProps;
+    const iframe = await renderIframe(<ElmHtml {...props} />);
+
+    expect(iframe.getAttribute("referrerpolicy")).toBe("no-referrer");
+  });
+
+  test("does not force referrerPolicy for html mode", async () => {
+    const iframe = await renderIframe(<ElmHtml html="<p>hi</p>" />);
+
+    expect(iframe.hasAttribute("referrerpolicy")).toBe(false);
+  });
+
+  test("never adds allow-same-origin for src content, even with autoHeight on and no allow-scripts", async () => {
+    const iframe = await renderIframe(
+      <ElmHtml src="https://example.com/doc.html" autoHeight={true} />,
+    );
+
+    expect(iframe.getAttribute("sandbox")?.split(/\s+/)).not.toContain(
+      "allow-same-origin",
+    );
+  });
+});

--- a/packages/qwik/src/components/code/elm-html.tsx
+++ b/packages/qwik/src/components/code/elm-html.tsx
@@ -13,15 +13,39 @@ export interface ElmHtmlProps extends Omit<
   PropsOf<"iframe">,
   // Qwik's JSX intrinsics derive prop names straight from the DOM IDL, where
   // this property is spelled all-lowercase (`HTMLIFrameElement.srcdoc`) —
-  // unlike React, which camelCases it to `srcDoc`.
-  "src" | "srcdoc"
+  // unlike React, which camelCases it to `srcDoc`. `src` and `referrerPolicy`
+  // are excluded too: both are fully internally-managed (see below), not
+  // caller-configurable passthrough.
+  "src" | "srcdoc" | "referrerPolicy"
 > {
-  /** Raw HTML markup to render, e.g. a Claude-authored artifact or a Notion page export. */
-  html: string;
+  /**
+   * Raw HTML markup to render, e.g. a Claude-authored artifact or a Notion
+   * page export. Mutually exclusive with `src` — provide exactly one of the
+   * two.
+   */
+  html?: string;
+
+  /**
+   * URL of a remote document to load in place of inline `html` (e.g. a
+   * presigned, time-limited link). Mutually exclusive with `html` — provide
+   * exactly one of the two.
+   *
+   * The framed document always gets `referrerPolicy="no-referrer"` so a
+   * token embedded in the URL's query string (as presigned links often
+   * carry) can't leak via the `Referer` header on requests the framed page
+   * itself makes. `autoHeight` has no effect in this mode — the browser
+   * blocks `contentDocument` access across origins regardless of sandbox
+   * flags, so cross-origin content can never be measured; size it with
+   * `height`/`style` instead. If the URL is time-limited, refreshing it
+   * before it expires is the caller's responsibility — this component never
+   * retries or reloads on its own.
+   */
+  src?: string;
 
   /**
    * Stretch the iframe to fit its content height. Set to false to size it
-   * yourself instead (via `style`, `height`, or a CSS class).
+   * yourself instead (via `style`, `height`, or a CSS class). Only takes
+   * effect in `html` mode — see `src` for why.
    * @default true
    */
   autoHeight?: boolean;
@@ -31,26 +55,35 @@ export const ElmHtml = component$<ElmHtmlProps>((props) => {
   const {
     class: className,
     html,
+    src,
     sandbox,
     style,
     height,
     autoHeight = true,
     title,
-    // `src`/`srcdoc` are excluded from `ElmHtmlProps` only at the type level
-    // (`Omit<..., "src" | "srcdoc">`) — a loosely-typed caller can still
+    // `srcdoc`/`referrerPolicy` are excluded from `ElmHtmlProps` only at the
+    // type level (`Omit<..., ...>`) — a loosely-typed caller can still
     // smuggle one into `rest` at runtime, where spreading it last onto the
-    // iframe would silently override our own `srcdoc={html}` below. Strip
-    // both castings of `srcdoc` (a caller could pass either) defensively so
-    // `html` stays the single source of truth for what renders.
-    src: _src,
+    // iframe would silently override our own values below. Strip every
+    // casing a caller could plausibly use so `html`/`src` and the
+    // no-referrer hardening stay the single source of truth.
     srcdoc: _srcdoc,
     srcDoc: _srcDoc,
+    referrerPolicy: _referrerPolicy,
+    referrerpolicy: _referrerpolicy,
     ...rest
   } = props as ElmHtmlProps & {
-    src?: unknown;
     srcdoc?: unknown;
     srcDoc?: unknown;
+    referrerPolicy?: unknown;
+    referrerpolicy?: unknown;
   };
+
+  // `html` and `src` are mutually exclusive (enforced by convention/docs,
+  // not a runtime check — this catalog doesn't validate cross-field
+  // constraints elsewhere either). `src` wins if a caller somehow supplies
+  // both.
+  const usingSrc = src !== undefined;
 
   const iframeRef = useSignal<HTMLIFrameElement>();
   const contentHeight = useSignal<number>();
@@ -62,6 +95,7 @@ export const ElmHtml = component$<ElmHtmlProps>((props) => {
   // navigation) — no snapshot/comparison state needed.
   useTask$(({ track }) => {
     track(() => props.html);
+    track(() => props.src);
     const nextAutoHeight = track(() => props.autoHeight ?? true);
     if (nextAutoHeight) contentHeight.value = undefined;
   });
@@ -92,7 +126,11 @@ export const ElmHtml = component$<ElmHtmlProps>((props) => {
         sandboxTokens.delete(token);
       }
     }
-  } else if (autoHeight) {
+  } else if (autoHeight && !usingSrc) {
+    // Cross-origin `src` content can never expose `contentDocument` (the
+    // browser blocks it regardless of sandbox flags — see the `src` doc
+    // comment), so granting allow-same-origin here would buy nothing; only
+    // widen the sandbox for no benefit.
     sandboxTokens.add("allow-same-origin");
   }
   const effectiveSandbox = [...sandboxTokens].join(" ");
@@ -100,6 +138,12 @@ export const ElmHtml = component$<ElmHtmlProps>((props) => {
   // eslint-disable-next-line qwik/no-use-visible-task
   useVisibleTask$(
     ({ track, cleanup }) => {
+      // Cross-origin `src` content can never be measured (see the `src` doc
+      // comment) — don't attempt it, and don't attach a load listener that
+      // could never do anything useful.
+      const nextSrc = track(() => props.src);
+      if (nextSrc !== undefined) return;
+
       track(() => props.html);
       const nextAutoHeight = track(() => props.autoHeight ?? true);
 
@@ -173,11 +217,22 @@ export const ElmHtml = component$<ElmHtmlProps>((props) => {
       // bag isn't caught by the exact-key destructures above, so it
       // survives into `rest` — but `setAttribute` lowercases attribute
       // names for HTML elements, so any such key still resolves to these
-      // same `sandbox`/`srcdoc` DOM attributes. Applying ours last
-      // guarantees they always win, regardless of what casing a smuggled
-      // key used.
-      srcdoc={html}
+      // same `sandbox`/`srcdoc`/`referrerpolicy` DOM attributes. Applying
+      // ours last guarantees they always win, regardless of what casing a
+      // smuggled key used.
+      //
+      // Exactly one of `src`/`srcdoc` is ever set — the HTML spec has
+      // `srcdoc` take precedence when both are present, so leaving the
+      // other one as `undefined` (never `""`) is required, not cosmetic: a
+      // literal `src=""` would self-navigate the iframe to the host page.
+      src={usingSrc ? src : undefined}
+      srcdoc={usingSrc ? undefined : (html ?? "")}
       sandbox={effectiveSandbox}
+      // Only forced for `src` — a presigned URL's query-string token must
+      // never reach a third party via `Referer`. `html`/`srcdoc` content has
+      // no URL of its own to leak, so it's left at the caller's/browser's
+      // default.
+      referrerPolicy={usingSrc ? "no-referrer" : undefined}
     />
   );
 });

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elmethis/react",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "React component library for elmethis.",
   "publishConfig": {
     "access": "public"

--- a/packages/react/src/components/a2ui/catalog/block-catalog.tsx
+++ b/packages/react/src/components/a2ui/catalog/block-catalog.tsx
@@ -288,7 +288,7 @@ const blockImplementations: ReactComponentImplementation[] = [
   )),
 
   createComponentImplementation(HtmlApi, ({ props }: any) => (
-    <ElmHtml html={props.html} autoHeight={props.autoHeight} />
+    <ElmHtml html={props.html} src={props.src} autoHeight={props.autoHeight} />
   )),
 
   // ----- Code / math / diagram -----

--- a/packages/react/src/components/code/elm-html.browser.spec.tsx
+++ b/packages/react/src/components/code/elm-html.browser.spec.tsx
@@ -254,6 +254,31 @@ describe("[CSR] ElmHtml — ResizeObserver on in-frame re-navigation", () => {
   });
 });
 
+describe("[CSR] ElmHtml — remote src", () => {
+  // A `data:` URL gets a unique opaque origin per navigation — the same
+  // cross-origin protection a real https:// src would get — so it exercises
+  // the "contentDocument is inaccessible" path without a network dependency.
+  const OPAQUE_ORIGIN_SRC =
+    "data:text/html,<div style=%22height:900px%22></div>";
+
+  test("navigates the iframe without crashing and never measures a height", async () => {
+    const screen = await render(
+      <ElmHtml src={OPAQUE_ORIGIN_SRC} autoHeight={true} height={200} />,
+    );
+    const iframe = screen.container.querySelector("iframe")!;
+
+    await vi.waitFor(() => {
+      expect(iframe.getAttribute("src")).toBe(OPAQUE_ORIGIN_SRC);
+    });
+
+    // Give any (incorrect) measurement attempt a chance to fire, then assert
+    // it never did: contentHeight stays unset, so the explicit `height` prop
+    // — not a measured value — is still what's applied.
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    expect(iframe.getAttribute("height")).toBe("200");
+  });
+});
+
 describe("[CSR] ElmHtml — layout defaults", () => {
   // BUG: the module CSS only sets `border: none`, so with no width supplied
   // by the caller the iframe falls back to its ~300px intrinsic default

--- a/packages/react/src/components/code/elm-html.spec.tsx
+++ b/packages/react/src/components/code/elm-html.spec.tsx
@@ -178,3 +178,83 @@ describe("[CSR] ElmHtml — sandboxing correctness", () => {
     );
   });
 });
+
+// happy-dom (this file's unit-layer environment) simulates real navigation
+// for an iframe's `src` — including an actual outbound `fetch()` — unlike
+// srcdoc, which it renders locally. A real `https://` value here would make
+// these "unit" tests silently depend on network reachability, so a `data:`
+// URI stands in for "some remote src value" throughout: it exercises the
+// exact same attribute-level code path without leaving the process.
+const REMOTE_SRC = "data:text/html,<p>remote</p>";
+const REMOTE_SRC_WITH_TOKEN = "data:text/html,<p>remote</p>?token=secret";
+
+describe("[CSR] ElmHtml — remote src", () => {
+  test("renders the iframe's src attribute and omits srcdoc", () => {
+    const { container } = render(<ElmHtml src={REMOTE_SRC} />);
+    const iframe = container.querySelector("iframe")!;
+
+    expect(iframe.getAttribute("src")).toBe(REMOTE_SRC);
+    expect(iframe.hasAttribute("srcdoc")).toBe(false);
+  });
+
+  test("html mode omits the src attribute", () => {
+    const { container } = render(<ElmHtml html="<p>hi</p>" />);
+    const iframe = container.querySelector("iframe")!;
+
+    expect(iframe.hasAttribute("src")).toBe(false);
+    expect(iframe.getAttribute("srcdoc")).toBe("<p>hi</p>");
+  });
+
+  test("src wins when both html and src are supplied", () => {
+    const props = {
+      html: "<p>trusted</p>",
+      src: REMOTE_SRC,
+    } as unknown as ElmHtmlProps;
+    const { container } = render(<ElmHtml {...props} />);
+    const iframe = container.querySelector("iframe")!;
+
+    expect(iframe.getAttribute("src")).toBe(REMOTE_SRC);
+    expect(iframe.hasAttribute("srcdoc")).toBe(false);
+  });
+
+  test("forces referrerPolicy=no-referrer so a presigned URL's query string can't leak via Referer", () => {
+    const { container } = render(<ElmHtml src={REMOTE_SRC_WITH_TOKEN} />);
+    const iframe = container.querySelector("iframe")!;
+
+    expect(iframe.getAttribute("referrerpolicy")).toBe("no-referrer");
+  });
+
+  // BUG-shaped regression: a differently-cased `referrerpolicy` (matching the
+  // HTML attribute spelling rather than the `referrerPolicy` prop name)
+  // smuggled through a loosely-typed props bag must not be able to weaken
+  // the no-referrer hardening — same defect class as the Sandbox/Srcdoc
+  // casing bugs above.
+  test("a smuggled differently-cased referrerpolicy cannot override the forced no-referrer", () => {
+    const props = {
+      src: REMOTE_SRC_WITH_TOKEN,
+      referrerpolicy: "unsafe-url",
+    } as unknown as ElmHtmlProps;
+    const { container } = render(<ElmHtml {...props} />);
+    const iframe = container.querySelector("iframe")!;
+
+    expect(iframe.getAttribute("referrerpolicy")).toBe("no-referrer");
+  });
+
+  test("does not force referrerPolicy for html mode", () => {
+    const { container } = render(<ElmHtml html="<p>hi</p>" />);
+    const iframe = container.querySelector("iframe")!;
+
+    expect(iframe.hasAttribute("referrerpolicy")).toBe(false);
+  });
+
+  test("never adds allow-same-origin for src content, even with autoHeight on and no allow-scripts", () => {
+    const { container } = render(
+      <ElmHtml src={REMOTE_SRC} autoHeight={true} />,
+    );
+    const iframe = container.querySelector("iframe")!;
+
+    expect(iframe.getAttribute("sandbox")?.split(/\s+/)).not.toContain(
+      "allow-same-origin",
+    );
+  });
+});

--- a/packages/react/src/components/code/elm-html.tsx
+++ b/packages/react/src/components/code/elm-html.tsx
@@ -10,14 +10,36 @@ import styles from "./elm-html.module.css";
 
 export interface ElmHtmlProps extends Omit<
   ComponentPropsWithoutRef<"iframe">,
-  "src" | "srcDoc"
+  "src" | "srcDoc" | "referrerPolicy"
 > {
-  /** Raw HTML markup to render, e.g. a Claude-authored artifact or a Notion page export. */
-  html: string;
+  /**
+   * Raw HTML markup to render, e.g. a Claude-authored artifact or a Notion
+   * page export. Mutually exclusive with `src` — provide exactly one of the
+   * two.
+   */
+  html?: string;
+
+  /**
+   * URL of a remote document to load in place of inline `html` (e.g. a
+   * presigned, time-limited link). Mutually exclusive with `html` — provide
+   * exactly one of the two.
+   *
+   * The framed document always gets `referrerPolicy="no-referrer"` so a
+   * token embedded in the URL's query string (as presigned links often
+   * carry) can't leak via the `Referer` header on requests the framed page
+   * itself makes. `autoHeight` has no effect in this mode — the browser
+   * blocks `contentDocument` access across origins regardless of sandbox
+   * flags, so cross-origin content can never be measured; size it with
+   * `height`/`style` instead. If the URL is time-limited, refreshing it
+   * before it expires is the caller's responsibility — this component never
+   * retries or reloads on its own.
+   */
+  src?: string;
 
   /**
    * Stretch the iframe to fit its content height. Set to false to size it
-   * yourself instead (via `style`, `height`, or a CSS class).
+   * yourself instead (via `style`, `height`, or a CSS class). Only takes
+   * effect in `html` mode — see `src` for why.
    * @default true
    */
   autoHeight?: boolean;
@@ -26,6 +48,7 @@ export interface ElmHtmlProps extends Omit<
 export const ElmHtml = ({
   className,
   html,
+  src,
   sandbox,
   style,
   height,
@@ -33,20 +56,30 @@ export const ElmHtml = ({
   title,
   ...rest
 }: ElmHtmlProps) => {
+  // `html` and `src` are mutually exclusive (enforced by convention/docs,
+  // not a runtime check — this catalog doesn't validate cross-field
+  // constraints elsewhere either). `src` wins if a caller somehow supplies
+  // both.
+  const usingSrc = src !== undefined;
+
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const [contentHeight, setContentHeight] = useState<number>();
 
   // `key={String(autoHeight)}` (below) gives a fresh, unloaded iframe node
-  // on an autoHeight toggle, and a plain html change is a fresh navigation
-  // too — either way the previously-measured height goes stale the moment
-  // `html`/`autoHeight` change, well before the effect that re-measures it
-  // gets to run. Resetting it here, during render (React's documented
-  // pattern for adjusting state in response to a prop change), avoids an
-  // extra render showing the stale value that a reset inside the effect
-  // would cause.
-  const [loadKey, setLoadKey] = useState({ html, autoHeight });
-  if (loadKey.html !== html || loadKey.autoHeight !== autoHeight) {
-    setLoadKey({ html, autoHeight });
+  // on an autoHeight toggle, and a plain html/src change is a fresh
+  // navigation too — either way the previously-measured height goes stale
+  // the moment `html`/`src`/`autoHeight` change, well before the effect that
+  // re-measures it gets to run. Resetting it here, during render (React's
+  // documented pattern for adjusting state in response to a prop change),
+  // avoids an extra render showing the stale value that a reset inside the
+  // effect would cause.
+  const [loadKey, setLoadKey] = useState({ html, src, autoHeight });
+  if (
+    loadKey.html !== html ||
+    loadKey.src !== src ||
+    loadKey.autoHeight !== autoHeight
+  ) {
+    setLoadKey({ html, src, autoHeight });
     if (autoHeight) setContentHeight(undefined);
   }
 
@@ -76,12 +109,21 @@ export const ElmHtml = ({
         sandboxTokens.delete(token);
       }
     }
-  } else if (autoHeight) {
+  } else if (autoHeight && !usingSrc) {
+    // Cross-origin `src` content can never expose `contentDocument` (the
+    // browser blocks it regardless of sandbox flags — see the `src` doc
+    // comment), so granting allow-same-origin here would buy nothing; only
+    // widen the sandbox for no benefit.
     sandboxTokens.add("allow-same-origin");
   }
   const effectiveSandbox = [...sandboxTokens].join(" ");
 
   useEffect(() => {
+    // Cross-origin `src` content can never be measured (see the `src` doc
+    // comment) — don't attempt it, and don't attach a load listener that
+    // could never do anything useful.
+    if (usingSrc) return;
+
     const iframe = iframeRef.current;
     if (!iframe) return;
 
@@ -113,23 +155,25 @@ export const ElmHtml = ({
       iframe.removeEventListener("load", onLoad);
       observer?.disconnect();
     };
-  }, [html, autoHeight]);
+  }, [html, usingSrc, autoHeight]);
 
-  // `src`/`srcDoc` are excluded from `ElmHtmlProps` only at the type level
-  // (`Omit<..., "src" | "srcDoc">`) — a loosely-typed caller can still
-  // smuggle one into `rest` at runtime, where spreading it last onto the
-  // iframe would silently override our own `srcDoc={html}` below. Strip both
-  // castings of `srcDoc` (a caller could pass either) defensively so `html`
-  // stays the single source of truth for what renders.
+  // `srcDoc`/`referrerPolicy` are excluded from `ElmHtmlProps` only at the
+  // type level (`Omit<..., ...>`) — a loosely-typed caller can still smuggle
+  // one into `rest` at runtime, where spreading it last onto the iframe
+  // would silently override our own values below. Strip every casing a
+  // caller could plausibly use so `html`/`src` and the no-referrer hardening
+  // stay the single source of truth.
   const {
-    src: _src,
     srcDoc: _srcDoc,
     srcdoc: _srcdoc,
+    referrerPolicy: _referrerPolicy,
+    referrerpolicy: _referrerpolicy,
     ...safeRest
   } = rest as typeof rest & {
-    src?: unknown;
     srcDoc?: unknown;
     srcdoc?: unknown;
+    referrerPolicy?: unknown;
+    referrerpolicy?: unknown;
   };
 
   return (
@@ -163,11 +207,22 @@ export const ElmHtml = ({
       // props bag isn't caught by the exact-key destructures above, so it
       // survives into `safeRest` — but `setAttribute` lowercases attribute
       // names for HTML elements, so any such key still resolves to these
-      // same `sandbox`/`srcdoc` DOM attributes. Applying ours last
-      // guarantees they always win, regardless of what casing a smuggled key
-      // used.
-      srcDoc={html}
+      // same `sandbox`/`srcdoc`/`referrerpolicy` DOM attributes. Applying
+      // ours last guarantees they always win, regardless of what casing a
+      // smuggled key used.
+      //
+      // Exactly one of `src`/`srcDoc` is ever set — the HTML spec has
+      // `srcDoc` take precedence when both are present, so leaving the
+      // other one as `undefined` (never `""`) is required, not cosmetic: a
+      // literal `src=""` would self-navigate the iframe to the host page.
+      src={usingSrc ? src : undefined}
+      srcDoc={usingSrc ? undefined : (html ?? "")}
       sandbox={effectiveSandbox}
+      // Only forced for `src` — a presigned URL's query-string token must
+      // never reach a third party via `Referer`. `html`/`srcDoc` content has
+      // no URL of its own to leak, so it's left at the caller's/browser's
+      // default.
+      referrerPolicy={usingSrc ? "no-referrer" : undefined}
     />
   );
 };

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elmethis/vue",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Vue 3 component library for elmethis.",
   "publishConfig": {
     "access": "public"

--- a/packages/vue/src/components/a2ui/catalog/block-catalog.spec.tsx
+++ b/packages/vue/src/components/a2ui/catalog/block-catalog.spec.tsx
@@ -153,6 +153,29 @@ describe("blockCatalog — media & embed", () => {
       expect(iframe.attributes("srcdoc")).toBe("<p>hello</p>");
     });
   });
+
+  // A `data:` URI avoids the real outbound `fetch()` happy-dom performs for
+  // an iframe's `src` (unlike `srcdoc`, which it renders locally) — keeping
+  // this unit-layer test hermetic while still exercising the same
+  // attribute-level code path a real remote URL would.
+  it("Html renders a remote src iframe with no-referrer hardening", async () => {
+    const wrapper = mountSurface([
+      {
+        component: "Html",
+        id: "root",
+        src: "data:text/html,<p>remote</p>?token=secret",
+      },
+    ]);
+    await vi.waitFor(() => {
+      const iframe = wrapper.find("iframe");
+      expect(iframe.exists()).toBe(true);
+      expect(iframe.attributes("src")).toBe(
+        "data:text/html,<p>remote</p>?token=secret",
+      );
+      expect(iframe.attributes("srcdoc")).toBeUndefined();
+      expect(iframe.attributes("referrerpolicy")).toBe("no-referrer");
+    });
+  });
 });
 
 describe("blockCatalog — code & table", () => {

--- a/packages/vue/src/components/a2ui/catalog/block-catalog.tsx
+++ b/packages/vue/src/components/a2ui/catalog/block-catalog.tsx
@@ -316,7 +316,11 @@ export const blockCatalog: CatalogRenderer = basicCatalog.extend(
   )),
 
   defineRenderer(HtmlApi, ({ props, resolve }) => (
-    <ElmHtml html={resolve(props.html)} autoHeight={props.autoHeight} />
+    <ElmHtml
+      html={props.html ? resolve(props.html) : undefined}
+      src={props.src ? resolve(props.src) : undefined}
+      autoHeight={props.autoHeight}
+    />
   )),
 
   // -------------------------------------------------------------------------

--- a/packages/vue/src/components/code/elm-html.browser.spec.tsx
+++ b/packages/vue/src/components/code/elm-html.browser.spec.tsx
@@ -228,6 +228,31 @@ describe("[CSR] ElmHtml — ResizeObserver on in-frame re-navigation", () => {
   });
 });
 
+describe("[CSR] ElmHtml — remote src", () => {
+  // A `data:` URL gets a unique opaque origin per navigation — the same
+  // cross-origin protection a real https:// src would get — so it exercises
+  // the "contentDocument is inaccessible" path without a network dependency.
+  const OPAQUE_ORIGIN_SRC =
+    "data:text/html,<div style=%22height:900px%22></div>";
+
+  test("navigates the iframe without crashing and never measures a height", async () => {
+    const screen = render(ElmHtml, {
+      props: { src: OPAQUE_ORIGIN_SRC, autoHeight: true, height: 200 },
+    });
+    const iframe = screen.container.querySelector("iframe")!;
+
+    await vi.waitFor(() => {
+      expect(iframe.getAttribute("src")).toBe(OPAQUE_ORIGIN_SRC);
+    });
+
+    // Give any (incorrect) measurement attempt a chance to fire, then assert
+    // it never did: contentHeight stays unset, so the explicit `height` prop
+    // — not a measured value — is still what's applied.
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    expect(iframe.getAttribute("height")).toBe("200");
+  });
+});
+
 describe("[CSR] ElmHtml — layout defaults", () => {
   test("fills its container width by default", async () => {
     const Harness = defineComponent({

--- a/packages/vue/src/components/code/elm-html.spec.tsx
+++ b/packages/vue/src/components/code/elm-html.spec.tsx
@@ -172,6 +172,82 @@ describe("[CSR] ElmHtml — sandboxing correctness", () => {
   });
 });
 
+// happy-dom (this file's unit-layer environment, via @vue/test-utils) also
+// simulates real navigation for an iframe's `src` — including an actual
+// outbound `fetch()` — unlike srcdoc, which it renders locally. A `data:`
+// URI stands in for "some remote src value" throughout: it exercises the
+// exact same attribute-level code path without leaving the process.
+const REMOTE_SRC = "data:text/html,<p>remote</p>";
+const REMOTE_SRC_WITH_TOKEN = "data:text/html,<p>remote</p>?token=secret";
+
+describe("[CSR] ElmHtml — remote src", () => {
+  test("renders the iframe's src attribute and omits srcdoc", () => {
+    const wrapper = mount(ElmHtml, { props: { src: REMOTE_SRC } });
+    const iframe = wrapper.find("iframe");
+
+    expect(iframe.attributes("src")).toBe(REMOTE_SRC);
+    expect(iframe.attributes("srcdoc")).toBeUndefined();
+  });
+
+  test("html mode omits the src attribute", () => {
+    const wrapper = mount(ElmHtml, { props: { html: "<p>hi</p>" } });
+    const iframe = wrapper.find("iframe");
+
+    expect(iframe.attributes("src")).toBeUndefined();
+    expect(iframe.attributes("srcdoc")).toBe("<p>hi</p>");
+  });
+
+  test("src wins when both html and src are supplied", () => {
+    const wrapper = mount(ElmHtml, {
+      props: { html: "<p>trusted</p>", src: REMOTE_SRC },
+    });
+    const iframe = wrapper.find("iframe");
+
+    expect(iframe.attributes("src")).toBe(REMOTE_SRC);
+    expect(iframe.attributes("srcdoc")).toBeUndefined();
+  });
+
+  test("forces referrerpolicy=no-referrer so a presigned URL's query string can't leak via Referer", () => {
+    const wrapper = mount(ElmHtml, {
+      props: { src: REMOTE_SRC_WITH_TOKEN },
+    });
+    const iframe = wrapper.find("iframe");
+
+    expect(iframe.attributes("referrerpolicy")).toBe("no-referrer");
+  });
+
+  // BUG-shaped regression: a differently-cased `referrerPolicy` smuggled
+  // through `attrs` must not be able to weaken the no-referrer hardening —
+  // same defect class as the Sandbox/Srcdoc casing bugs above.
+  test("a smuggled differently-cased referrerPolicy cannot override the forced no-referrer", () => {
+    const wrapper = mount(ElmHtml, {
+      props: { src: REMOTE_SRC_WITH_TOKEN },
+      attrs: { referrerPolicy: "unsafe-url" },
+    });
+    const iframe = wrapper.find("iframe");
+
+    expect(iframe.attributes("referrerpolicy")).toBe("no-referrer");
+  });
+
+  test("does not force referrerpolicy for html mode", () => {
+    const wrapper = mount(ElmHtml, { props: { html: "<p>hi</p>" } });
+    const iframe = wrapper.find("iframe");
+
+    expect(iframe.attributes("referrerpolicy")).toBeUndefined();
+  });
+
+  test("never adds allow-same-origin for src content, even with autoHeight on and no allow-scripts", () => {
+    const wrapper = mount(ElmHtml, {
+      props: { src: REMOTE_SRC, autoHeight: true },
+    });
+    const iframe = wrapper.find("iframe");
+
+    expect(iframe.attributes("sandbox")?.split(/\s+/)).not.toContain(
+      "allow-same-origin",
+    );
+  });
+});
+
 // ---------------------------------------------------------------------------
 // [CSR]
 //

--- a/packages/vue/src/components/code/elm-html.tsx
+++ b/packages/vue/src/components/code/elm-html.tsx
@@ -85,12 +85,34 @@ const toStyleObject = (
 };
 
 export interface ElmHtmlProps extends HTMLAttributes {
-  /** Raw HTML markup to render, e.g. a Claude-authored artifact or a Notion page export. */
-  html: string;
+  /**
+   * Raw HTML markup to render, e.g. a Claude-authored artifact or a Notion
+   * page export. Mutually exclusive with `src` — provide exactly one of the
+   * two.
+   */
+  html?: string;
+
+  /**
+   * URL of a remote document to load in place of inline `html` (e.g. a
+   * presigned, time-limited link). Mutually exclusive with `html` — provide
+   * exactly one of the two.
+   *
+   * The framed document always gets `referrerpolicy="no-referrer"` so a
+   * token embedded in the URL's query string (as presigned links often
+   * carry) can't leak via the `Referer` header on requests the framed page
+   * itself makes. `autoHeight` has no effect in this mode — the browser
+   * blocks `contentDocument` access across origins regardless of sandbox
+   * flags, so cross-origin content can never be measured; size it with
+   * `height`/`style` instead. If the URL is time-limited, refreshing it
+   * before it expires is the caller's responsibility — this component never
+   * retries or reloads on its own.
+   */
+  src?: string;
 
   /**
    * Stretch the iframe to fit its content height. Set to false to size it
-   * yourself instead (via `style`, `height`, or a CSS class).
+   * yourself instead (via `style`, `height`, or a CSS class). Only takes
+   * effect in `html` mode — see `src` for why.
    * @default true
    */
   autoHeight?: boolean;
@@ -115,7 +137,8 @@ export const ElmHtml = defineComponent({
   // <iframe> manually below, same convention as elm-table.tsx.
   inheritAttrs: false,
   props: {
-    html: { type: String, required: true },
+    html: { type: String, default: undefined },
+    src: { type: String, default: undefined },
     autoHeight: { type: Boolean, default: true },
     sandbox: { type: String, default: undefined },
     height: {
@@ -128,25 +151,31 @@ export const ElmHtml = defineComponent({
     const iframeRef = ref<HTMLIFrameElement | null>(null);
     const contentHeight = ref<number | undefined>(undefined);
 
+    // `html` and `src` are mutually exclusive (enforced by convention/docs,
+    // not a runtime check — this catalog doesn't validate cross-field
+    // constraints elsewhere either). `src` wins if a caller somehow supplies
+    // both.
+    const usingSrc = () => props.src !== undefined;
+
     // The `key={String(autoHeight)}` on the <iframe> below (and a plain
-    // `html` change, which is a fresh navigation on its own) both make a
-    // previously-measured height stale the moment `html`/`autoHeight`
+    // `html`/`src` change, which is a fresh navigation on its own) both make
+    // a previously-measured height stale the moment `html`/`src`/`autoHeight`
     // change — well before the watcher below that re-measures it gets to
     // run. `flush: "pre"` runs this before the DOM patches, so (unlike
     // react, which needed an awkward render-time-state-adjustment workaround
     // purely to satisfy a lint rule vue doesn't have) there's no stale-paint
     // frame to guard against.
     watch(
-      () => [props.html, props.autoHeight] as const,
-      ([, autoHeight]) => {
+      () => [props.html, props.src, props.autoHeight] as const,
+      ([, , autoHeight]) => {
         if (autoHeight) contentHeight.value = undefined;
       },
       { flush: "pre" },
     );
 
     // ResizeObserver + `load` listener attach/cleanup, rerunning whenever
-    // `html`/`autoHeight` change — mirrors react's `useEffect(fn, [html,
-    // autoHeight])` cleanup-per-run semantics.
+    // `html`/`src`/`autoHeight` change — mirrors react's `useEffect(fn,
+    // [html, usingSrc, autoHeight])` cleanup-per-run semantics.
     //
     // This is NOT a single `watch(..., { immediate: true, flush: "post" })`,
     // even though that reads as the obvious vue equivalent. It was tried
@@ -165,6 +194,11 @@ export const ElmHtml = defineComponent({
     let disposeLifecycle: (() => void) | undefined;
 
     const attachLifecycle = (autoHeight: boolean) => {
+      // Cross-origin `src` content can never be measured (see the `src` doc
+      // comment) — don't attempt it, and don't attach a load listener that
+      // could never do anything useful.
+      if (usingSrc()) return;
+
       const iframe = iframeRef.value;
       if (!iframe) return;
 
@@ -200,8 +234,8 @@ export const ElmHtml = defineComponent({
     onMounted(() => attachLifecycle(props.autoHeight));
 
     watch(
-      () => [props.html, props.autoHeight] as const,
-      ([, autoHeight]) => {
+      () => [props.html, props.src, props.autoHeight] as const,
+      ([, , autoHeight]) => {
         disposeLifecycle?.();
         attachLifecycle(autoHeight);
       },
@@ -211,18 +245,21 @@ export const ElmHtml = defineComponent({
     onBeforeUnmount(() => disposeLifecycle?.());
 
     return () => {
-      // `src`/`srcdoc` are excluded from `ElmHtmlProps` only at the type
-      // level — a loosely-typed caller can still smuggle one into `attrs` at
-      // runtime, where spreading it last onto the iframe would silently
-      // override our own `srcdoc={props.html}` below. Strip both defensively
-      // (both castings of `srcDoc`, since a caller could pass either) so
-      // `html` stays the single source of truth for what renders.
+      const usingSrcValue = usingSrc();
+
+      // `srcdoc`/`referrerpolicy` are excluded from `ElmHtmlProps` only at
+      // the type level — a loosely-typed caller can still smuggle one into
+      // `attrs` at runtime, where spreading it last onto the iframe would
+      // silently override our own values below. Strip every casing a caller
+      // could plausibly use so `html`/`src` and the no-referrer hardening
+      // stay the single source of truth.
       const {
         class: className,
         style,
-        src: _src,
         srcDoc: _srcDoc,
         srcdoc: _srcdoc,
+        referrerPolicy: _referrerPolicy,
+        referrerpolicy: _referrerpolicy,
         ...safeRest
       } = attrs as Record<string, unknown>;
 
@@ -259,7 +296,11 @@ export const ElmHtml = defineComponent({
             sandboxTokens.delete(token);
           }
         }
-      } else if (props.autoHeight) {
+      } else if (props.autoHeight && !usingSrcValue) {
+        // Cross-origin `src` content can never expose `contentDocument`
+        // (the browser blocks it regardless of sandbox flags — see the
+        // `src` doc comment), so granting allow-same-origin here would buy
+        // nothing; only widen the sandbox for no benefit.
         sandboxTokens.add("allow-same-origin");
       }
       const effectiveSandbox = [...sandboxTokens].join(" ");
@@ -309,11 +350,23 @@ export const ElmHtml = defineComponent({
           // caught by Vue's exact-key prop/destructure matching above, so it
           // survives into `safeRest` — but `setAttribute` lowercases
           // attribute names for HTML elements, so any such key still
-          // resolves to these same `sandbox`/`srcdoc` DOM attributes.
-          // Applying ours last guarantees they always win, regardless of
-          // what casing a smuggled key used.
-          srcdoc={props.html}
+          // resolves to these same `sandbox`/`srcdoc`/`referrerpolicy` DOM
+          // attributes. Applying ours last guarantees they always win,
+          // regardless of what casing a smuggled key used.
+          //
+          // Exactly one of `src`/`srcdoc` is ever set — the HTML spec has
+          // `srcdoc` take precedence when both are present, so leaving the
+          // other one as `undefined` (never `""`) is required, not
+          // cosmetic: a literal `src=""` would self-navigate the iframe to
+          // the host page.
+          src={usingSrcValue ? props.src : undefined}
+          srcdoc={usingSrcValue ? undefined : (props.html ?? "")}
           sandbox={effectiveSandbox}
+          // Only forced for `src` — a presigned URL's query-string token
+          // must never reach a third party via `Referer`. `html`/`srcdoc`
+          // content has no URL of its own to leak, so it's left at the
+          // caller's/browser's default.
+          referrerpolicy={usingSrcValue ? "no-referrer" : undefined}
         />
       );
     };


### PR DESCRIPTION
## Summary
- Add an optional `src: string` to the A2UI `Html` block schema (`@elmethis/core`) alongside the now-optional `html`. Exactly one is expected — documented in both field descriptions, not zod-enforced, matching this catalog's existing lack of cross-field validation elsewhere.
- Port `src` support to `ElmHtml` in **qwik, react, and vue** (standardized across all three, not just the original qwik scope) and their A2UI catalog wiring:
  - `src` renders `<iframe src>`; `html` renders `<iframe srcdoc>` — exactly one is ever set (never both, never `""`, since an empty `src` self-navigates the iframe and `srcdoc` takes precedence over `src` per spec when both are present).
  - `referrerPolicy="no-referrer"` is force-applied whenever `src` is used, defended against casing-smuggling the same way `sandbox`/`srcdoc` already are, so a presigned URL's query-string token can't leak via `Referer`.
  - `allow-same-origin` is no longer auto-granted for `autoHeight` in `src` mode — cross-origin `contentDocument` access is blocked regardless, so the grant is pure downside.
  - The height-measurement machinery (ResizeObserver / load listener) is skipped entirely in `src` mode rather than left to silently no-op.

## Test plan
- [x] `pnpm --filter @elmethis/core run check` + core test suite (schema/catalog-json regression tests)
- [x] `pnpm --filter @elmethis/qwik run check` + full unit (562) and browser (76) suites
- [x] `pnpm --filter @elmethis/react run check` + full unit (491) and browser suites
- [x] `pnpm --filter @elmethis/vue run check` + full unit (448) and browser (57) suites
- [x] New unit-layer coverage per framework: mode selection, src-wins-if-both, no-referrer forcing + casing-smuggle resistance, no wasted `allow-same-origin`
- [x] New browser-layer coverage per framework: real opaque-origin (`data:`) navigation with no crash and no bogus measurement
- [x] Catalog-level render tests updated (qwik/vue behavioral; react structural) for the new `src` path
- [x] Regenerated `dist/a2ui/v0_9/block_catalog.json` (gitignored build artifact) confirms `html`/`src` are both optional in the emitted schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)