### PR TITLE
Add allowScripts support to the A2UI Html component

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elmethis/core",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "author": {
     "name": "Ikuma Yamashita",
     "url": "https://www.ikuma.cloud/"

--- a/packages/core/src/a2ui/v0_9/block-catalog.ts
+++ b/packages/core/src/a2ui/v0_9/block-catalog.ts
@@ -530,6 +530,12 @@ export const HtmlApi = {
           "Stretch the iframe to fit its content height. Defaults to true. Only takes effect for `html`-rendered content.",
         )
         .optional(),
+      allowScripts: z
+        .boolean()
+        .describe(
+          "Allow the embedded content to run JavaScript (adds the iframe sandbox's `allow-scripts` token). Defaults to false — script execution is disabled by default. `allow-same-origin` is never granted together with this, in `html` or `src` mode, so the embedded document can never escape the sandbox even with scripts enabled.",
+        )
+        .optional(),
     })
     .strict(),
 } satisfies ComponentApi;

--- a/packages/qwik/package.json
+++ b/packages/qwik/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elmethis/qwik",
-  "version": "1.0.0-alpha.39",
+  "version": "1.0.0-alpha.40",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/qwik/src/components/a2ui/catalog/block-catalog.spec.tsx
+++ b/packages/qwik/src/components/a2ui/catalog/block-catalog.spec.tsx
@@ -391,6 +391,31 @@ describe("blockCatalog: media and embed", () => {
     expect(html).not.toContain("srcdoc=");
     expect(html).toContain('referrerpolicy="no-referrer"');
   });
+
+  test("Html adds allow-scripts to the sandbox when allowScripts is set", async () => {
+    const html = await renderArgs(
+      buildArgs({
+        component: "Html",
+        id: "e",
+        html: "<p>hello</p>",
+        allowScripts: true,
+      }),
+      "Html",
+    );
+    expect(html).toMatch(/sandbox="[^"]*\ballow-scripts\b[^"]*"/);
+  });
+
+  test("Html omits allow-scripts from the sandbox by default", async () => {
+    const html = await renderArgs(
+      buildArgs({
+        component: "Html",
+        id: "e",
+        html: "<p>hello</p>",
+      }),
+      "Html",
+    );
+    expect(html).not.toMatch(/sandbox="[^"]*\ballow-scripts\b[^"]*"/);
+  });
 });
 
 describe("blockCatalog: code and math", () => {

--- a/packages/qwik/src/components/a2ui/catalog/block-catalog.tsx
+++ b/packages/qwik/src/components/a2ui/catalog/block-catalog.tsx
@@ -316,6 +316,7 @@ export const blockCatalog: CatalogRenderer = basicCatalog.extend(
       html={props.html ? resolve(props.html) : undefined}
       src={props.src ? resolve(props.src) : undefined}
       autoHeight={props.autoHeight}
+      allowScripts={props.allowScripts}
     />
   )),
 

--- a/packages/qwik/src/components/code/elm-html.spec.tsx
+++ b/packages/qwik/src/components/code/elm-html.spec.tsx
@@ -152,6 +152,34 @@ describe("[CSR] ElmHtml — sandboxing correctness", () => {
       "allow-same-origin",
     );
   });
+
+  test("allowScripts adds allow-scripts to the sandbox", async () => {
+    const iframe = await renderIframe(
+      <ElmHtml html="<p>x</p>" allowScripts={true} />,
+    );
+
+    expect(iframe.getAttribute("sandbox")?.split(/\s+/)).toContain(
+      "allow-scripts",
+    );
+  });
+
+  test("does not add allow-scripts when allowScripts is unset", async () => {
+    const iframe = await renderIframe(<ElmHtml html="<p>x</p>" />);
+
+    expect(iframe.getAttribute("sandbox")?.split(/\s+/)).not.toContain(
+      "allow-scripts",
+    );
+  });
+
+  test("allowScripts still strips allow-same-origin even with autoHeight on", async () => {
+    const iframe = await renderIframe(
+      <ElmHtml html="<p>x</p>" allowScripts={true} autoHeight={true} />,
+    );
+    const tokens = iframe.getAttribute("sandbox")?.split(/\s+/);
+
+    expect(tokens).toContain("allow-scripts");
+    expect(tokens).not.toContain("allow-same-origin");
+  });
 });
 
 describe("[CSR] ElmHtml — remote src", () => {

--- a/packages/qwik/src/components/code/elm-html.stories.tsx
+++ b/packages/qwik/src/components/code/elm-html.stories.tsx
@@ -85,3 +85,37 @@ export const FixedHeight: Story = {
     style: { width: "100%", height: "150px" },
   },
 };
+
+const SCRIPTED_HTML = `
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <style>
+      body { font-family: sans-serif; margin: 1.5rem; }
+    </style>
+  </head>
+  <body>
+    <p>Counter: <span id="count">0</span></p>
+    <button onclick="document.getElementById('count').textContent = Number(document.getElementById('count').textContent) + 1">
+      Increment
+    </button>
+    <script>
+      document.title = "Script ran";
+    </script>
+  </body>
+</html>
+`;
+
+/**
+ * With `allowScripts`, the embedded document may run JavaScript
+ * (`sandbox="allow-scripts"`). `allow-same-origin` is still never granted,
+ * so the embedded document can't read/write the host page or its own
+ * `contentDocument` — only run script within its own sandboxed origin.
+ */
+export const AllowScripts: Story = {
+  args: {
+    html: SCRIPTED_HTML,
+    allowScripts: true,
+  },
+};

--- a/packages/qwik/src/components/code/elm-html.tsx
+++ b/packages/qwik/src/components/code/elm-html.tsx
@@ -49,6 +49,16 @@ export interface ElmHtmlProps extends Omit<
    * @default true
    */
   autoHeight?: boolean;
+
+  /**
+   * Allow the embedded content to run JavaScript by adding `allow-scripts`
+   * to the iframe's `sandbox` attribute. Defaults to false. `allow-same-origin`
+   * is never granted together with this — see the sandbox-token logic below
+   * for why combining the two would let the embedded document escape the
+   * sandbox entirely.
+   * @default false
+   */
+  allowScripts?: boolean;
 }
 
 export const ElmHtml = component$<ElmHtmlProps>((props) => {
@@ -60,6 +70,7 @@ export const ElmHtml = component$<ElmHtmlProps>((props) => {
     style,
     height,
     autoHeight = true,
+    allowScripts = false,
     title,
     // `srcdoc`/`referrerPolicy` are excluded from `ElmHtmlProps` only at the
     // type level (`Omit<..., ...>`) — a loosely-typed caller can still
@@ -117,6 +128,7 @@ export const ElmHtml = component$<ElmHtmlProps>((props) => {
   // `sandbox` attribute matches its keywords case-insensitively, so a
   // case-sensitive check here could be defeated by a differently-cased token.
   const sandboxTokens = new Set(sandbox?.split(/\s+/).filter(Boolean) ?? []);
+  if (allowScripts) sandboxTokens.add("allow-scripts");
   const hasAllowScripts = [...sandboxTokens].some(
     (token) => token.toLowerCase() === "allow-scripts",
   );

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elmethis/react",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "React component library for elmethis.",
   "publishConfig": {
     "access": "public"

--- a/packages/react/src/components/a2ui/catalog/block-catalog.tsx
+++ b/packages/react/src/components/a2ui/catalog/block-catalog.tsx
@@ -288,7 +288,12 @@ const blockImplementations: ReactComponentImplementation[] = [
   )),
 
   createComponentImplementation(HtmlApi, ({ props }: any) => (
-    <ElmHtml html={props.html} src={props.src} autoHeight={props.autoHeight} />
+    <ElmHtml
+      html={props.html}
+      src={props.src}
+      autoHeight={props.autoHeight}
+      allowScripts={props.allowScripts}
+    />
   )),
 
   // ----- Code / math / diagram -----

--- a/packages/react/src/components/code/elm-html.spec.tsx
+++ b/packages/react/src/components/code/elm-html.spec.tsx
@@ -177,6 +177,37 @@ describe("[CSR] ElmHtml — sandboxing correctness", () => {
       "allow-same-origin",
     );
   });
+
+  test("allowScripts adds allow-scripts to the sandbox", () => {
+    const { container } = render(
+      <ElmHtml html="<p>x</p>" allowScripts={true} />,
+    );
+    const iframe = container.querySelector("iframe")!;
+
+    expect(iframe.getAttribute("sandbox")?.split(/\s+/)).toContain(
+      "allow-scripts",
+    );
+  });
+
+  test("does not add allow-scripts when allowScripts is unset", () => {
+    const { container } = render(<ElmHtml html="<p>x</p>" />);
+    const iframe = container.querySelector("iframe")!;
+
+    expect(iframe.getAttribute("sandbox")?.split(/\s+/)).not.toContain(
+      "allow-scripts",
+    );
+  });
+
+  test("allowScripts still strips allow-same-origin even with autoHeight on", () => {
+    const { container } = render(
+      <ElmHtml html="<p>x</p>" allowScripts={true} autoHeight={true} />,
+    );
+    const iframe = container.querySelector("iframe")!;
+    const tokens = iframe.getAttribute("sandbox")?.split(/\s+/);
+
+    expect(tokens).toContain("allow-scripts");
+    expect(tokens).not.toContain("allow-same-origin");
+  });
 });
 
 // happy-dom (this file's unit-layer environment) simulates real navigation

--- a/packages/react/src/components/code/elm-html.stories.tsx
+++ b/packages/react/src/components/code/elm-html.stories.tsx
@@ -85,3 +85,37 @@ export const FixedHeight: Story = {
     style: { width: "100%", height: "150px" },
   },
 };
+
+const SCRIPTED_HTML = `
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <style>
+      body { font-family: sans-serif; margin: 1.5rem; }
+    </style>
+  </head>
+  <body>
+    <p>Counter: <span id="count">0</span></p>
+    <button onclick="document.getElementById('count').textContent = Number(document.getElementById('count').textContent) + 1">
+      Increment
+    </button>
+    <script>
+      document.title = "Script ran";
+    </script>
+  </body>
+</html>
+`;
+
+/**
+ * With `allowScripts`, the embedded document may run JavaScript
+ * (`sandbox="allow-scripts"`). `allow-same-origin` is still never granted,
+ * so the embedded document can't read/write the host page or its own
+ * `contentDocument` — only run script within its own sandboxed origin.
+ */
+export const AllowScripts: Story = {
+  args: {
+    html: SCRIPTED_HTML,
+    allowScripts: true,
+  },
+};

--- a/packages/react/src/components/code/elm-html.tsx
+++ b/packages/react/src/components/code/elm-html.tsx
@@ -43,6 +43,16 @@ export interface ElmHtmlProps extends Omit<
    * @default true
    */
   autoHeight?: boolean;
+
+  /**
+   * Allow the embedded content to run JavaScript by adding `allow-scripts`
+   * to the iframe's `sandbox` attribute. Defaults to false. `allow-same-origin`
+   * is never granted together with this — see the sandbox-token logic below
+   * for why combining the two would let the embedded document escape the
+   * sandbox entirely.
+   * @default false
+   */
+  allowScripts?: boolean;
 }
 
 export const ElmHtml = ({
@@ -53,6 +63,7 @@ export const ElmHtml = ({
   style,
   height,
   autoHeight = true,
+  allowScripts = false,
   title,
   ...rest
 }: ElmHtmlProps) => {
@@ -100,6 +111,7 @@ export const ElmHtml = ({
   // `sandbox` attribute matches its keywords case-insensitively, so a
   // case-sensitive check here could be defeated by a differently-cased token.
   const sandboxTokens = new Set(sandbox?.split(/\s+/).filter(Boolean) ?? []);
+  if (allowScripts) sandboxTokens.add("allow-scripts");
   const hasAllowScripts = [...sandboxTokens].some(
     (token) => token.toLowerCase() === "allow-scripts",
   );

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elmethis/vue",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Vue 3 component library for elmethis.",
   "publishConfig": {
     "access": "public"

--- a/packages/vue/src/components/a2ui/catalog/block-catalog.spec.tsx
+++ b/packages/vue/src/components/a2ui/catalog/block-catalog.spec.tsx
@@ -176,6 +176,37 @@ describe("blockCatalog — media & embed", () => {
       expect(iframe.attributes("referrerpolicy")).toBe("no-referrer");
     });
   });
+
+  it("Html adds allow-scripts to the sandbox when allowScripts is set", async () => {
+    const wrapper = mountSurface([
+      {
+        component: "Html",
+        id: "root",
+        html: "<p>hello</p>",
+        allowScripts: true,
+      },
+    ]);
+    await vi.waitFor(() => {
+      const iframe = wrapper.find("iframe");
+      expect(iframe.exists()).toBe(true);
+      expect(iframe.attributes("sandbox")?.split(/\s+/)).toContain(
+        "allow-scripts",
+      );
+    });
+  });
+
+  it("Html omits allow-scripts from the sandbox by default", async () => {
+    const wrapper = mountSurface([
+      { component: "Html", id: "root", html: "<p>hello</p>" },
+    ]);
+    await vi.waitFor(() => {
+      const iframe = wrapper.find("iframe");
+      expect(iframe.exists()).toBe(true);
+      expect(iframe.attributes("sandbox")?.split(/\s+/)).not.toContain(
+        "allow-scripts",
+      );
+    });
+  });
 });
 
 describe("blockCatalog — code & table", () => {

--- a/packages/vue/src/components/a2ui/catalog/block-catalog.tsx
+++ b/packages/vue/src/components/a2ui/catalog/block-catalog.tsx
@@ -320,6 +320,7 @@ export const blockCatalog: CatalogRenderer = basicCatalog.extend(
       html={props.html ? resolve(props.html) : undefined}
       src={props.src ? resolve(props.src) : undefined}
       autoHeight={props.autoHeight}
+      allowScripts={props.allowScripts}
     />
   )),
 

--- a/packages/vue/src/components/code/elm-html.spec.tsx
+++ b/packages/vue/src/components/code/elm-html.spec.tsx
@@ -170,6 +170,37 @@ describe("[CSR] ElmHtml — sandboxing correctness", () => {
       "allow-same-origin",
     );
   });
+
+  test("allowScripts adds allow-scripts to the sandbox", () => {
+    const wrapper = mount(ElmHtml, {
+      props: { html: "<p>x</p>", allowScripts: true },
+    });
+    const iframe = wrapper.find("iframe");
+
+    expect(iframe.attributes("sandbox")?.split(/\s+/)).toContain(
+      "allow-scripts",
+    );
+  });
+
+  test("does not add allow-scripts when allowScripts is unset", () => {
+    const wrapper = mount(ElmHtml, { props: { html: "<p>x</p>" } });
+    const iframe = wrapper.find("iframe");
+
+    expect(iframe.attributes("sandbox")?.split(/\s+/)).not.toContain(
+      "allow-scripts",
+    );
+  });
+
+  test("allowScripts still strips allow-same-origin even with autoHeight on", () => {
+    const wrapper = mount(ElmHtml, {
+      props: { html: "<p>x</p>", allowScripts: true, autoHeight: true },
+    });
+    const iframe = wrapper.find("iframe");
+    const tokens = iframe.attributes("sandbox")?.split(/\s+/);
+
+    expect(tokens).toContain("allow-scripts");
+    expect(tokens).not.toContain("allow-same-origin");
+  });
 });
 
 // happy-dom (this file's unit-layer environment, via @vue/test-utils) also

--- a/packages/vue/src/components/code/elm-html.stories.tsx
+++ b/packages/vue/src/components/code/elm-html.stories.tsx
@@ -85,3 +85,37 @@ export const FixedHeight: Story = {
     style: { width: "100%", height: "150px" },
   },
 };
+
+const SCRIPTED_HTML = `
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <style>
+      body { font-family: sans-serif; margin: 1.5rem; }
+    </style>
+  </head>
+  <body>
+    <p>Counter: <span id="count">0</span></p>
+    <button onclick="document.getElementById('count').textContent = Number(document.getElementById('count').textContent) + 1">
+      Increment
+    </button>
+    <script>
+      document.title = "Script ran";
+    </script>
+  </body>
+</html>
+`;
+
+/**
+ * With `allowScripts`, the embedded document may run JavaScript
+ * (`sandbox="allow-scripts"`). `allow-same-origin` is still never granted,
+ * so the embedded document can't read/write the host page or its own
+ * `contentDocument` — only run script within its own sandboxed origin.
+ */
+export const AllowScripts: Story = {
+  args: {
+    html: SCRIPTED_HTML,
+    allowScripts: true,
+  },
+};

--- a/packages/vue/src/components/code/elm-html.tsx
+++ b/packages/vue/src/components/code/elm-html.tsx
@@ -124,6 +124,16 @@ export interface ElmHtmlProps extends HTMLAttributes {
    */
   sandbox?: string;
 
+  /**
+   * Allow the embedded content to run JavaScript by adding `allow-scripts`
+   * to the iframe's `sandbox` attribute. Defaults to false. `allow-same-origin`
+   * is never granted together with this — see the sandbox-token logic below
+   * for why combining the two would let the embedded document escape the
+   * sandbox entirely.
+   * @default false
+   */
+  allowScripts?: boolean;
+
   /** Native iframe `height` attribute, in pixels. */
   height?: number | `${number}`;
 
@@ -141,6 +151,7 @@ export const ElmHtml = defineComponent({
     src: { type: String, default: undefined },
     autoHeight: { type: Boolean, default: true },
     sandbox: { type: String, default: undefined },
+    allowScripts: { type: Boolean, default: false },
     height: {
       type: [Number, String] as PropType<number | `${number}`>,
       default: undefined,
@@ -287,6 +298,7 @@ export const ElmHtml = defineComponent({
       const sandboxTokens = new Set(
         props.sandbox?.split(/\s+/).filter(Boolean) ?? [],
       );
+      if (props.allowScripts) sandboxTokens.add("allow-scripts");
       const hasAllowScripts = [...sandboxTokens].some(
         (token) => token.toLowerCase() === "allow-scripts",
       );


### PR DESCRIPTION
## Summary
- Adds an optional `allowScripts` boolean to the A2UI `Html` block schema (`@elmethis/core`), defaulting to `false`.
- When set, `ElmHtml` in qwik/react/vue adds `allow-scripts` to the iframe's `sandbox` attribute — the existing sandbox-token guard still unconditionally strips `allow-same-origin` whenever `allow-scripts` is present, so a scripted embed can never escape the sandbox or become same-origin with the host.
- qwik was the reference implementation; react and vue were ported for full framework parity, following the same rollout pattern as the prior "remote src" feature.
- Bumps package versions: `@elmethis/core` 0.18.0 → 0.19.0, `@elmethis/qwik` 1.0.0-alpha.39 → 1.0.0-alpha.40, `@elmethis/react` 0.16.0 → 0.17.0, `@elmethis/vue` 0.14.0 → 0.15.0, and tags the version-bump commit accordingly.

## Test plan
- [x] `pnpm --filter @elmethis/core run build`
- [x] `pnpm exec vitest run` for `elm-html.spec.tsx` and `block-catalog.spec.tsx` in qwik, react, vue (all pass)
- [x] `pnpm --filter @elmethis/qwik run check`, `pnpm --filter @elmethis/react run check`, `pnpm --filter @elmethis/vue run check` (fmt/lint/types all clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)