### PR TITLE
chore: install knowledge skills from 46ki75/yaarr and enable official plugins

### DIFF
--- a/.agents/skills/a2ui-knowledge/.sources.json
+++ b/.agents/skills/a2ui-knowledge/.sources.json
@@ -1,0 +1,10 @@
+{
+  "skill": "a2ui-knowledge",
+  "sources": [
+    {
+      "repo": "submodules/A2UI",
+      "synced": "6895e1df52c9441d4b754fd63951bbfdc3dcb32d",
+      "paths": ["docs", "specification"]
+    }
+  ]
+}

--- a/.agents/skills/a2ui-knowledge/SKILL.md
+++ b/.agents/skills/a2ui-knowledge/SKILL.md
@@ -1,0 +1,256 @@
+---
+name: a2ui-knowledge
+description: >
+  Expert guidance for implementing the A2UI (Agent to UI) protocol — covering
+  surfaces, components, data binding, catalogs, message streams (v0.9 / v0.9.1:
+  createSurface / updateComponents / updateDataModel / deleteSurface; v1.0 adds
+  callFunction / functionResponse / actionResponse; v0.8: surfaceUpdate /
+  dataModelUpdate / beginRendering), the A2A extension binding, custom
+  component catalogs (schemas, renderers, negotiation, versioning, graceful
+  degradation), client/renderer architecture (MessageProcessor / SurfaceModel
+  / ComponentImplementation / Binder), custom functions, the sendDataModel
+  flag, surfaceProperties, and v0.8 → v0.9 → v0.9.1 → v1.0 migration. Always
+  invoke for any question that mentions A2UI, surfaceUpdate, beginRendering,
+  createSurface,
+  updateComponents, updateDataModel, sendDataModel, callFunction,
+  functionResponse, actionResponse, surfaceProperties,
+  a2uiClientCapabilities, supportedCatalogIds, catalogId, basic_catalog,
+  formatString, ChildList, ComponentId, or agent-driven UI streaming.
+license: MIT
+metadata:
+  author: "Ikuma Yamashita"
+  version: "2.0.0"
+---
+
+# A2UI Skill
+
+You are an expert in the A2UI (Agent to UI) protocol — a declarative,
+streaming JSON protocol that lets AI agents generate rich, interactive UIs
+which render natively on any platform (web, mobile, desktop) without
+executing arbitrary code.
+
+## What A2UI Is
+
+A2UI transmits abstract component trees as streams of JSON messages. The
+agent describes UI structure; the client renders it with its own native
+widgets. Key properties:
+
+- **Declarative and LLM-friendly** — flat component lists keyed by id
+  (adjacency-list model) so the LLM doesn't have to generate deeply nested
+  JSON in a single pass.
+- **Platform-agnostic** — the same JSON renders on React, Angular, Lit,
+  Flutter, iOS, Android.
+- **Separation of concerns** — UI structure, application state, and
+  rendering are decoupled.
+- **Secure** — declarative data only, no code execution. Component types
+  are restricted to an allowlist (the active catalog).
+
+## Versions
+
+Per upstream `docs/roadmap.md`:
+
+| Version | Status                  | Key server-to-client message types                                                |
+| :------ | :---------------------- | :-------------------------------------------------------------------------------- |
+| v0.8    | Prior (minimal support) | `surfaceUpdate`, `dataModelUpdate`, `beginRendering`, `deleteSurface`             |
+| v0.9    | Prior (legacy support)  | `createSurface`, `updateComponents`, `updateDataModel`, `deleteSurface`           |
+| v0.9.1  | Current (stable)        | identical to v0.9                                                                 |
+| v1.0    | Candidate (release)     | v0.9 set plus `callFunction` and `actionResponse`; adds client `functionResponse` |
+
+Default to **v0.9.1** for production work; it is the current stable release
+and is wire-compatible with v0.9. Use **v1.0** when the user wants the release
+candidate's RPC features (synchronous `actionResponse`, server-initiated
+`callFunction`/`functionResponse`), `surfaceProperties`, or single-message UI
+instantiation. Use **v0.9 / v0.8** only when working on or migrating from an
+existing deployment.
+
+v0.9 introduced the **prompt-first** redesign: the schema is meant to live in
+the LLM's system prompt rather than rely solely on structured output. It has a
+flatter component syntax, standard JSON for data models, a unified catalog
+(components + functions), the optional `sendDataModel` flag on `createSurface`
+for client-to-server data sync, and a structured `VALIDATION_FAILED` feedback
+loop. v0.8 was optimized for strict structured output / function calling.
+
+**v0.9.1** is a minor refinement of v0.9: the payload MIME type is
+standardized to `application/a2ui+json` (the legacy `application/json+a2ui`
+is dropped), and `surfaceId` uniqueness is relaxed from the renderer's full
+lifetime to currently-active surfaces only. Message names are identical to
+v0.9, so the v0.9 protocol reference remains substantively accurate for
+v0.9.1.
+
+**v1.0** (release candidate) adds bidirectional RPC (`actionResponse`,
+`callFunction`/`functionResponse`), replaces `theme` with `surfaceProperties`
+(dropping `primaryColor`), allows inline `components`/`dataModel` directly in
+`createSurface`, turns the catalog `functions` list into a name-keyed map,
+embeds catalog `instructions` (replacing `rules.txt`), enforces UAX #31
+identifier naming, adds the `@index` template function, and switches
+`updateDataModel` deletion to explicit `null`. See `references/v1.0/`.
+
+## Core Concepts
+
+- **Surface** — a named UI region (chat bubble, side panel, dialog). Has
+  its own component tree and data model. One stream can drive many.
+- **Component** — an abstract UI element (`Text`, `Button`, `Row`, `Card`,
+  …) drawn from a catalog. Components reference children by id, not by
+  nesting.
+- **Data Model** — a JSON object per surface; components bind to JSON
+  Pointer paths within it. v0.9 supports relative paths inside templates.
+- **Catalog** — a JSON Schema document defining the available component and
+  function types. The Basic Catalog is the spec's reference; production apps
+  usually define their own. v1.0 catalogs also carry `instructions`
+  (inline Markdown) and a name-keyed `functions` map.
+- **A2A Extension** — how A2UI is advertised and activated when transported
+  over the A2A protocol. Each protocol version has its own activation URI:
+  - v0.8: `https://a2ui.org/a2a-extension/a2ui/v0.8`
+  - v0.9: `https://a2ui.org/a2a-extension/a2ui/v0.9`
+  - v0.9.1: `https://a2ui.org/a2a-extension/a2ui/v0.9.1`
+  - v1.0: `https://a2ui.org/a2a-extension/a2ui/v1.0`
+
+## Reference Files
+
+Read the appropriate reference as needed.
+
+### v1.0 (release candidate)
+
+- **`references/v1.0/protocol.md`** — Full v1.0 protocol: the four core
+  messages plus `callFunction`/`actionResponse`, `surfaceProperties`,
+  inline `components`/`dataModel` in `createSurface`, `null`-based
+  `updateDataModel` deletion, the `@index` template function, UAX #31
+  identifier rules, and `INVALID_FUNCTION_CALL`.
+- **`references/v1.0/a2a-extension.md`** — v1.0 extension URI,
+  `application/a2ui+json` DataPart encoding, list semantics, and the v1.0
+  capability metadata.
+- **`references/v1.0/evolution-guide.md`** — v0.9 → v0.9.1 → v1.0 migration:
+  every schema/message/catalog change plus agent-side and renderer-side
+  migration checklists.
+- **`references/v1.0/custom-functions.md`** — v1.0 custom functions: the
+  name-keyed `functions` map, `callableFrom` execution boundaries,
+  `returnType` as catalog metadata, server-initiated `callFunction`, and the
+  `INVALID_FUNCTION_CALL` contract.
+- **`references/v1.0/basic-catalog-guide.md`** — v1.0 Basic Catalog: new
+  props (`Video.posterUrl`, `TextField.placeholder`, `Slider.steps`), the
+  `Icon` `path` rename, `surfaceProperties`, and catalog `instructions`.
+- **`references/v1.0/renderer-guide.md`** — v1.0 renderer architecture:
+  handling `callFunction`/`functionResponse`, `actionResponse` write-back,
+  `@index` collection scope, and execution-boundary enforcement.
+- **`references/v1.0/custom-catalog-guide.md`** — v1.0 custom catalogs: the
+  `functions` map, `callableFrom`, inline `instructions`, standard JSON
+  Schema metadata, UAX #31 naming, negotiation, and versioning.
+
+### v0.9 / v0.9.1 (legacy / current stable)
+
+The v0.9 references below are substantively accurate for **v0.9.1** as well —
+the only v0.9.1 differences are the `application/a2ui+json` MIME type and the
+relaxed `surfaceId` uniqueness rule (see `references/v1.0/evolution-guide.md`).
+
+- **`references/v0.9/protocol.md`** — Full v0.9 protocol: `createSurface`
+  (with the `sendDataModel` boolean property), `updateComponents`,
+  `updateDataModel`, `deleteSurface`, flat component syntax with
+  `"component": "Type"`, JSON-Pointer binding, root/relative scope,
+  `formatString`, the prompt → generate → validate loop, and capability
+  metadata.
+- **`references/v0.9/a2a-extension.md`** — v0.9 extension URI, Agent Card
+  params, list-of-messages DataPart encoding, metadata fields
+  (`a2uiClientCapabilities`, `a2uiClientDataModel`).
+- **`references/v0.9/evolution-guide.md`** — Comprehensive v0.8 → v0.9
+  diff: philosophy shift, renamed messages, schema changes, component
+  property renames, and a migration checklist. Read this when helping
+  someone migrate or explaining why v0.9 looks different.
+- **`references/v0.9/custom-functions.md`** — How to define custom
+  functions inside a catalog, expose them via `anyFunction`, and have
+  validators recognize them (e.g. `trim`, `getScreenResolution`).
+- **`references/v0.9/basic-catalog-guide.md`** — Per-component rendering
+  guidance for every Basic Catalog component and function, plus the
+  Leaf-Margin spacing strategy and color/contrast inheritance pattern.
+- **`references/v0.9/renderer-guide.md`** — Client/renderer architecture:
+  the agnostic data layer (`MessageProcessor`, `SurfaceModel`,
+  `DataModel`, `ComponentContext`), the catalog API, three binder
+  strategies (direct, binder layer, generic), lifecycle/memory rules, and
+  the step-by-step build plan.
+- **`references/v0.9/custom-catalog-guide.md`** — End-to-end custom
+  catalog workflow: defining a schema, extending or cherry-picking from
+  the Basic Catalog, bundling with `assemble_catalog.py`, the four-step
+  authoring loop (schema → implement → register → invoke), the
+  catalog-negotiation handshake, versioning + breaking-change rules,
+  two-phase validation, graceful degradation, security, and agent-side
+  ADK integration (`A2uiSchemaManager`, `SendA2uiToClientToolset`,
+  `A2uiEventConverter`).
+
+### v0.8 (prior)
+
+- **`references/v0.8/protocol.md`** — Full v0.8 protocol: message schemas
+  (`surfaceUpdate`, `dataModelUpdate`, `beginRendering`, `deleteSurface`),
+  the `BoundValue` typed-literal pattern (`literalString` / `path` /
+  initialization shorthand), key-wrapped component objects
+  (`{"Text": {...}}`), `explicitList` vs `template` for container
+  children, and the canonical client-side architecture.
+- **`references/v0.8/a2a-extension.md`** — v0.8 extension URI, Agent Card
+  declaration, activation, single-message DataPart encoding,
+  `a2uiClientCapabilities` in metadata.
+- **`references/v0.8/custom-catalog.md`** — Per-request catalog
+  negotiation (the change that landed in v0.8), `supportedCatalogIds`,
+  `inlineCatalogs`, `acceptsInlineCatalogs`, per-surface `catalogId` in
+  `beginRendering`, and the implementation guide for agent and renderer
+  developers.
+
+## When to Read Which Files
+
+| User is asking about…                                              | Read                                      |
+| :----------------------------------------------------------------- | :---------------------------------------- |
+| v1.0 message format / schema (the release candidate)               | `references/v1.0/protocol.md`             |
+| `callFunction` / `functionResponse` / `actionResponse`             | `references/v1.0/protocol.md`             |
+| `surfaceProperties`, inline `components`/`dataModel`               | `references/v1.0/protocol.md`             |
+| `@index`, UAX #31 naming, `null`-based deletion                    | `references/v1.0/protocol.md`             |
+| v1.0 A2A integration                                               | `references/v1.0/a2a-extension.md`        |
+| v0.9 → v0.9.1 → v1.0 migration / which version to use              | `references/v1.0/evolution-guide.md`      |
+| v1.0 custom functions / `callableFrom` / execution boundaries      | `references/v1.0/custom-functions.md`     |
+| v1.0 Basic Catalog props (`posterUrl`, `placeholder`, `steps`)     | `references/v1.0/basic-catalog-guide.md`  |
+| Building a v1.0 client / handling `callFunction`                   | `references/v1.0/renderer-guide.md`       |
+| v1.0 custom component catalog                                      | `references/v1.0/custom-catalog-guide.md` |
+| v0.9 / v0.9.1 message format / schema                              | `references/v0.9/protocol.md`             |
+| v0.9 / v0.9.1 A2A integration                                      | `references/v0.9/a2a-extension.md`        |
+| v0.8 → v0.9 migration / differences                                | `references/v0.9/evolution-guide.md`      |
+| Custom functions (defining, validating, registering)               | `references/v0.9/custom-functions.md`     |
+| Rendering specific components (Text, Button, Card, Modal, …)       | `references/v0.9/basic-catalog-guide.md`  |
+| Building a client / renderer / MessageProcessor                    | `references/v0.9/renderer-guide.md`       |
+| Custom component catalog (define / register / negotiate / version) | `references/v0.9/custom-catalog-guide.md` |
+| `supportedCatalogIds` / catalog negotiation handshake              | `references/v0.9/custom-catalog-guide.md` |
+| Catalog versioning, breaking changes, migration                    | `references/v0.9/custom-catalog-guide.md` |
+| Agent-side ADK integration (`SendA2uiToClientToolset`, etc.)       | `references/v0.9/custom-catalog-guide.md` |
+| Two-phase validation, graceful degradation                         | `references/v0.9/custom-catalog-guide.md` |
+| Leaf-Margin spacing strategy / color inheritance                   | `references/v0.9/basic-catalog-guide.md`  |
+| `formatString`, `${...}` interpolation                             | `references/v0.9/protocol.md`             |
+| `sendDataModel`, two-way binding, data sync                        | `references/v0.9/protocol.md`             |
+| v0.8 message format / schema                                       | `references/v0.8/protocol.md`             |
+| v0.8 A2A integration                                               | `references/v0.8/a2a-extension.md`        |
+| v0.8 custom catalogs / `inlineCatalogs`                            | `references/v0.8/custom-catalog.md`       |
+
+## Working Tips
+
+- The v0.9 / v0.9.1 server-to-client message stream has exactly **four**
+  methods: `createSurface`, `updateComponents`, `updateDataModel`,
+  `deleteSurface`. `sendDataModel` is **not** a fifth message — it is a
+  boolean property **inside** `createSurface` that turns on client-to-server
+  data sync. v1.0 adds two more server-to-client messages
+  (`callFunction`, `actionResponse`) and a client-to-server `functionResponse`.
+- When a user mentions `callFunction`, `functionResponse`, `actionResponse`,
+  or `surfaceProperties`, you're in v1.0 territory. `createSurface` /
+  `updateComponents` / `updateDataModel` with `theme` are v0.9 / v0.9.1.
+  `surfaceUpdate`, `dataModelUpdate`, `beginRendering`, or `literalString`
+  are v0.8. When unclear, ask which version they're targeting.
+- Catalog schemas must use `common_types.json` references for ids and
+  child lists (`ComponentId`, `ChildList`) — raw `"type": "string"` makes
+  validators silently miss broken references.
+- In v1.0, catalog `functions` is a **name-keyed map** (not a list),
+  function names must conform to UAX #31, and the `@` prefix is reserved
+  for system functions like `@index` — custom catalogs MUST NOT define
+  `@`-prefixed functions.
+- The `${...}` string-interpolation syntax is valid **only** inside the
+  `formatString` function. Don't suggest it in arbitrary string properties.
+- A2A `DataPart.data` is a **list** of A2UI messages (since v0.9), processed
+  sequentially with per-message atomicity. The current MIME type is
+  `application/a2ui+json` (standardized in v0.9.1); the legacy
+  `application/json+a2ui` appears only in pre-v0.9.1 deployments. v0.8 used a
+  single message, not a list.
+- Source files in this skill end with a `Source:` footer pointing back to
+  the upstream spec `.md` in the `a2ui-project/a2ui` repo, so you can verify
+  or re-sync against the spec.

--- a/.agents/skills/a2ui-knowledge/references/v0.8/a2a-extension.md
+++ b/.agents/skills/a2ui-knowledge/references/v0.8/a2a-extension.md
@@ -1,0 +1,136 @@
+# A2UI v0.8 — A2A Extension
+
+This document describes how A2UI v0.8 is advertised and transported over the
+A2A (Agent-to-Agent) protocol. Use it whenever you need to wire A2UI messages
+through A2A transport — Agent Card declaration, extension activation, or
+DataPart encoding.
+
+## Extension URI
+
+```text
+https://a2ui.org/a2a-extension/a2ui/v0.8
+```
+
+This is the **only** URI accepted for the v0.8 extension. Anything else is
+non-conformant.
+
+## Core concepts
+
+- **Surfaces** — distinct, independently controllable UI regions identified by
+  `surfaceId`. A single agent stream can drive many surfaces simultaneously
+  (e.g. a chat bubble plus a sticky side panel).
+- **Catalog Definition Document** — the extension is component-agnostic. All
+  component types and styles live in a separate catalog schema, which client
+  and server negotiate per session.
+- **Client capabilities** — the client declares its supported catalogs in an
+  `a2uiClientCapabilities` object inside the `metadata` field of **every** A2A
+  `Message` it sends.
+
+The extension is defined by three primary JSON schemas:
+
+1. **Catalog Definition Schema** — describes the available components and
+   styles.
+2. **Server-to-Client Message Schema** — wire format for `surfaceUpdate`,
+   `dataModelUpdate`, `beginRendering`, `deleteSurface`.
+3. **Client-to-Server Event Schema** — wire format for `userAction` and
+   `error`.
+
+## Agent Card declaration
+
+Agents advertise A2UI support inside `AgentCapabilities.extensions`. The
+`params` object carries the agent's specific capability flags.
+
+```json
+{
+  "uri": "https://a2ui.org/a2a-extension/a2ui/v0.8",
+  "description": "Ability to render A2UI",
+  "required": false,
+  "params": {
+    "supportedCatalogIds": [
+      "https://a2ui.org/specification/v0_8/standard_catalog_definition.json",
+      "https://my-company.com/a2ui/v0.8/my_custom_catalog.json"
+    ],
+    "acceptsInlineCatalogs": true
+  }
+}
+```
+
+### Parameters
+
+| Param | Type | Required | Meaning |
+| :--- | :--- | :--- | :--- |
+| `supportedCatalogIds` | `string[]` | optional | URIs of catalog definition schemas the agent can generate UI for. |
+| `acceptsInlineCatalogs` | `boolean` | optional, default `false` | Whether the agent can accept `inlineCatalogs` sent in the client's `a2uiClientCapabilities`. |
+
+`supportedCatalogIds` is a **soft signal**, not a strict contract — an
+orchestrating agent may dynamically delegate to subagents that support
+catalogs the orchestrator never advertised. Clients should treat the
+advertised list as a subset of true support.
+
+## Extension activation
+
+Clients activate the extension via A2A's standard transport-defined activation:
+
+- **JSON-RPC / HTTP**: `X-A2A-Extensions` HTTP header.
+- **gRPC**: `X-A2A-Extensions` metadata value.
+
+Activating the extension means the server may emit A2UI messages
+(e.g. `surfaceUpdate`) and the client is expected to send A2UI events
+(e.g. `userAction`) back.
+
+## Data encoding
+
+A2UI messages travel as an A2A `DataPart`. The `DataPart` must carry the
+mimeType marker identifying it as A2UI content:
+
+- `metadata.mimeType` = `application/json+a2ui`
+
+The `data` field holds the A2UI JSON message itself (e.g. `surfaceUpdate`,
+`userAction`).
+
+> **MIME type note:** v0.8 used the legacy `application/json+a2ui` spelling
+> (shown below for historical accuracy). The MIME type was later standardized
+> to `application/a2ui+json` in v0.9.1; use that form for any current
+> (v0.9.1 / v1.0) deployment.
+
+### Example DataPart
+
+```json
+{
+  "data": {
+    "beginRendering": {
+      "surfaceId": "outlier_stores_map_surface"
+    }
+  },
+  "kind": "data",
+  "metadata": {
+    "mimeType": "application/json+a2ui"
+  }
+}
+```
+
+## Client capabilities in message metadata
+
+Independently of the Agent Card, the client must inject its capabilities into
+the metadata of every outbound A2A `Message`:
+
+```json
+{
+  "metadata": {
+    "a2uiClientCapabilities": {
+      "supportedCatalogIds": [
+        "https://a2ui.org/specification/v0_8/standard_catalog_definition.json"
+      ],
+      "inlineCatalogs": []
+    }
+  }
+}
+```
+
+The agent inspects this on every request to decide which catalog to use when
+emitting `beginRendering`. See `custom-catalog.md` for the full negotiation
+flow and implementation guidance for both agent and renderer libraries.
+
+---
+
+Source: `submodules/A2UI/specification/v0_8/docs/a2ui_extension_specification.md`.

--- a/.agents/skills/a2ui-knowledge/references/v0.8/custom-catalog.md
+++ b/.agents/skills/a2ui-knowledge/references/v0.8/custom-catalog.md
@@ -1,0 +1,136 @@
+# A2UI v0.8 — Custom Catalog Negotiation
+
+v0.8 introduced a per-request capability handshake that replaces the older
+one-shot `clientUiCapabilities` message. Use this reference whenever you are
+implementing the agent or renderer side of catalog negotiation, building a
+custom catalog, or supporting `inlineCatalogs` for local development.
+
+## Why the change
+
+The earlier `clientUiCapabilities` message was a single, one-time declaration.
+The v0.8 mechanism:
+
+- runs **on every request**, so capabilities can vary per call,
+- lets a single client advertise **multiple** pre-compiled catalogs,
+- allows the agent to pick the **right catalog per surface**,
+- supports `inlineCatalogs` so a client can ship a fresh catalog definition
+  at runtime (useful in local dev where you don't want to bake the catalog
+  into the agent).
+
+## Key protocol changes
+
+### 1. Agent advertises capabilities
+
+Inside the A2UI extension block of the Agent Card:
+
+- `supportedCatalogIds` — URIs of catalogs the agent can generate UI for.
+- `acceptsInlineCatalogs` — `true` if the agent can process catalogs the
+  client supplies at runtime.
+
+See `a2a-extension.md` for the full Agent Card schema.
+
+### 2. Client capabilities ride in A2A message metadata
+
+`a2uiClientCapabilities` is **no longer a standalone message** — it lives in
+the `metadata` field of **every** A2A `Message` the client sends:
+
+```json
+{
+  "metadata": {
+    "a2uiClientCapabilities": {
+      "supportedCatalogIds": [
+        "https://a2ui.org/specification/v0_8/standard_catalog_definition.json"
+      ],
+      "inlineCatalogs": []
+    }
+  }
+}
+```
+
+- `supportedCatalogIds` (required) — IDs of pre-compiled catalogs.
+- `inlineCatalogs` (optional) — array of complete catalog definition documents.
+
+Schema: `specification/v0_8/json/a2ui_client_capabilities_schema.json`.
+
+### 3. Per-surface catalog selection on `beginRendering`
+
+The agent declares which catalog applies to each surface:
+
+```json
+{
+  "beginRendering": {
+    "surfaceId": "s1",
+    "catalogId": "https://my-company.com/.../catalog.json",
+    "root": "root"
+  }
+}
+```
+
+If `catalogId` is omitted, the client **MUST** default to the v0.8 standard
+catalog (`https://a2ui.org/specification/v0_8/standard_catalog_definition.json`).
+
+Schema: `specification/v0_8/json/server_to_client.json`.
+
+### 4. Catalogs carry their own `catalogId`
+
+The Catalog Definition Schema now requires a top-level `catalogId` field, so
+inline catalogs are self-identifying.
+
+Schema: `specification/v0_8/json/catalog_description_schema.json`.
+
+## Implementation guide — Agent (server) developers
+
+Your job is to parse client capabilities and choose a catalog per surface.
+
+1. **Advertise capability** — in your Agent Card, declare
+   `supportedCatalogIds` and `acceptsInlineCatalogs: true` (if applicable)
+   inside the A2UI extension block.
+2. **Parse capabilities on every request** — read
+   `metadata.a2uiClientCapabilities` from each incoming A2A message to learn
+   what catalogs this client supports.
+3. **Choose a catalog** — for each surface you intend to render, pick a catalog
+   the client advertised (either via `supportedCatalogIds` or `inlineCatalogs`).
+4. **Specify the catalog on render** — set `catalogId` on the corresponding
+   `beginRendering` message. Omitting it implicitly requests the standard
+   catalog.
+5. **Generate compliant UI** — every component in subsequent `surfaceUpdate`
+   messages must conform to the property schema of the chosen catalog.
+
+Recommended workflow: resolve `server_to_client.json` against the chosen
+catalog at build time, and feed the resolved schema to the LLM as structured
+output, so the model only emits valid components and styles.
+
+## Implementation guide — Renderer (client) developers
+
+Your job is to declare capabilities and render each surface using the catalog
+the agent picked.
+
+1. **Inject capabilities on every request** — every outbound A2A message must
+   include `metadata.a2uiClientCapabilities`.
+2. **Populate `supportedCatalogIds`** — list every pre-compiled catalog you
+   support. Include the standard catalog ID explicitly if you support it:
+   `https://a2ui.org/specification/v0_8/standard_catalog_definition.json`.
+3. **(Optional) provide `inlineCatalogs`** — full catalog definitions you
+   generated or loaded at runtime. The agent must have advertised
+   `acceptsInlineCatalogs: true` for this to be honored.
+4. **Process `beginRendering.catalogId`** — when it arrives, look the catalog
+   up by ID:
+   - present → render the surface against that catalog,
+   - absent  → default to the v0.8 standard catalog.
+5. **Handle multiple catalogs in parallel** — different surfaces may use
+   different catalogs simultaneously. A `Map<surfaceId, catalog>` is the
+   common pattern.
+
+## Security note
+
+Pre-compile your supported catalogs into the client — do **not** fetch them
+at runtime. The spec calls this out explicitly: runtime catalog fetching
+opens a prompt-injection vector by letting external content reshape the
+agent's structured-output schema. `inlineCatalogs` are intended for local
+development workflows only.
+
+---
+
+Source: `submodules/A2UI/specification/v0_8/docs/custom_catalog_changes.md`
+(supplemented by the negotiation section of
+`submodules/A2UI/specification/v0_8/docs/a2ui_protocol.md`).

--- a/.agents/skills/a2ui-knowledge/references/v0.8/protocol.md
+++ b/.agents/skills/a2ui-knowledge/references/v0.8/protocol.md
@@ -1,0 +1,380 @@
+# A2UI v0.8 Protocol Reference
+
+A2UI v0.8 is a JSONL-based streaming UI protocol that lets an agent describe a
+component tree and data model which a client renders with native widgets. v0.8
+is the **prior** release — feature-complete v0.9 is now recommended, but v0.8
+remains in use by existing deployments.
+
+## Table of Contents
+
+- [Design Principles](#design-principles)
+- [Server-to-Client Message Types](#server-to-client-message-types)
+- [Surfaces](#surfaces)
+- [Catalog Negotiation](#catalog-negotiation)
+- [Component Model](#component-model)
+- [UI Composition (Adjacency List, Templates)](#ui-composition)
+- [Data Model and Binding](#data-model-and-binding)
+- [Event Handling (Client → Server)](#event-handling)
+- [Client-Side Architecture](#client-side-architecture)
+- [Full Stream Example](#full-stream-example)
+
+## Design Principles
+
+- **Declarative, flat structure** — components form an adjacency list keyed by
+  `id`, not a nested tree. This is far easier for an LLM to generate
+  incrementally and tolerates out-of-order messages.
+- **Stateless messages** — each JSONL line is self-contained
+  (`surfaceUpdate`, `dataModelUpdate`, `beginRendering`, `deleteSurface`).
+- **Progressive rendering** — the client buffers until it sees `beginRendering`,
+  then renders from the supplied `root` component.
+- **Platform-agnostic** — the wire format only references abstract component
+  names; the client maps them to native widgets via a Widget Registry.
+- **Separation of structure and state** — `surfaceUpdate` defines components;
+  `dataModelUpdate` carries dynamic values that components bind to.
+- **Unidirectional UI stream** — UI flows server → client (typically SSE).
+  User interactions flow back as separate A2A messages.
+
+## Server-to-Client Message Types
+
+v0.8 defines four message types. Each is a top-level object with a single
+discriminator key.
+
+| Message | Purpose |
+| :--- | :--- |
+| `surfaceUpdate` | Add or replace component definitions on a surface |
+| `dataModelUpdate` | Insert / replace data inside a surface's data model |
+| `beginRendering` | Signal the client to render; pick the `root` component and (optionally) a catalog |
+| `deleteSurface` | Remove a surface and all its UI |
+
+### `surfaceUpdate`
+
+```json
+{
+  "surfaceUpdate": {
+    "surfaceId": "main_content_area",
+    "components": [
+      {
+        "id": "unique-component-id",
+        "component": {
+          "Text": { "text": { "literalString": "Hello, World!" } }
+        }
+      }
+    ]
+  }
+}
+```
+
+- `components` is a flat list of `{ id, component }` pairs.
+- `component` is a wrapper that must contain exactly one key — the component
+  type name from the active catalog (e.g. `"Text"`, `"Row"`, `"Button"`).
+
+### `dataModelUpdate`
+
+`contents` is an **adjacency list** of typed entries — each entry has a `key`
+and exactly one `value*` field.
+
+```json
+{
+  "dataModelUpdate": {
+    "surfaceId": "main_content_area",
+    "path": "user",
+    "contents": [
+      {"key": "name", "valueString": "Bob"},
+      {"key": "isVerified", "valueBoolean": true},
+      {
+        "key": "address",
+        "valueMap": [
+          {"key": "street", "valueString": "123 Main St"},
+          {"key": "city",   "valueString": "Anytown"}
+        ]
+      }
+    ]
+  }
+}
+```
+
+Typed value fields: `valueString`, `valueNumber`, `valueBoolean`, `valueMap`
+(nested adjacency list), `valueArray`. If `path` is omitted, the update applies
+to the root of the surface's data model.
+
+### `beginRendering`
+
+```json
+{
+  "beginRendering": {
+    "surfaceId": "unique-surface-1",
+    "catalogId": "https://my-company.com/inline_catalogs/temp-catalog",
+    "root": "root-component-id"
+  }
+}
+```
+
+- `surfaceId` — which surface to render.
+- `root` — id of the component used as the surface's root.
+- `catalogId` — optional. If omitted the client **MUST** default to the
+  standard catalog (`https://a2ui.org/specification/v0_8/standard_catalog_definition.json`).
+
+### `deleteSurface`
+
+```json
+{ "deleteSurface": { "surfaceId": "side_panel" } }
+```
+
+Removes the surface, its component buffer entries, and its data model.
+
+## Surfaces
+
+A **Surface** is a controllable region of screen real estate. Each surface
+has:
+
+- its own component buffer (`Map<componentId, Component>`),
+- its own data model (independent JSON object), and
+- its own root component / catalog choice.
+
+A single A2UI stream can drive many surfaces in parallel (e.g. a chat history
+where each assistant turn is rendered into a separate surface, plus a sticky
+side panel).
+
+## Catalog Negotiation
+
+A **Catalog** is a JSON-Schema-style document listing the component types the
+client can render and their properties. v0.8 introduces a flexible three-step
+negotiation:
+
+### 1. Agent advertises capability (Agent Card)
+
+```json
+{
+  "uri": "https://a2ui.org/a2a-extension/a2ui/v0.8",
+  "params": {
+    "supportedCatalogIds": [
+      "https://a2ui.org/specification/v0_8/standard_catalog_definition.json",
+      "https://my-company.com/a2ui/v0.8/my_custom_catalog.json"
+    ],
+    "acceptsInlineCatalogs": true
+  }
+}
+```
+
+`supportedCatalogIds` is a soft signal — orchestrating agents may delegate to
+subagents whose catalogs are not advertised, so clients should treat this as a
+subset of true support.
+
+### 2. Client declares supported catalogs on every message
+
+The client adds `a2uiClientCapabilities` to the A2A `Message.metadata` of
+**every** outbound message:
+
+```json
+{
+  "metadata": {
+    "a2uiClientCapabilities": {
+      "supportedCatalogIds": [
+        "https://a2ui.org/specification/v0_8/standard_catalog_definition.json"
+      ],
+      "inlineCatalogs": [
+        {
+          "catalogId": "https://my-company.com/inline_catalogs/temp-signature-pad-catalog",
+          "components": {
+            "SignaturePad": {
+              "type": "object",
+              "properties": {"penColor": {"type": "string"}}
+            }
+          },
+          "styles": {}
+        }
+      ]
+    }
+  }
+}
+```
+
+- `supportedCatalogIds` (required) — IDs of pre-compiled catalogs the renderer
+  ships with. Include the standard catalog ID explicitly if you support it.
+  These contents must be compiled in, not fetched at runtime — that's the
+  guardrail against prompt-injected catalogs.
+- `inlineCatalogs` (optional) — full catalog definition documents supplied at
+  runtime. Only allowed when the agent advertised
+  `acceptsInlineCatalogs: true`. Primarily intended for local development.
+
+### 3. Server selects per-surface
+
+The agent picks a catalog for each surface and sets it on `beginRendering`:
+
+```json
+{
+  "beginRendering": {
+    "surfaceId": "s1",
+    "catalogId": "https://my-company.com/inline_catalogs/temp-signature-pad-catalog",
+    "root": "root"
+  }
+}
+```
+
+The chosen `catalogId` must appear in the client's `supportedCatalogIds` or as
+a `catalogId` inside an `inlineCatalogs` entry. Omit `catalogId` to mean
+"use the standard catalog."
+
+### Schemas for developers
+
+The generic `server_to_client.json` is the abstract wire schema. For agent
+implementation, resolve it against your target catalog so the LLM sees the
+exact components and styles available:
+
+```python
+component_properties = custom_catalog_definition["components"]
+style_properties     = custom_catalog_definition["styles"]
+resolved_schema = copy.deepcopy(server_to_client_schema)
+resolved_schema["properties"]["surfaceUpdate"]["properties"] \
+    ["components"]["items"]["properties"]["component"] \
+    ["properties"] = component_properties
+resolved_schema["properties"]["beginRendering"]["properties"] \
+    ["styles"]["properties"] = style_properties
+```
+
+`server_to_client_with_standard_catalog.json` is the pre-resolved form for the
+standard catalog.
+
+## Component Model
+
+Each entry in `components` is:
+
+- `id` (string, required) — unique within the surface; referenced by parents.
+- `component` (object, required) — **exactly one key**, naming the component
+  type from the catalog. The value is that type's properties:
+
+```json
+"component": {
+  "Button": {
+    "label": { "literalString": "Click Me" },
+    "action": { "name": "submit_form" }
+  }
+}
+```
+
+The set of valid component type names and property shapes is **not** in the
+core schema — it comes from the active catalog.
+
+## UI Composition
+
+### Adjacency list model
+
+The UI is sent as a flat list. Parent/child relationships are expressed by
+component-`id` references, not nesting. The client stores all components in a
+`Map<id, Component>` and reconstructs the tree at render time.
+
+This means messages can arrive in any order; only the final `beginRendering`
+matters for the first render.
+
+### Container children: `explicitList` vs `template`
+
+Containers like `Row`, `Column`, `List` use a `children` object that contains
+**exactly one** of:
+
+- `explicitList: ["id1", "id2", ...]` — static, known children.
+- `template: { dataBinding: <DataPath>, componentId: "<id>" }` — dynamic list:
+  iterate over the bound data, render `componentId` once per item, exposing the
+  item to the template for relative binding.
+
+## Data Model and Binding
+
+### The `BoundValue` object
+
+Bindable component properties (e.g. `text` on `Text`) accept a `BoundValue`:
+
+```json
+{
+  "literalString": "static value",   // OR another literal* type
+  "path": "/data/path"               // OR a JSON-Pointer path
+}
+```
+
+Behaviors:
+
+- **Literal only** — `"text": { "literalString": "Hello" }` — static.
+- **Path only** — `"text": { "path": "/user/name" }` — dynamic, resolved at
+  render time and re-resolved on data model updates.
+- **Both = initialization shorthand** — `"text": { "path": "/user/name", "literalString": "Guest" }`
+  — the client must (1) implicitly write the literal into the data model at
+  `path`, then (2) bind to that path. Lets the server set a default and bind
+  it in one step.
+
+Typed literals: `literalString`, `literalNumber`, `literalBoolean`,
+`literalArray`.
+
+v0.8 binding is direct 1:1 — there are **no transformers / formatters /
+conditionals**. Any data transformation must be done server-side before the
+`dataModelUpdate`.
+
+## Event Handling
+
+User interactions return to the server as A2A messages. The payload is a
+JSON object with exactly one of `userAction` or `error`.
+
+### `userAction`
+
+```json
+{
+  "userAction": {
+    "name": "submit_form",
+    "surfaceId": "main_content_area",
+    "sourceComponentId": "submit_btn",
+    "timestamp": "2025-09-19T17:05:00Z",
+    "context": {
+      "userInput": "User input text",
+      "formId": "f-123"
+    }
+  }
+}
+```
+
+The client builds `context` by iterating the component's `action.context`
+array and resolving each `BoundValue` against the surface's data model.
+
+### `error`
+
+A flexible feedback channel — sent when the client hits a rendering or
+binding error. The payload shape is intentionally open.
+
+### Round-trip
+
+User action → A2A message → server processes → server emits new
+`surfaceUpdate` / `dataModelUpdate` / `deleteSurface` over the same SSE
+stream → client updates buffers and re-renders.
+
+## Client-Side Architecture
+
+A working v0.8 client typically has:
+
+- **JSONL parser** — line-delimited reader over SSE.
+- **Message dispatcher** — routes by message-type key.
+- **Component buffer** — `Map<id, Component>` per surface.
+- **Data model store** — JSON object per surface.
+- **Interpreter state** — tracks "ready to render" (flipped by
+  `beginRendering`).
+- **Widget registry** — caller-supplied map from component-type names to
+  native widget builders.
+- **Binding resolver** — turns a `BoundValue` into a concrete value.
+- **Surface manager** — creates/deletes surfaces by `surfaceId`.
+- **Event handler** — builds and dispatches `userAction` / `error` back over
+  A2A.
+
+## Full Stream Example
+
+```jsonl
+{"surfaceUpdate": {"components": [{"id": "root", "component": {"Column": {"children": {"explicitList": ["profile_card"]}}}}]}}
+{"surfaceUpdate": {"components": [{"id": "profile_card", "component": {"Card": {"child": "card_content"}}}]}}
+{"surfaceUpdate": {"components": [{"id": "card_content", "component": {"Column": {"children": {"explicitList": ["header_row", "bio_text"]}}}}]}}
+{"surfaceUpdate": {"components": [{"id": "header_row", "component": {"Row": {"alignment": "center", "children": {"explicitList": ["avatar", "name_column"]}}}}]}}
+{"surfaceUpdate": {"components": [{"id": "avatar", "component": {"Image": {"url": {"literalString": "https://www.example.com/profile.jpg"}}}}]}}
+{"surfaceUpdate": {"components": [{"id": "name_column", "component": {"Column": {"alignment": "start", "children": {"explicitList": ["name_text", "handle_text"]}}}}]}}
+{"surfaceUpdate": {"components": [{"id": "name_text", "component": {"Text": {"usageHint": "h3", "text": {"literalString": "A2A Fan"}}}}]}}
+{"surfaceUpdate": {"components": [{"id": "handle_text", "component": {"Text": {"text": {"literalString": "@a2a_fan"}}}}]}}
+{"surfaceUpdate": {"components": [{"id": "bio_text", "component": {"Text": {"text": {"literalString": "Building beautiful apps from a single codebase."}}}}]}}
+{"dataModelUpdate": {"contents": {}}}
+{"beginRendering": {"root": "root"}}
+```
+
+---
+
+Source: `submodules/A2UI/specification/v0_8/docs/a2ui_protocol.md`.

--- a/.agents/skills/a2ui-knowledge/references/v0.9/a2a-extension.md
+++ b/.agents/skills/a2ui-knowledge/references/v0.9/a2a-extension.md
@@ -1,0 +1,170 @@
+# A2UI v0.9 — A2A Extension
+
+This document describes how A2UI v0.9 is advertised and transported over the
+A2A (Agent-to-Agent) protocol. The shape is similar to v0.8 with three
+notable changes: a new URI, the `data` field now carries a **list** of
+messages, and capabilities now reference the `server_capabilities.json` /
+`client_capabilities.json` schemas.
+
+## Extension URI
+
+```text
+https://a2ui.org/a2a-extension/a2ui/v0.9
+```
+
+This is the only URI accepted for the v0.9 extension.
+
+## Core concepts
+
+- **Surfaces** — independently controllable UI regions identified by
+  `surfaceId`. A single agent can manage many in parallel.
+- **Catalog Definition Document** — components, functions, and theme schema
+  live in a catalog the client and server agree on per session.
+- **Capabilities exchange** — agents advertise capabilities via Agent Card
+  `params` (matching `server_capabilities.json`), clients reply via
+  `a2uiClientCapabilities` in message metadata (matching
+  `client_capabilities.json`).
+
+Five primary schemas back the extension:
+
+| Schema | Purpose |
+| :--- | :--- |
+| Catalog Definition | A library of components, functions, and a theme schema |
+| Server-to-Client Message List | Wire format for `createSurface`, `updateComponents`, `updateDataModel`, `deleteSurface` |
+| Client-to-Server Message List | Wire format for `action` and `error` |
+| Server Capabilities | `a2uiServerCapabilities` (UI generation capabilities) |
+| Client Capabilities | `a2uiClientCapabilities` (supported catalogs + inline catalogs) |
+
+## Agent Card declaration
+
+Inside `AgentCapabilities.extensions`:
+
+```json
+{
+  "uri": "https://a2ui.org/a2a-extension/a2ui/v0.9",
+  "description": "Ability to render A2UI v0.9",
+  "required": false,
+  "params": {
+    "supportedCatalogIds": [
+      "https://a2ui.org/specification/v0_9/basic_catalog.json",
+      "https://my-company.com/a2ui/v0.9/my_custom_catalog.json"
+    ],
+    "acceptsInlineCatalogs": true
+  }
+}
+```
+
+### Parameters
+
+| Param | Type | Required | Meaning |
+| :--- | :--- | :--- | :--- |
+| `supportedCatalogIds` | `string[]` | optional | IDs of catalogs the agent can generate UI for. Not necessarily resolvable URIs — just stable identifiers. |
+| `acceptsInlineCatalogs` | `boolean` | optional, default `false` | Whether the agent can use catalogs the client supplies at runtime via `a2uiClientCapabilities.inlineCatalogs`. |
+
+The `params` object corresponds directly to the `v0.9` object in
+`server_capabilities.json`. Treat the advertised list as a soft signal —
+orchestrators may delegate to sub-agents whose catalogs aren't in the
+parent's advertisement.
+
+## Extension activation
+
+Clients activate the extension via the standard A2A activation mechanism:
+
+- **JSON-RPC / HTTP**: `X-A2A-Extensions` HTTP header.
+- **gRPC**: `X-A2A-Extensions` metadata value.
+
+Activating the extension means the agent may emit A2UI server messages
+(e.g. `createSurface`) and the client is expected to send A2UI client
+messages (e.g. `action`) back.
+
+## Data encoding — list semantics
+
+A2UI v0.9 messages travel as an A2A `DataPart`:
+
+- `metadata.mimeType` = `application/a2ui+json`
+- `data` is an **array of A2UI messages**, not a single message.
+
+> **MIME type note:** v0.9.1 standardized the payload MIME type to
+> `application/a2ui+json` (the form shown throughout this document). Early
+> v0.9 draft material used the legacy `application/json+a2ui`; update any
+> hardcoded references to the current spelling. Message names and structure
+> are otherwise identical between v0.9 and v0.9.1.
+
+```json
+{
+  "data": [
+    {
+      "version": "v0.9",
+      "createSurface": {
+        "surfaceId": "example_surface",
+        "catalogId": "https://a2ui.org/specification/v0_9/basic_catalog.json"
+      }
+    },
+    {
+      "version": "v0.9",
+      "updateComponents": {
+        "surfaceId": "example_surface",
+        "components": [{ "id": "root", "component": "Text", "text": "Hello!" }]
+      }
+    }
+  ],
+  "kind": "data",
+  "metadata": { "mimeType": "application/a2ui+json" }
+}
+```
+
+### Processing rules
+
+The message list is **not transactional**. Receivers (both clients and
+agents) must:
+
+- process messages **sequentially**,
+- if any individual message fails to validate or apply, log/report the
+  error for that message but **continue** processing the rest,
+- treat atomicity as a per-message property only.
+
+However, **renderers should not repaint until the whole list is processed**
+— that avoids flashing intermediate states across a batch update.
+
+## Client-to-server messages
+
+The same DataPart format, but `data` validates against the Client-to-Server
+Message List Schema (`client_to_server.json`):
+
+```json
+{
+  "data": [{
+    "version": "v0.9",
+    "action": {
+      "name": "submit_form",
+      "surfaceId": "contact_form_1",
+      "sourceComponentId": "submit_button",
+      "timestamp": "2026-01-15T12:00:00Z",
+      "context": { "email": "user@example.com" }
+    }
+  }],
+  "kind": "data",
+  "metadata": { "mimeType": "application/a2ui+json" }
+}
+```
+
+## Metadata fields
+
+Two A2UI-defined objects ride in A2A `Message.metadata`:
+
+| Field | Schema | When |
+| :--- | :--- | :--- |
+| `a2uiClientCapabilities` | `client_capabilities.json` | every client → server message |
+| `a2uiClientDataModel` | `client_data_model.json` | client → server messages, when at least one active surface was created with `sendDataModel: true` |
+
+See `custom-catalog-guide.md` for the catalog-negotiation flow and
+`protocol.md` for the data-sync semantics.
+
+## Context mapping
+
+A2UI sessions typically map to an A2A `contextId`. Messages for a set of
+related surfaces should share the same `contextId`.
+
+---
+
+Source: `submodules/A2UI/specification/v0_9/docs/a2ui_extension_specification.md`.

--- a/.agents/skills/a2ui-knowledge/references/v0.9/basic-catalog-guide.md
+++ b/.agents/skills/a2ui-knowledge/references/v0.9/basic-catalog-guide.md
@@ -1,0 +1,314 @@
+# A2UI v0.9 — Basic Catalog Implementation Guide
+
+This is the per-component implementation reference for renderer / client
+developers targeting the v0.9 Basic Catalog. Use it when wiring framework
+adapters (Layer 3 in `renderer-guide.md`) over the generic A2UI bindings —
+it spells out expected visual behavior, suggested defaults, and interaction
+patterns for each component and each built-in function.
+
+## Table of Contents
+
+- [Components](#components)
+- [Client-Side Functions](#client-side-functions)
+- [Layout Spacing — the Leaf-Margin Strategy](#layout-spacing--the-leaf-margin-strategy)
+- [Color, Contrast, and Nesting](#color-contrast-and-nesting)
+
+## Components
+
+### Text
+
+Displays text content; supports simple Markdown.
+
+- Render through a Markdown parser when available. If it's unavailable or
+  fails, fall back to the raw text — and ideally strip common Markdown
+  markers (`**`, `#`) so legibility is preserved.
+- Variants: `h1`–`h5` (suggested sizes 2.5x / 2x / 1.75x / 1.5x / 1.25x the
+  base), `caption` (~0.8x base, lighter/italic), `body` (default).
+
+### Image
+
+Image from a URL. Default to flexible width filling the container.
+
+- Map `fit` to the platform's content-scale mode (CSS `object-fit`, iOS
+  `contentMode`, Android `ScaleType`).
+- Variants: `icon` (~24x24dp square), `avatar` (small, rounded/circular),
+  `smallFeature` (~100x100dp), `mediumFeature` (default, ~200x200dp or 100%
+  width), `largeFeature` (large prominent), `header` (full-width banner with
+  cover/crop scaling).
+
+### Icon
+
+System-provided icon by name. Map the `name` (e.g. `accountCircle`) to a
+system icon set (Material Symbols, SF Symbols, …) — converting case as
+needed (`account_circle`). Default size 24dp; inherit current text color.
+
+### Video
+
+Native video player with controls; full container width; support scrubbing
+where the native control allows.
+
+### AudioPlayer
+
+Native audio player with controls; full container width; support scrubbing.
+
+### Row
+
+Horizontal layout (CSS flex row / Compose `Row` / SwiftUI `HStack`). Fill
+available width.
+
+- `justify` → main-axis (`justify-content` / `horizontalArrangement`):
+  `start`, `center`, `end`, `spaceBetween`.
+- `align` → cross-axis (`align-items` / `verticalAlignment`).
+
+### Column
+
+Vertical layout (CSS flex column / Compose `Column` / SwiftUI `VStack`).
+Mirrors `Row` but `justify` is vertical, `align` is horizontal.
+
+### List
+
+Scrollable list.
+
+- `direction` defaults to `vertical` (CSS `overflow-y: auto`, Compose
+  `LazyColumn`, SwiftUI vertical `ScrollView`). For `horizontal`, hide the
+  scrollbar where possible. Horizontal-list children typically need a
+  bounded max width.
+
+### Card
+
+Container with card styling — distinct background, rounded corners (e.g.
+8–12dp), subtle elevation/shadow, inner padding (~16dp).
+
+**Card accepts exactly one child.** If the agent wants several elements
+inside, wrap them in a `Column` (or `Row`).
+
+### Tabs
+
+Horizontal row of selectable headers above the active tab's child.
+
+- Maintain a local `selectedIndex` (default `0`).
+- On tap, update `selectedIndex` and render only that index's `child`.
+- Visually indicate the active tab (bold, colored underline, …).
+
+### Divider
+
+- `axis: horizontal` (default) — 1dp tall, 100% width, subtle outline color.
+- `axis: vertical` — 1dp wide, full container height.
+
+### Modal
+
+Dialog over the main content. Behaves as a **modal entry point**, not a
+regular container:
+
+- Render only the `trigger` child in the surface tree.
+- When the user taps the trigger, open the modal and render the `content`
+  child.
+- Desktop: centered popup over a dimmed backdrop. Mobile: bottom sheet or
+  full-screen dialog.
+- Always provide a close mechanism (X button, backdrop tap, swipe-down).
+
+### Button
+
+Native button that dispatches an action when tapped.
+
+- Always renders its `child` inside (typically a `Text` or `Icon`).
+- Variants: `default` (subtle background + border), `primary` (use theme's
+  `primaryColor` as background with contrasting text), `borderless` (no
+  background or border, like a text link).
+- Action context is resolved at the moment of interaction (so it reflects
+  the user's latest inputs).
+
+### TextField
+
+Native text input. Establishes two-way binding — on each keystroke, write
+the new string back to the bound `value` path.
+
+- Variants: `shortText` (default single line), `longText` (multi-line),
+  `number` (numeric keyboard), `obscured` (password/secure).
+
+### CheckBox
+
+Native checkbox/toggle alongside its label. Two-way bind boolean `true`/
+`false` to the bound `value` path.
+
+### ChoicePicker
+
+Selects one or more options.
+
+- `displayStyle: "checkbox"` (default) — dropdown / picker / expanding list.
+  A dropdown wrapper is preferred for space.
+- `displayStyle: "chips"` — horizontal wrapping row of selectable chips.
+  Selected chips visually distinct.
+- If `filterable: true`, render a search input over the option list;
+  case-insensitive substring match on labels.
+- Binds to an array of strings (the active selections).
+
+### Slider
+
+Native slider/seek bar. Optionally display the current value next to the
+track.
+
+- `min`/`max` set the range. The value is a `number` (not integer), so
+  decimal ranges like 0.0–1.0 are valid.
+- Two-way bind on drag.
+
+### DateTimeInput
+
+Native date/time picker.
+
+- `enableDate` + `enableTime` → both pickers shown.
+- `enableDate` only → date picker only.
+- `enableTime` only → time picker only.
+
+Write **ISO 8601 strings** to the data model (and parse ISO 8601 coming back
+into the picker).
+
+## Client-Side Functions
+
+Most functions are pure logic — they take resolved args and return a value.
+The Binder/Context layer wraps execution in a reactive stream so the
+function re-runs when any dynamic argument changes. `formatString` is the
+notable exception: it must parse its own expression string to find
+dependencies, then build a reactive `computed`.
+
+### `formatString`
+
+The core interpolation engine; the only place `${expression}` syntax is
+valid.
+
+Implementation:
+
+1. **Parse** the input for `${...}` blocks. Handle escapes (`\${` → literal
+   `${`).
+2. **Tokenize** inside an interpolation block:
+   - **Literals** — quoted strings (`'...'` / `"..."`), numbers, `true` /
+     `false` / `null`.
+   - **Data paths** — start with `/` (absolute) or a bare identifier
+     (relative within the current scope).
+   - **Function calls** — identifier followed by `()` with named args.
+3. **Resolve** each path/call through `DataContext.resolveSignal(token)` to
+   get a reactive stream.
+4. **Return** a `computed(() => ...)` that concatenates the resolved values
+   with the literal text fragments, applying the type-coercion rules
+   (number / boolean → string; null/undefined → `""`; object/array →
+   JSON-stringify).
+
+### `required`
+
+Returns `true` if `args.value` is not `null`, not `undefined`, not `""`, and
+not `[]`.
+
+### `regex`
+
+Compile `args.pattern` as a RegExp, test against `args.value`.
+
+### `length`
+
+True iff `args.value.length` is `>= args.min` (if provided) and `<= args.max`
+(if provided).
+
+### `numeric`
+
+Parse `args.value` as a number; check it's in `[args.min, args.max]`. Return
+`false` if it isn't a parseable number.
+
+### `email`
+
+Test against a standard email regex like `/^[^\s@]+@[^\s@]+\.[^\s@]+$/`.
+
+### `formatNumber`
+
+Native locale formatting (`Intl.NumberFormat`, `NumberFormatter`). Apply
+`args.decimals` as both min and max fraction digits. Enable grouping
+unless `args.grouping: false`.
+
+### `formatCurrency`
+
+Like `formatNumber` but currency style, using ISO 4217 code from
+`args.currency` (`USD`, `EUR`, …).
+
+### `formatDate`
+
+Parse `args.value` as a date/time; format using a Unicode TR35 pattern
+(`yyyy-MM-dd`, `HH:mm`, …) — typically via a platform-specific date
+library.
+
+### `pluralize`
+
+Resolve the plural category for `args.value` via `Intl.PluralRules` (or
+equivalent). Map the resulting category (`zero` / `one` / `two` / `few` /
+`many` / `other`) to the corresponding string in `args`. Fall back to
+`args.other` if a category-specific string is missing.
+
+### `openUrl`
+
+Open `args.url` via the native URL handler. Returns `void`; runs as a
+side-effect, only from user actions.
+
+### `and` / `or` / `not`
+
+Standard short-circuited boolean operators over `args.values` (or
+`args.value` for `not`).
+
+## Layout Spacing — the Leaf-Margin Strategy
+
+A common pitfall in dynamic UI: nesting `Row` inside `Column` inside `Row`
+accumulates padding/margins and the design feels "off." A2UI's recommended
+strategy:
+
+1. **Structural containers contribute zero spacing.** `Row`, `Column`,
+   `List` get **no internal padding** and **no external margin**. They are
+   pure structural boundaries — wrapping an element in a `Column` must not
+   alter its spacing.
+2. **Leaf components carry the margin.** `Text`, `Image`, `Icon`, `Video`,
+   `AudioPlayer`, `Slider`, etc. apply a uniform external margin (e.g.
+   `8dp` on all sides).
+3. **Visually-outlined containers also carry margin.** `Card`, `Button`,
+   `TextField`, `CheckBox`, `ChoicePicker` apply the same external margin.
+   They additionally need internal padding to keep content off their own
+   borders, but that padding is local and doesn't affect the surrounding
+   layout.
+
+Margins-on-leaves (rather than padding/gap on parents) makes spacing
+predictable under arbitrarily deep nesting: structural containers
+contribute zero, so the same component always reserves the same space
+regardless of how it's wrapped.
+
+## Color, Contrast, and Nesting
+
+Don't manually thread color properties down the A2UI tree. Use the native
+framework's theme/context inheritance instead.
+
+### Text & Icon contrast
+
+A `primary` `Button` defines its own background color; it must also publish
+the expected foreground color so nested `Text` / `Icon` adapt automatically.
+
+- **Web** — set CSS `color` on the button wrapper. CSS inheritance does the
+  rest.
+- **Compose (Android)** — `CompositionLocalProvider(LocalContentColor provides ...)`.
+- **SwiftUI (iOS)** — `.foregroundColor(...)` or
+  `.environment(\.colorScheme, ...)` on the button wrapper.
+- **Flutter** — `DefaultTextStyle.merge()` + `IconTheme.merge()`. With
+  Material buttons this is often automatic.
+
+Rule of thumb: **leaf `Text` and `Icon` components never hardcode color
+unless explicitly instructed by a property** — they inherit from their
+environment.
+
+### Nested containers (Cards inside Cards)
+
+Trying to alternate surface colors by depth is messy. Simplest robust
+default:
+
+- Give `Card` a **transparent background** and a **visible 1dp outline** in
+  the theme's outline color.
+- Borders compose cleanly under arbitrary nesting — nested cards just draw
+  an inner boundary inside the parent.
+- If your design system requires opaque cards, use the framework's
+  elevation/tint system (Material elevation, SwiftUI's `Material`, …)
+  rather than coding depth-aware color logic into the A2UI adapters.
+
+---
+
+Source: `submodules/A2UI/specification/v0_9/docs/basic_catalog_implementation_guide.md`.

--- a/.agents/skills/a2ui-knowledge/references/v0.9/custom-catalog-guide.md
+++ b/.agents/skills/a2ui-knowledge/references/v0.9/custom-catalog-guide.md
@@ -1,0 +1,528 @@
+# A2UI v0.9 — Custom Catalog Guide
+
+This guide covers the **end-to-end** workflow for replacing or extending the
+Basic Catalog with your own application-specific catalog: defining the
+schema, registering components in the renderer, the catalog-negotiation
+handshake, versioning, validation, and graceful degradation.
+
+## Table of Contents
+
+- [Why Define a Custom Catalog](#why-define-a-custom-catalog)
+- [Catalog Schema Anatomy](#catalog-schema-anatomy)
+- [Building a Catalog](#building-a-catalog)
+- [Authoring a Component (Schema → Implementation → Registration)](#authoring-a-component-schema--implementation--registration)
+- [Catalog Negotiation Handshake](#catalog-negotiation-handshake)
+- [Versioning and Migrations](#versioning-and-migrations)
+- [Validation Strategy](#validation-strategy)
+- [Graceful Degradation](#graceful-degradation)
+- [Security Considerations](#security-considerations)
+- [Agent-Side Integration (ADK)](#agent-side-integration-adk)
+- [Inline Catalogs](#inline-catalogs)
+
+## Why Define a Custom Catalog
+
+Every A2UI surface is driven by a Catalog — a JSON Schema file telling the
+agent which components, functions, and themes are available. The Basic
+Catalog is deliberately sparse to be implementable across renderers; most
+production apps replace it.
+
+Benefits:
+
+- **Design-system alignment** — restrict the agent to your real components,
+  not generic primitives.
+- **Security / type safety** — you register the entire catalog with the
+  client app, so only trusted components ever render.
+- **No mappers needed** — catalogs that mirror your component library beat
+  Basic-Catalog-plus-adapter every time. Since the LLM interprets the
+  catalog itself, you don't need a portable lingua franca across clients.
+
+| Use case | Recommendation | Effort |
+| :--- | :--- | :--- |
+| A2UI added to a mature frontend | Define a catalog mirroring your existing design system | Medium |
+| Greenfield app | Start with the Basic Catalog; evolve into your own as the app matures | Low (assuming a renderer exists) |
+
+## Catalog Schema Anatomy
+
+The full catalog schema (excerpted from `client_capabilities.json`):
+
+```json
+{
+  "Catalog": {
+    "type": "object",
+    "description": "A collection of component and function definitions.",
+    "properties": {
+      "catalogId":  { "type": "string", "description": "Unique identifier" },
+      "components": { "type": "object", "additionalProperties": { "$ref": "https://json-schema.org/draft/2020-12/schema" } },
+      "functions":  { "type": "array",  "items": { "$ref": "#/$defs/FunctionDefinition" } },
+      "theme":      { "type": "object", "additionalProperties": { "$ref": "https://json-schema.org/draft/2020-12/schema" } }
+    },
+    "required": ["catalogId"],
+    "additionalProperties": false
+  }
+}
+```
+
+Key constraints:
+
+- **Freestanding** — final catalogs MUST have no external `$ref`s. This
+  simplifies LLM inference and removes runtime dependencies. You **may** use
+  external `$ref`s during local development and bundle them with
+  `tools/build_catalog/assemble_catalog.py` before publishing.
+- **Validator-compliant types** — when a property references another
+  component by id, use
+  `"$ref": "common_types.json#/$defs/ComponentId"` (not raw `string`); for
+  lists/templates, use `ChildList`. Raw strings make validators treat the
+  field as static text and silently miss broken references.
+
+## Building a Catalog
+
+### Minimal example
+
+A catalog with one component:
+
+```json
+{
+  "$id": "https://github.com/.../hello_world/v1/catalog.json",
+  "components": {
+    "HelloWorldBanner": {
+      "type": "object",
+      "description": "A simple banner greeting.",
+      "properties": {
+        "message": { "type": "string", "description": "The banner text." },
+        "backgroundColor": { "type": "string", "default": "#f0f0f0" }
+      },
+      "required": ["message"]
+    }
+  }
+}
+```
+
+Generated payload:
+
+```json
+[
+  { "version": "v0.9",
+    "createSurface": { "surfaceId": "hello-world-surface",
+                       "catalogId": "https://github.com/.../hello_world/v1/catalog.json" } },
+  { "version": "v0.9",
+    "updateComponents": { "surfaceId": "hello-world-surface",
+                          "components": [
+                            { "id": "root", "component": "HelloWorldBanner",
+                              "message": "Hello, world!", "backgroundColor": "#4CAF50" }
+                          ] } }
+]
+```
+
+### Extending the Basic Catalog
+
+```json
+{
+  "$id": "https://github.com/.../my_app/v1/catalog.json",
+  "components": {
+    "allOf": [
+      { "$ref": "basic_catalog_definition.json#/components" },
+      {
+        "SuggestionChips": {
+          "type": "object",
+          "description": "A list of suggested prompts",
+          "properties": { "suggestions": { "type": "array", "description": "The suggested prompts." } },
+          "required": ["suggestions"]
+        }
+      }
+    ]
+  }
+}
+```
+
+### Cherry-picking from the Basic Catalog
+
+```json
+{
+  "$id": "https://github.com/.../popup_app/v1/catalog.json",
+  "components": {
+    "allOf": [
+      { "$ref": "basic_catalog.json#/components/Text" },
+      {
+        "Popup": {
+          "type": "object",
+          "description": "A modal overlay that displays an icon and text.",
+          "properties": { "text": { "$ref": "common_types.json#/$defs/ComponentId" } },
+          "required": ["text"]
+        }
+      }
+    ]
+  }
+}
+```
+
+### Bundling with `assemble_catalog.py`
+
+```bash
+uv run tools/build_catalog/assemble_catalog.py [INPUTS ...] \
+  --output-name <OUTPUT_NAME> \
+  [--catalog-id <ID>] \
+  [--version 0.9 | 0.10] \
+  [--extend-basic-catalog] \
+  [--out-dir <DIR>] \
+  [--verbose]
+```
+
+Key flags:
+
+- `--output-name` (required) — name of the combined catalog file.
+- `--catalog-id` — defaults to `urn:a2ui:catalog:<base_name>`.
+- `--version` — A2UI spec version for official fallbacks (`0.9` or `0.10`).
+- `--extend-basic-catalog` — automatically inline the entire
+  `basic_catalog.json` even if your inputs don't reference it.
+
+## Authoring a Component (Schema → Implementation → Registration)
+
+The four-step workflow, illustrated with the `rizzcharts` sample's `Chart`
+component (Angular renderer).
+
+### 1. Define the schema
+
+In `rizzcharts_catalog_definition.json`:
+
+```json
+"Chart": {
+  "type": "object",
+  "description": "An interactive chart that uses a hierarchical list of objects for its data.",
+  "properties": {
+    "type":  { "type": "string", "description": "The type of chart to render.", "enum": ["doughnut", "pie"] },
+    "title": { "type": "object",
+               "properties": { "literalString": {"type": "string"}, "path": {"type": "string"} } },
+    "chartData": { "type": "object",
+      "properties": {
+        "literalArray": {
+          "type": "array",
+          "items": { "type": "object",
+                     "properties": { "label": {"type": "string"}, "value": {"type": "number"},
+                                     "drillDown": { "type": "array",
+                                       "items": { "type": "object",
+                                                  "properties": { "label": {"type": "string"}, "value": {"type": "number"} },
+                                                  "required": ["label", "value"] } } },
+                     "required": ["label", "value"] }
+        },
+        "path": { "type": "string" }
+      }
+    }
+  },
+  "required": ["type", "chartData"]
+}
+```
+
+### 2. Implement the component (Angular)
+
+Extend `DynamicComponent` from `@a2ui/angular`:
+
+```typescript
+import { DynamicComponent } from '@a2ui/angular';
+import * as Primitives from '@a2ui/web_core/types/primitives';
+import * as Types from '@a2ui/web_core/types/types';
+import { Component, computed, input } from '@angular/core';
+
+@Component({
+  selector: 'a2ui-chart',
+  template: `
+    <div>
+      <h2>{{ resolvedTitle() }}</h2>
+      <canvas baseChart [data]="currentData()" [type]="chartType()"></canvas>
+    </div>
+  `,
+})
+export class Chart extends DynamicComponent<Types.CustomNode> {
+  readonly type = input.required<string>();
+  protected readonly chartType = computed(() => this.type() as ChartType);
+
+  readonly title = input<Primitives.StringValue | null>();
+  protected readonly resolvedTitle = computed(() => super.resolvePrimitive(this.title() ?? null));
+
+  readonly chartData = input.required<Primitives.StringValue | null>();
+  // ... data resolution logic using super.resolvePrimitive for data paths
+}
+```
+
+`super.resolvePrimitive` is the helper that turns A2UI `DynamicString` /
+`DynamicArray` shapes into real values, handling both literals and `path`
+bindings.
+
+### 3. Register in the client catalog
+
+```typescript
+import { Catalog, DEFAULT_CATALOG } from '@a2ui/angular';
+import { inputBinding } from '@angular/core';
+
+export const RIZZ_CHARTS_CATALOG = {
+  ...DEFAULT_CATALOG,            // include the Basic Catalog
+  Chart: {
+    type: () => import('./chart').then(r => r.Chart),   // lazy-loaded
+    bindings: ({ properties }) => [
+      inputBinding('type',      () => ('type' in properties && properties['type']) || undefined),
+      inputBinding('title',     () => ('title' in properties && properties['title']) || undefined),
+      inputBinding('chartData', () => ('chartData' in properties && properties['chartData']) || undefined),
+    ],
+  },
+} as Catalog;
+```
+
+### 4. Wire the agent (see "Agent-Side Integration" below)
+
+## Catalog Negotiation Handshake
+
+Three steps:
+
+### Step 1 — Agent advertises support (optional)
+
+A2A AgentCard hint:
+
+```json
+{
+  "name": "Ecommerce Dashboard Agent",
+  "capabilities": {
+    "extensions": [{
+      "uri": "https://a2ui.org/a2a-extension/a2ui/v0.9",
+      "params": {
+        "supportedCatalogIds": [
+          "https://a2ui.org/specification/v0_9/basic_catalog.json",
+          "https://github.com/.../rizzcharts_catalog_definition.json"
+        ]
+      }
+    }]
+  }
+}
+```
+
+Informational — helps the client know what to expect, doesn't bind the
+agent.
+
+### Step 2 — Client declares support (required, every message)
+
+Every outbound A2A message metadata carries `a2uiClientCapabilities` with a
+**preference-ordered** list:
+
+```json
+{
+  "parts": [{ "text": "What is the current status of my flight?" }],
+  "metadata": {
+    "a2uiClientCapabilities": {
+      "supportedCatalogIds": [
+        "https://a2ui.org/specification/v0_9/basic_catalog.json",
+        "https://github.com/.../rizzcharts_catalog_definition.json"
+      ]
+    }
+  }
+}
+```
+
+### Step 3 — Agent picks per-surface
+
+When the agent creates a surface, it picks the best match from the client's
+list. Once chosen, the choice is **locked for the lifetime of that
+surface**. If no compatible catalog is found, the agent does not send UI.
+
+```json
+{
+  "createSurface": {
+    "surfaceId": "salesDashboard",
+    "catalogId": "https://a2ui.org/specification/v0_9/basic_catalog.json"
+  }
+}
+```
+
+## Versioning and Migrations
+
+### `catalogId` is a URI
+
+Recommended pattern: `https://example.com/catalogs/mysurface/v1/catalog.json`.
+
+- The URI is **just an identifier** — no runtime fetch. The catalog
+  definition must be known to both agent and client beforehand (compile/
+  deploy time).
+- URIs make IDs globally unique and easy for humans to inspect.
+
+### Breaking vs non-breaking
+
+The standard JSON parser ignores unknown fields, but in a server-driven UI
+silently dropping a *container* component drops its entire subtree. Update
+classification:
+
+**Breaking (major version bump required)** — bump `v1` → `v2`:
+
+- Adding a container (old clients would render no children when the
+  container is dropped).
+- Removing a container.
+- Changing a property's type (validator failure on older clients).
+- Adding a required property without a default.
+
+**Non-breaking (stay on current major)**:
+
+- Adding a leaf component (safe to ignore).
+- Adding an optional property.
+- Removing a property (clients can ignore if no longer sent).
+- Adding new functions or styles.
+- Doc-only changes (`description`, typo fixes).
+
+### Migration playbook
+
+To roll out a new major version without downtime:
+
+1. **Client updates first** — clients advertise *both* versions
+   (`[".../v2/...", ".../v1/..."]`) in `supportedCatalogIds`.
+2. **Agents update** — rebuilt agents see v2 and prefer it.
+3. **Legacy support** — older agents that haven't been rebuilt still match
+   v1 in the client's list and remain functional.
+
+## Validation Strategy
+
+Two-phase, defense in depth:
+
+### Agent-side (pre-send)
+
+Before transmitting any UI payload, the agent runtime validates the
+generated JSON against the catalog.
+
+- **Purpose** — catch hallucinated properties or malformed structures at
+  the source.
+- **Outcome on failure** — agent attempts to fix/regenerate the JSON, or
+  gracefully degrades (e.g. plain text response).
+
+### Client-side
+
+The client library validates the payload against its local catalog
+definition before rendering.
+
+- **Purpose** — security + stability against version mismatches or
+  compromised agent outputs.
+- **Outcome on failure** — emit a `VALIDATION_FAILED` error back to the
+  agent:
+
+```json
+{
+  "version": "v0.9",
+  "error": {
+    "code": "VALIDATION_FAILED",
+    "surfaceId": "flight-status-card-123",
+    "path": "/components/FlightCard/flightNumber",
+    "message": "Missing required property 'flightNumber' in component 'FlightCard'."
+  }
+}
+```
+
+## Graceful Degradation
+
+Even after schema validation passes, the renderer may hit runtime issues
+(missing asset, component implementation not loaded, platform limitation).
+**Don't crash.**
+
+- **Unknown components** — render a safe fallback (a generic card with the
+  component's debug name) or skip the node entirely.
+- **Text fallback** — if a whole surface fails to render, display the raw
+  text description (if available) or a generic message like
+  "This interface could not be displayed."
+
+Real-world version-skew scenarios:
+
+- **Old iOS client, newer agent** — agent sends a new `Badge` component;
+  the old client renders a placeholder/text fallback. Agent sends a new
+  property on `Button`; the old client ignores it. Agent removed a
+  component the old client supports; nothing breaks because the agent just
+  stops sending it.
+- **New web client, older agent** — client supports new `Badge` but the
+  agent never sends it; no issue. Client removed an old property and
+  ignores it if the agent still sends it. Client added new styles the
+  agent doesn't use; no issue.
+
+## Security Considerations
+
+1. **Allowlist components** — only register components you trust. Don't
+   expose components that offer dangerous capabilities (script execution,
+   `<iframe src="...">` with arbitrary URLs) unless they're tightly
+   constrained.
+2. **Validate properties** — always validate agent-supplied properties
+   against type constraints before rendering. Schema validation is the
+   first line; runtime validation is the second.
+3. **Sanitize text** — never render unsanitized agent-provided content
+   unless the rendering path is known-safe (e.g. the renderer's Markdown
+   pipeline does sanitization).
+4. **Pre-compile catalogs into the client** — do not fetch catalogs at
+   runtime from the network. Inline catalogs in `a2uiClientCapabilities`
+   exist for local dev only; production catalogs must be compile-time.
+
+## Agent-Side Integration (ADK)
+
+The Python ADK provides a turnkey path for wiring an agent to a custom
+catalog.
+
+### Session preparation (executor)
+
+Intercept the incoming message to detect A2UI activation and the catalog
+the client supports; resolve and stash it in session state:
+
+```python
+use_ui = try_activate_a2ui_extension(context)
+if use_ui:
+    a2ui_catalog = self.schema_manager.get_selected_catalog(
+        client_ui_capabilities=capabilities
+    )
+    examples = self.schema_manager.load_examples(a2ui_catalog, validate=True)
+
+    await runner.session_service.append_event(
+        session,
+        Event(actions=EventActions(state_delta={
+            _A2UI_ENABLED_KEY: True,
+            _A2UI_CATALOG_KEY: a2ui_catalog,
+            _A2UI_EXAMPLES_KEY: examples,
+        })),
+    )
+```
+
+`A2uiSchemaManager` is responsible for choosing the right catalog from the
+client's advertised list and pre-loading validated examples for the LLM
+prompt.
+
+### Tool setup
+
+Expose `SendA2uiToClientToolset` so the LLM can emit A2UI payloads as tool
+calls:
+
+```python
+from a2ui.adk.send_a2ui_to_client_toolset import SendA2uiToClientToolset
+
+a2ui_catalog = self.schema_manager.get_selected_catalog(
+    client_ui_capabilities=capabilities
+)
+agent.tools = [
+    SendA2uiToClientToolset(
+        a2ui_catalog=a2ui_catalog,
+        a2ui_enabled=True,
+    )
+]
+```
+
+### Event converter
+
+Bridge the LLM's tool calls into A2A `DataPart`s with the A2UI mimeType:
+
+```python
+from a2ui.adk.send_a2ui_to_client_toolset import A2uiEventConverter
+
+config = A2aAgentExecutorConfig(event_converter=A2uiEventConverter())
+```
+
+## Inline Catalogs
+
+`a2uiClientCapabilities.inlineCatalogs` lets the client supply a full
+catalog definition at runtime. **Supported, but not recommended in
+production** — it's intended for local dev, where round-tripping a catalog
+through the agent build is too slow. In production, pre-compile catalogs
+into the agent's deployment.
+
+The agent must have advertised `acceptsInlineCatalogs: true` (in
+`server_capabilities.json`) for an inline catalog to be honored.
+
+---
+
+Source: synthesized from `submodules/A2UI/docs/concepts/catalogs.md`,
+`submodules/A2UI/docs/guides/defining-your-own-catalog.md`, and
+`submodules/A2UI/docs/guides/authoring-components.md`.

--- a/.agents/skills/a2ui-knowledge/references/v0.9/custom-functions.md
+++ b/.agents/skills/a2ui-knowledge/references/v0.9/custom-functions.md
@@ -1,0 +1,159 @@
+# A2UI v0.9 — Custom Functions
+
+A2UI functions are first-class members of a Catalog alongside components. When
+you define a custom catalog, you can add functions that suit your application
+or design system — e.g. a string `trim` or a hardware-query helper like
+`getScreenResolution`.
+
+This reference walks through defining custom functions and wiring them in
+so validators recognize them.
+
+## 1. Add functions to the catalog JSON Schema
+
+Use a `functions` map keyed by function name. Each entry is a schema for the
+`FunctionCall` shape — `call`, `args`, and `returnType`.
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/schemas/custom_catalog.json",
+  "title": "Custom Function Catalog",
+  "functions": {
+    "trim": {
+      "type": "object",
+      "description": "Removes whitespace (or other characters) from the beginning and end of a string.",
+      "properties": {
+        "call": { "const": "trim" },
+        "args": {
+          "type": "object",
+          "properties": {
+            "value": {
+              "$ref": "common_types.json#/$defs/DynamicString",
+              "description": "The string to trim."
+            },
+            "chars": {
+              "$ref": "common_types.json#/$defs/DynamicString",
+              "description": "Optional. A set of characters to remove. Defaults to whitespace."
+            }
+          },
+          "required": ["value"],
+          "unevaluatedProperties": false
+        },
+        "returnType": { "const": "string" }
+      },
+      "required": ["call", "args"],
+      "unevaluatedProperties": false
+    },
+
+    "getScreenResolution": {
+      "type": "object",
+      "description": "Queries hardware for screen resolution.",
+      "properties": {
+        "call": { "const": "getScreenResolution" },
+        "args": {
+          "type": "object",
+          "properties": {
+            "screenIndex": {
+              "$ref": "common_types.json#/$defs/DynamicNumber",
+              "description": "Optional. Defaults to 0 (primary screen)."
+            }
+          },
+          "unevaluatedProperties": false
+        },
+        "returnType": { "const": "array" }
+      },
+      "required": ["call", "args"],
+      "unevaluatedProperties": false
+    }
+  }
+}
+```
+
+Key conventions:
+
+- `call` is a constant matching the function name — that's what the validator
+  uses as a discriminator.
+- `args` is an object with named properties; reuse `common_types.json` types
+  (`DynamicString`, `DynamicNumber`, …) so the same binding semantics work.
+- `returnType` is one of `string`, `number`, `boolean`, `array`, `object`,
+  `any`, `void`.
+- `unevaluatedProperties: false` everywhere keeps the LLM honest about not
+  emitting extra fields.
+
+## 2. Expose them via `anyFunction`
+
+The `FunctionCall` definition in the envelope refers to a catalog-agnostic
+`anyFunction`. Your catalog must define that reference to enumerate which
+functions actually exist:
+
+```json
+{
+  "$defs": {
+    "anyFunction": {
+      "oneOf": [
+        { "$ref": "#/functions/trim" },
+        { "$ref": "#/functions/getScreenResolution" }
+      ]
+    }
+  }
+}
+```
+
+### Including the Basic Catalog's functions
+
+To extend rather than replace the built-ins (`required`, `regex`, `email`,
+`formatString`, …), `oneOf`-in the Basic Catalog's `anyFunction`:
+
+```json
+{
+  "$defs": {
+    "anyFunction": {
+      "oneOf": [
+        { "$ref": "#/functions/trim" },
+        { "$ref": "#/functions/getScreenResolution" },
+        { "$ref": "basic_catalog.json#/$defs/anyFunction" }
+      ]
+    }
+  }
+}
+```
+
+If you're producing a freestanding (no external `$ref`) catalog for production
+use, run `tools/build_catalog/assemble_catalog.py` to inline the dependencies.
+
+## 3. How validation works
+
+When a `FunctionCall` is validated:
+
+1. **Discriminator lookup** — the validator reads `call`.
+2. **Schema matching** —
+   - `call: "length"` → matches the built-in `length` schema, validates `args`.
+   - `call: "trim"` → matches your custom `trim` schema.
+   - `call: "unknownFunc"` → fails immediately (strict mode).
+3. **Args validation** — the matched schema's `args` properties enforce types
+   on each named argument.
+
+This strict-by-default approach catches typos early and lets you add
+capabilities with full type safety.
+
+## 4. Implementing the function (renderer side)
+
+The schema only describes the contract. The renderer must also provide a
+**runtime implementation** registered in its catalog (`FunctionImplementation`
+in the renderer architecture — see `renderer-guide.md`). The implementation
+receives statically resolved `args` and returns either a value or a reactive
+stream:
+
+- **Pure-logic functions** (e.g. `trim`) — synchronous, return a static value.
+- **External-state functions** (e.g. `getScreenResolution` that watches the
+  display) — return a reactive stream so changes propagate to the UI.
+- **Effect functions** (e.g. `openUrl`) — return `void`; triggered by user
+  actions, not interpolation.
+
+If the function returns a reactive stream, use an idiomatic listening mechanism
+that supports unsubscription — the binder layer disposes subscriptions on
+component unmount.
+
+---
+
+Source: `submodules/A2UI/specification/v0_9/docs/a2ui_custom_functions.md`.

--- a/.agents/skills/a2ui-knowledge/references/v0.9/evolution-guide.md
+++ b/.agents/skills/a2ui-knowledge/references/v0.9/evolution-guide.md
@@ -1,0 +1,236 @@
+# A2UI Evolution Guide — v0.8.1 → v0.9
+
+Use this reference when migrating an existing v0.8 implementation, or when
+deciding which version to target for a new project.
+
+## Why v0.9 exists
+
+v0.8 was optimized for **structured output** — strict JSON mode or function
+calling. It relied on key-wrapped components and adjacency-list maps that
+schema validators could pin down precisely but that LLMs found awkward to
+generate.
+
+v0.9 is **prompt-first** — the schema is meant to be embedded directly in
+the model's system prompt and the model is expected to produce JSON that
+matches by example. That gives:
+
+1. **Richer schemas** — no longer constrained by what structured-output
+   modes accept. Catalogs can be more expressive and more readable.
+2. **Modular schemas** — split into `common_types.json`, `server_to_client.json`,
+   `basic_catalog.json` (plus capability schemas), making custom catalogs easy.
+
+The trade-off: the LLM is no longer **strictly** constrained by the schema,
+so v0.9 requires robust post-generation validation and a retry/correct
+loop. That loop is built in via the `VALIDATION_FAILED` error format.
+
+## Summary table
+
+| Feature | v0.8.1 | v0.9 |
+| :--- | :--- | :--- |
+| Philosophy | Structured Output / Function Calling | Prompt-First / In-Context Schema |
+| Message types | `beginRendering`, `surfaceUpdate`, `dataModelUpdate`, `deleteSurface` | `createSurface`, `updateComponents`, `updateDataModel`, `deleteSurface` |
+| Surface creation | `beginRendering` (also flags ready-to-render) | `createSurface` (separate creation + render-when-ready-via-root) |
+| Component shape | Key-based wrapper `{"Text": {...}}` | Property discriminator `"component": "Text"` |
+| Data model update | Array of typed key-value entries | Standard JSON object at `path` |
+| Data binding | `dataBinding` / `literalString` typed wrappers | `path` / native JSON types |
+| Button context | Array of key-value pairs | Standard JSON object |
+| Button variant | Boolean `primary: true` | Enum `variant: "primary" \| "borderless"` |
+| Catalog | Separate component + function catalogs | Unified catalog (`basic_catalog.json`) |
+| Auxiliary rules | (none) | `basic_catalog_rules.txt` prompt fragment |
+| Validation | Schema-only | `ValidationFailed` feedback loop |
+| Data sync | Ad-hoc | Explicit `sendDataModel` flag |
+
+## Architectural & schema changes
+
+### Modular schema layout
+
+v0.8.1 had a monolithic `server_to_client.json`. v0.9 splits into:
+
+- `common_types.json` — `DynamicString`, `DynamicNumber`, `DynamicBoolean`,
+  `DynamicStringList`, `ChildList`, `ComponentId`, `FunctionCall`.
+- `server_to_client.json` — the envelope (top-level `oneOf` over the four
+  message types).
+- `basic_catalog.json` — unified components + functions + theme.
+
+The envelope references the catalog via a relative `catalog.json` placeholder
+(`$ref: "catalog.json#/$defs/anyComponent"`), so validators can alias it to
+`basic_catalog.json` or any custom catalog without modifying the envelope.
+
+### Strict message typing
+
+v0.8.1 relied on `minProperties: 1` over optional keys. v0.9 uses a
+top-level `oneOf` constraint — natural for both LLMs and human readers.
+
+### Auxiliary rules file
+
+v0.9 ships a new artifact: `basic_catalog_rules.txt`, a plain-text prompt
+fragment for rules that are awkward to express in JSON Schema (e.g.,
+"`Button` MUST provide `action`"). Designed to be appended to the system
+prompt alongside the catalog.
+
+## Protocol lifecycle changes
+
+### `beginRendering` → `createSurface`
+
+v0.8.1: `beginRendering` was a render-now signal carrying `root` and
+optional `styles`.
+
+v0.9: `createSurface` creates the surface. The render trigger is no longer
+explicit — clients render as soon as a valid tree with id `root` exists.
+`createSurface` carries `theme` (instead of `styles`) and requires
+`catalogId`.
+
+v0.8.1 example → v0.9 equivalent:
+
+```json
+// v0.8.1
+{ "beginRendering": { "surfaceId": "card", "root": "root",
+                      "styles": { "primaryColor": "#007bff" } } }
+
+// v0.9
+{ "version": "v0.9",
+  "createSurface": { "surfaceId": "card",
+                     "catalogId": "https://a2ui.org/specification/v0_9/basic_catalog.json",
+                     "theme": { "primaryColor": "#007bff" } } }
+```
+
+## Message-structure comparison
+
+### Component updates
+
+v0.8.1 wrapped components by type name:
+
+```json
+{ "id": "title", "component": { "Text": { "text": { "literalString": "Hello" } } } }
+```
+
+v0.9 flattens with a discriminator:
+
+```json
+{ "id": "title", "component": "Text", "text": "Hello" }
+```
+
+LLMs generate the v0.9 form far more consistently. It also simplifies
+polymorphism for JSON parsers in static languages.
+
+### Data model updates
+
+v0.8.1 adjacency-list array:
+
+```json
+"contents": [{ "key": "name", "valueString": "Alice" }]
+```
+
+v0.9 standard JSON at `path` with upsert semantics (omitted `value` removes
+the key; arrays preserve length when an index is cleared):
+
+```json
+{ "updateDataModel": { "surfaceId": "s1", "path": "/user",
+                       "value": { "name": "Alice" } } }
+```
+
+## Data binding & state
+
+### Unified `path`
+
+v0.8.1 used `dataBinding` inside `childrenProperty` templates and `path`
+inside `BoundValue` — inconsistent. v0.9 uses `path` everywhere. Same word,
+same meaning: JSON Pointer to data.
+
+### Implicit typing
+
+v0.8.1: `{ "text": { "literalString": "Hello" } }` or
+`{ "text": { "path": "/msg" } }` — explicit wrapper required even for
+literals.
+
+v0.9: `{ "text": "Hello" }` and `{ "value": { "path": "/msg" } }` both
+valid. `DynamicString`/`DynamicNumber`/`DynamicBoolean` in
+`common_types.json` accept either a literal of the right primitive type or
+a path/function call.
+
+### String interpolation: `formatString`
+
+v0.8.1 had no native interpolation — combining static text with bound
+values required custom logic or pre-concatenation on the server.
+
+v0.9 introduces `formatString`:
+
+```json
+{ "call": "formatString",
+  "args": { "value": "Hello, ${/user/firstName}! It is ${formatDate(value: ${/now}, format: 'yyyy-MM-dd')}" } }
+```
+
+Important constraint: `${...}` interpolation works **only** inside
+`formatString`, not in arbitrary string properties. This keeps the wire
+format unambiguous.
+
+### Explicit client → server data sync
+
+v0.8.1 had no first-class way to send the data model back. v0.9
+introduces the `sendDataModel: true` flag on `createSurface`; when set,
+the client attaches the surface's full data model to every outbound
+message's transport metadata.
+
+## Component-specific changes
+
+| Component | v0.8.1 | v0.9 |
+| :--- | :--- | :--- |
+| Button | `context: [{key, value}]`, `primary: true` | `context: { ... }`, `variant: "primary" \| "borderless"` |
+| TextField | `textFieldType`, `validationRegexp`, prop `text` | `variant`, `checks: [...]`, prop `value` |
+| MultipleChoice → ChoicePicker | `MultipleChoice`, `selections`, `maxAllowedSelections` | `ChoicePicker`, `value` (array), `variant: "multipleSelection" \| "mutuallyExclusive"` |
+| Slider | `minValue`, `maxValue` | `min`, `max` |
+
+## Error handling
+
+v0.9 introduces the strict `VALIDATION_FAILED` format in `client_to_server.json`:
+
+```json
+{
+  "error": {
+    "code": "VALIDATION_FAILED",
+    "surfaceId": "...",
+    "path": "/components/0/text",
+    "message": "Expected string, got number"
+  }
+}
+```
+
+This is the feedback half of the prompt-first loop — the LLM sees a
+machine-readable description of what went wrong and can self-correct on the
+next turn.
+
+## Property-rename quick reference
+
+| Component | Old name (v0.8.1) | New name (v0.9) |
+| :--- | :--- | :--- |
+| Row / Column | `distribution` | `justify` |
+| Row / Column | `alignment` | `align` |
+| Modal | `entryPointChild` | `trigger` |
+| Modal | `contentChild` | `content` |
+| Tabs | `tabItems` | `tabs` |
+| TextField | `text` | `value` |
+| many | `usageHint` | `variant` |
+| client→server | `userAction` | `action` |
+| common type | `childrenProperty` | `ChildList` |
+
+## Migration checklist
+
+1. **Update the extension URI** in Agent Cards from
+   `.../a2a-extension/a2ui/v0.8` to `.../a2a-extension/a2ui/v0.9`.
+2. **Update message names**: `surfaceUpdate` → `updateComponents`,
+   `dataModelUpdate` → `updateDataModel`, `beginRendering` →
+   `createSurface` (set `catalogId` explicitly; move `styles` → `theme`).
+3. **Flatten components** — `{ "Text": { ... } }` → `{ "component": "Text", ... }`.
+4. **Convert data model updates** to standard JSON objects at `path`.
+5. **Convert bound values** — drop `{ "literalString": "x" }` for plain
+   `"x"` where the field accepts `DynamicString`; keep `{ "path": "/foo" }`
+   as is.
+6. **Switch button context** from key-value array to a JSON object.
+7. **Rename component properties** per the table above.
+8. **Wrap A2A `DataPart.data` in a list** (it was a single object in v0.8).
+9. **Implement the validation loop** — when validation fails, return the
+   `VALIDATION_FAILED` error format and prompt the LLM to retry.
+
+---
+
+Source: `submodules/A2UI/specification/v0_9/docs/evolution_guide.md`.

--- a/.agents/skills/a2ui-knowledge/references/v0.9/protocol.md
+++ b/.agents/skills/a2ui-knowledge/references/v0.9/protocol.md
@@ -1,0 +1,527 @@
+# A2UI v0.9 Protocol Reference
+
+A2UI v0.9 is the **current, feature-complete** release of the protocol. It is
+a "prompt-first" redesign of v0.8: the schema is meant to be embedded directly
+in an LLM's system prompt rather than rely solely on structured-output / function
+calling. The trade-off is that the LLM is no longer strictly constrained by the
+schema, so robust post-generation validation and a "validate-then-correct" loop
+are mandatory parts of a real implementation.
+
+## Table of Contents
+
+- [Server-to-Client Message Types](#server-to-client-message-types)
+- [The Schema Layout](#the-schema-layout)
+- [Components and the Adjacency List Model](#components-and-the-adjacency-list-model)
+- [Actions](#actions)
+- [Data Model: Binding and Scope](#data-model-binding-and-scope)
+- [Two-Way Binding for Inputs](#two-way-binding-for-inputs)
+- [Data Synchronization (`sendDataModel`)](#data-synchronization-senddatamodel)
+- [Functions and Validation](#functions-and-validation)
+- [Basic Catalog](#basic-catalog)
+- [`formatString` String Interpolation](#formatstring-string-interpolation)
+- [Prompt → Generate → Validate Loop](#prompt--generate--validate-loop)
+- [Client-to-Server Messages](#client-to-server-messages)
+- [Capabilities (Server and Client)](#capabilities-server-and-client)
+- [Transport Decoupling](#transport-decoupling)
+- [Full Example Stream](#full-example-stream)
+
+## Server-to-Client Message Types
+
+Each top-level envelope contains **exactly one** of these four keys:
+
+| Message | Purpose |
+| :--- | :--- |
+| `createSurface` | Create a new surface, bind it to a catalog and theme, optionally turn on data-model sync |
+| `updateComponents` | Add or replace components in a surface (flat list, ID references) |
+| `updateDataModel` | Upsert (or remove) a value at a JSON-Pointer path |
+| `deleteSurface` | Remove a surface and all its state |
+
+A surface must exist before any `updateComponents` / `updateDataModel` is sent
+to it. `surfaceId` is fixed for the lifetime of the surface — to change
+`catalogId` or `theme`, delete and recreate. Sending `createSurface` for an
+already-active `surfaceId` is an error.
+
+### `createSurface`
+
+```json
+{
+  "version": "v0.9",
+  "createSurface": {
+    "surfaceId": "user_profile_card",
+    "catalogId": "https://a2ui.org/specification/v0_9/basic_catalog.json",
+    "theme": { "primaryColor": "#00BFFF" },
+    "sendDataModel": true
+  }
+}
+```
+
+- `surfaceId` (string, required) — unique within the session.
+- `catalogId` (string, required) — identifier of the catalog this surface
+  uses. Recommended pattern: a URI in a domain you own (e.g.
+  `https://mycompany.com/1.0/somecatalog`). The URI is purely an identifier;
+  no runtime fetch is performed.
+- `theme` (object, optional) — values for the catalog's theme schema.
+- `sendDataModel` (boolean, optional, default `false`) — if `true`, the client
+  attaches the full data model of this surface to the metadata of every
+  message it sends to the server.
+
+Exactly one component in the resulting tree must have id `root`.
+
+### `updateComponents`
+
+Flat list of components. Parents reference children by id. Components may
+arrive in any order, and may reference children that don't yet exist —
+clients should render progressively and fill in as definitions arrive.
+
+```json
+{
+  "version": "v0.9",
+  "updateComponents": {
+    "surfaceId": "user_profile_card",
+    "components": [
+      { "id": "root", "component": "Column", "children": ["user_name", "user_title"] },
+      { "id": "user_name", "component": "Text", "text": "John Doe" },
+      { "id": "user_title", "component": "Text", "text": "Software Engineer" }
+    ]
+  }
+}
+```
+
+If a re-emitted `id` has a **different** `component` type, the implementation
+must remove the old component and create a fresh one — so framework
+renderers reset their internal state.
+
+### `updateDataModel`
+
+Upserts at a JSON Pointer path. Omitting `value` removes the key. Omitting
+`path` (or setting it to `/`) replaces the whole model.
+
+```json
+{
+  "version": "v0.9",
+  "updateDataModel": {
+    "surfaceId": "user_profile_card",
+    "path": "/user/name",
+    "value": "Jane Doe"
+  }
+}
+```
+
+Arrays: omitted `value` at an index sets the slot to `undefined`, **preserving
+length** (sparse array).
+
+### `deleteSurface`
+
+```json
+{ "version": "v0.9", "deleteSurface": { "surfaceId": "user_profile_card" } }
+```
+
+Removes all components, data, and subscriptions for the surface.
+
+## The Schema Layout
+
+v0.9 splits the protocol into three interacting schemas:
+
+1. **`common_types.json`** — reusable primitives:
+   - `DynamicString` / `DynamicNumber` / `DynamicBoolean` / `DynamicStringList`
+     — any bindable value. Accepts a literal, a `path`, or a `FunctionCall`.
+   - `ChildList` — for container children. Either an `array` of `ComponentId`s
+     or an `object` with a template `{ componentId, path }`.
+   - `ComponentId` — a typed reference to another component within the surface.
+2. **`server_to_client.json`** — the envelope. Uses a top-level `oneOf` to
+   discriminate among the four message types. The envelope references the
+   catalog through a relative `catalog.json` placeholder
+   (`$ref: "catalog.json#/$defs/anyComponent"`).
+3. **`basic_catalog.json`** — the default catalog: components, functions,
+   theme schema. Custom catalogs follow the same shape and reuse the
+   `common_types.json` primitives.
+
+To validate a payload, alias `catalog.json` to whichever real catalog file
+applies (`basic_catalog.json` or `my_company_catalog.json`). That indirection
+is what makes catalogs swappable without modifying the envelope.
+
+### Validator-compliance rules for custom catalogs
+
+To let automated validators verify the component tree, custom catalogs MUST
+use the typed primitives:
+
+- Any property that holds the id of another component MUST use
+  `$ref: "common_types.json#/$defs/ComponentId"` — not raw `"type": "string"`.
+- Any list of children or template MUST use
+  `$ref: "common_types.json#/$defs/ChildList"`.
+
+Using raw `string` for an id makes the validator treat it as static text and
+silently miss broken references.
+
+## Components and the Adjacency List Model
+
+A component object looks like:
+
+```json
+{
+  "id": "user_name",       // ComponentId, required
+  "component": "Text",     // discriminator, required
+  "text": "John Doe"       // type-specific properties inline
+}
+```
+
+Properties live **inline** on the same object, keyed by the catalog. The
+discriminator approach (`"component": "Text"`) is the v0.9 successor to v0.8's
+`{ "Text": { ... } }` wrapper — much easier for LLMs to emit consistently.
+
+### Adjacency list
+
+The UI is a flat list, parents reference children by id. The client stores
+all components in a `Map<id, Component>` and builds the tree at render time.
+This:
+
+- lets the server stream components in any order,
+- allows progressive rendering as soon as `root` is defined,
+- means components may transiently reference children or data paths that
+  don't exist yet — renderers must handle `undefined` gracefully (placeholder
+  or loading state).
+
+The tree must contain exactly **one** component with id `root`. Until `root`
+exists, other component updates are buffered and have no visible effect.
+
+### Containers with `ChildList`
+
+Containers (`Row`, `Column`, `List`, …) define children either as:
+
+- a static array of ids: `"children": ["a", "b", "c"]`, or
+- a template that iterates over a data path:
+
+  ```json
+  {
+    "id": "employee_list",
+    "component": "List",
+    "children": { "path": "/employees", "componentId": "employee_card_template" }
+  }
+  ```
+
+When the container iterates a bound array, each instantiated child runs in a
+**child scope** rooted at `/employees/N`.
+
+## Actions
+
+Interactive components use an `action` object. There are two flavors:
+
+### Server action — emits an event over the transport
+
+```json
+{
+  "component": "Button",
+  "text": "Submit",
+  "action": {
+    "event": {
+      "name": "submit_form",
+      "context": { "itemId": "123" }
+    }
+  }
+}
+```
+
+`context` is a standard JSON object (in v0.8 it was an array of key-value
+pairs). Values can be literals, `{ "path": "..." }`, or function calls.
+
+### Local action — executes a client-side function
+
+```json
+{
+  "component": "Button",
+  "text": "Open Link",
+  "action": {
+    "functionCall": {
+      "call": "openUrl",
+      "args": { "url": "${/url}" }
+    }
+  }
+}
+```
+
+## Data Model: Binding and Scope
+
+Bindings use JSON Pointer ([RFC 6901]) with one v0.9 extension: **relative
+paths** that don't start with `/`.
+
+### Root scope
+
+By default a component is in the root scope:
+
+- A path starting with `/` (e.g. `/user/profile/name`) is **absolute** and
+  resolves from the data model root.
+
+### Collection scope (relative paths)
+
+When a container uses a template (`ChildList` with a bound `path`), a new
+**child scope** is created per item. Inside that scope:
+
+- a path **without** a leading `/` is **relative** and resolves against the
+  current item: `firstName` becomes `/users/0/firstName`, `/users/1/firstName`,
+  etc.
+- a path **with** a leading `/` still escapes to root scope.
+
+Example:
+
+```jsonc
+// Data model: { "company": "Acme Corp", "employees": [{...}, {...}] }
+{ "id": "name_text",    "component": "Text", "text": { "path": "name" } }       // /employees/N/name
+{ "id": "company_text", "component": "Text", "text": { "path": "/company" } }   // "Acme Corp"
+```
+
+### Type coercion
+
+When a non-string value is interpolated, the client converts to string:
+
+| Input | Result |
+| :--- | :--- |
+| number / boolean | standard string representation |
+| `null` / `undefined` | `""` (empty string) |
+| object / array | JSON-stringified |
+
+## Two-Way Binding for Inputs
+
+`TextField`, `CheckBox`, `Slider`, `ChoicePicker`, `DateTimeInput` establish
+two-way bindings.
+
+- **Read (model → view)**: component initial value comes from the bound path;
+  the component re-renders on `updateDataModel`.
+- **Write (view → model)**: user input writes **immediately** to the local
+  data model at the bound path.
+
+Two-way binding is **local to the client** — keystrokes don't trigger network
+requests on their own. The server sees the new state only when a `Button`
+(or other action source) fires and the `action.context` references the
+modified path. (Or, if the surface was created with `sendDataModel: true`,
+the full data model is attached automatically.)
+
+## Data Synchronization (`sendDataModel`)
+
+When a surface is created with `sendDataModel: true`, the client attaches
+the surface's **entire** data model to the metadata of every message it
+sends back to the server, following [`client_data_model.json`]
+(`a2uiClientDataModel`).
+
+Properties:
+
+- **Targeted** — only sent to the server that created the surface.
+- **Triggered** — only sent alongside a real client-to-server message
+  (e.g. an action). Passive edits don't generate traffic.
+- **Convergence** — the server treats the received model as the latest
+  client state at the moment of the action.
+
+## Functions and Validation
+
+Functions are referenced by name via a `FunctionCall` object. They are
+defined in the active catalog (so the schema can validate calls and the
+LLM sees what's available); they are **not** executable code on the wire.
+
+Validation `checks` on input components and buttons:
+
+```json
+"checks": [
+  { "call": "required",
+    "args": { "value": { "path": "/formData/zip" } },
+    "message": "Zip code is required" },
+  { "call": "regex",
+    "args": { "value": { "path": "/formData/zip" }, "pattern": "^[0-9]{5}$" },
+    "message": "Must be a 5-digit zip code" }
+]
+```
+
+Failing checks surface the `message` and reactively disable the action
+(e.g. the button becomes inert until all checks pass). Conditional logic
+nests freely:
+
+```json
+{
+  "component": "Button",
+  "text": "Submit",
+  "checks": [{
+    "condition": {
+      "call": "and",
+      "args": { "values": [
+        { "call": "required", "args": { "value": { "path": "/formData/terms" } } },
+        { "call": "or", "args": { "values": [
+          { "call": "required", "args": { "value": { "path": "/formData/email" } } },
+          { "call": "required", "args": { "value": { "path": "/formData/phone" } } }
+        ] } }
+      ] }
+    },
+    "message": "You must accept terms AND provide either email or phone"
+  }]
+}
+```
+
+## Basic Catalog
+
+[`basic_catalog.json`] provides the reference set. See `basic-catalog-guide.md`
+for rendering guidelines per component.
+
+### Components (18)
+
+`Text`, `Image`, `Icon`, `Video`, `AudioPlayer`, `Row`, `Column`, `List`,
+`Card`, `Tabs`, `Divider`, `Modal`, `Button`, `CheckBox`, `TextField`,
+`DateTimeInput`, `ChoicePicker`, `Slider`.
+
+### Functions (14)
+
+- **Validation**: `required`, `regex`, `length`, `numeric`, `email`
+- **Formatting**: `formatString`, `formatNumber`, `formatCurrency`,
+  `formatDate`, `pluralize`
+- **Logic**: `and`, `or`, `not`
+- **Effects**: `openUrl`
+
+### Theme
+
+| Property | Type | Use |
+| :--- | :--- | :--- |
+| `primaryColor` | hex string (`#00BFFF`) | Brand highlight |
+| `iconUrl` | URI | Agent/tool avatar shown next to the surface |
+| `agentDisplayName` | string | Text identity shown next to the surface |
+
+In multi-agent systems an orchestrator should set/verify `iconUrl` and
+`agentDisplayName` so malicious sub-agents can't spoof a trusted identity.
+
+## `formatString` String Interpolation
+
+String interpolation works **only** inside the `formatString` function — the
+spec deliberately prevents generic `${...}` in arbitrary string properties.
+
+```json
+{
+  "id": "user_welcome",
+  "component": "Text",
+  "text": {
+    "call": "formatString",
+    "args": { "value": "Hello, ${/user/firstName}! Welcome back to ${/appName}." }
+  }
+}
+```
+
+Syntax:
+
+- `${/absolute/path}` — absolute data binding.
+- `${relative/path}` — relative (in a template scope).
+- `${funcName(arg: value, arg2: ${/nested})}` — nested function calls /
+  bindings; nest `${...}` deeper to keep tokenization unambiguous.
+- `\${literal}` — escape a literal `${`.
+
+## Prompt → Generate → Validate Loop
+
+The intended runtime pattern:
+
+1. **Prompt** — include the desired UI request, the A2UI envelope schema,
+   the catalog schema, and examples.
+2. **Generate** — receive raw JSON from the LLM.
+3. **Validate** — schema-check against the resolved envelope + catalog. If
+   invalid, return a structured `VALIDATION_FAILED` error so the LLM can
+   self-correct on the next turn:
+
+```json
+{
+  "error": {
+    "code": "VALIDATION_FAILED",
+    "surfaceId": "user_profile_card",
+    "path": "/components/0/text",
+    "message": "Expected stringOrPath, got integer"
+  }
+}
+```
+
+This loop is the whole point of the prompt-first redesign — the schema
+provides the discipline that structured-output mode would have otherwise.
+
+## Client-to-Server Messages
+
+Defined in [`client_to_server.json`].
+
+### `action`
+
+```json
+{
+  "version": "v0.9",
+  "action": {
+    "name": "submit_form",
+    "surfaceId": "contact_form_1",
+    "sourceComponentId": "submit_button",
+    "timestamp": "2026-01-15T12:00:00Z",
+    "context": { "email": "user@example.com" }
+  }
+}
+```
+
+### `error`
+
+Used to report client-side validation/runtime failures (see the
+`VALIDATION_FAILED` format above).
+
+## Capabilities (Server and Client)
+
+v0.9 moves capabilities to **transport metadata** (no first-class A2UI
+message for them).
+
+### Server capabilities ([`server_capabilities.json`])
+
+Declared via the transport's identity mechanism — A2A AgentCard params,
+MCP server capabilities, etc. Lists `supportedCatalogIds` and
+`acceptsInlineCatalogs`.
+
+### Client capabilities ([`client_capabilities.json`])
+
+`a2uiClientCapabilities` lives in the metadata of every client-to-server
+message:
+
+- `supportedCatalogIds` (string[], required) — IDs of catalogs the client
+  ships with.
+- `inlineCatalogs` (array, optional) — fully-defined catalogs supplied at
+  runtime. Useful for local dev; not recommended for production.
+
+### Client data model ([`client_data_model.json`])
+
+When any active surface has `sendDataModel: true`, the client includes
+`a2uiClientDataModel` (`{ surfaces: { <surfaceId>: <dataModel> } }`) in
+metadata alongside the action.
+
+## Transport Decoupling
+
+v0.9 is transport-agnostic. To carry A2UI, a transport must:
+
+1. **Deliver in order** — A2UI relies on stateful sequencing
+   (`createSurface` before `updateComponents` etc.).
+2. **Frame messages** — newline-delimited JSONL, WebSocket frames, SSE events.
+3. **Carry metadata** — for capabilities exchange and `sendDataModel`
+   payloads.
+4. **(Optional)** Provide a return channel for `action` messages.
+
+Common bindings: **A2A** (extension URI
+`https://a2ui.org/a2a-extension/a2ui/v0.9`), **AG-UI**, **MCP**, **SSE+JSON-RPC**,
+**WebSockets**, **REST** (no streaming). For A2A specifics see
+`a2a-extension.md`.
+
+## Full Example Stream
+
+JSONL stream rendering a contact form:
+
+```jsonl
+{"version": "v0.9", "createSurface":{"surfaceId":"contact_form_1","catalogId":"https://a2ui.org/specification/v0_9/basic_catalog.json"}}
+{"version": "v0.9", "updateComponents":{"surfaceId":"contact_form_1","components":[{"id":"root","component":"Card","child":"form_container"}, ...]}}
+{"version": "v0.9", "updateDataModel":{"surfaceId":"contact_form_1","path":"/contact","value":{"firstName":"John","lastName":"Doe","email":"john.doe@example.com"}}}
+{"version": "v0.9", "deleteSurface":{"surfaceId":"contact_form_1"}}
+```
+
+(See the upstream protocol doc for the complete contact-form stream with every
+component — it's roughly 30 components long and demonstrates `Card`, `Row`,
+`Column`, `TextField` with `checks`, `ChoicePicker`, `CheckBox`, `Button`
+with `action.event.context`, `formatDate` inside a context, and more.)
+
+[`basic_catalog.json`]: ../../../../submodules/A2UI/specification/v0_9/json/basic_catalog.json
+[`client_to_server.json`]: ../../../../submodules/A2UI/specification/v0_9/json/client_to_server.json
+[`server_capabilities.json`]: ../../../../submodules/A2UI/specification/v0_9/json/server_capabilities.json
+[`client_capabilities.json`]: ../../../../submodules/A2UI/specification/v0_9/json/client_capabilities.json
+[`client_data_model.json`]: ../../../../submodules/A2UI/specification/v0_9/json/client_data_model.json
+[RFC 6901]: https://datatracker.ietf.org/doc/html/rfc6901
+
+---
+
+Source: `submodules/A2UI/specification/v0_9/docs/a2ui_protocol.md`.

--- a/.agents/skills/a2ui-knowledge/references/v0.9/renderer-guide.md
+++ b/.agents/skills/a2ui-knowledge/references/v0.9/renderer-guide.md
@@ -1,0 +1,493 @@
+# A2UI v0.9 — Renderer Architecture Guide
+
+This reference covers how to build an A2UI client/renderer. The architecture
+separates a **framework-agnostic** data layer (JSON parsing, state, pointer
+resolution) from a **framework-specific** view layer (React nodes, Flutter
+widgets, iOS views), so the same core logic can serve many UI frameworks.
+
+## Table of Contents
+
+- [Architecture Overview](#architecture-overview)
+- [The Five Core Interfaces](#the-five-core-interfaces)
+- [Framework-Agnostic Layer (Data)](#framework-agnostic-layer-data)
+- [The Catalog & Functions API](#the-catalog--functions-api)
+- [Framework-Specific Layer (View)](#framework-specific-layer-view)
+- [Lifecycles, Subscriptions, and Memory](#lifecycles-subscriptions-and-memory)
+- [The Gallery App (Reference Tooling)](#the-gallery-app-reference-tooling)
+- [Step-by-Step Renderer Build Plan](#step-by-step-renderer-build-plan)
+
+## Architecture Overview
+
+Data flow:
+
+1. A2UI messages arrive from the server.
+2. The **`MessageProcessor`** parses each into a strongly-typed
+   `A2uiMessage` and mutates the **`SurfaceModel`** state.
+3. The **`Surface`** view (framework-specific) listens to the model and
+   begins rendering — starting at component id `root`.
+4. The `Surface` instantiates **`ComponentImplementation`** nodes
+   recursively to build the UI tree.
+
+The split:
+
+- **Framework-agnostic** — JSON parsing, schemas, JSON-pointer resolution,
+  state stores. Identical across UI frameworks in a given language.
+- **Framework-specific** — turning structured state into actual pixels.
+
+### Implementation topologies
+
+| Ecosystem | Approach |
+| :--- | :--- |
+| Dynamic langs (TS/JS) | Split into a `web_core` package (data + generic binder via reflection) and per-framework renderer packages (React, Angular, Vue, Lit). |
+| Static langs (Kotlin / Swift / Dart) | `<lang>_core` provides the data layer + **manually-implemented** binders for the Basic Catalog. Custom components either get codegen-generated binders or use a "binderless" direct-implementation flow. |
+| Single-framework langs (Swift + SwiftUI) | Often a single combined library. Keeping a Binder Layer is still recommended so adopters can swap individual component implementations without rewriting subscription/binding boilerplate. |
+
+## The Five Core Interfaces
+
+### `ComponentApi`
+
+Framework-agnostic contract — name + schema only, no rendering.
+
+```typescript
+interface ComponentApi {
+  readonly name: string;        // e.g. "Button"
+  readonly schema: Schema;      // technical definition for validation / capabilities
+}
+```
+
+### `ComponentImplementation`
+
+Framework-specific rendering logic, extends `ComponentApi`.
+
+Reactive frameworks (Flutter / SwiftUI / React):
+
+```typescript
+interface ComponentImplementation extends ComponentApi {
+  build(
+    ctx: ComponentContext<ComponentImplementation>,
+    buildChild: (id: string) => NativeWidget
+  ): NativeWidget;
+}
+```
+
+Stateful/imperative frameworks (Vanilla DOM / Android Views):
+
+```typescript
+interface ComponentInstance {
+  mount(container: NativeElement): void;
+  update(ctx: ComponentContext<ComponentImplementation>): void;
+  unmount(): void;
+}
+
+interface ComponentImplementation extends ComponentApi {
+  createInstance(ctx: ComponentContext<ComponentImplementation>): ComponentInstance;
+}
+```
+
+### `Surface`
+
+The framework entrypoint widget. Instantiated with a `SurfaceModel`, listens
+to lifecycle events, and recursively builds the UI starting at `root`.
+
+### `SurfaceModel` & `ComponentContext`
+
+- **`SurfaceModel`** — long-lived state of one surface: `dataModel`,
+  `componentsModel`, `catalog`, `theme`, `sendDataModel`, plus the `onAction`
+  event source.
+- **`ComponentContext`** — transient object created per render: pairs a
+  specific `ComponentModel` configuration with a scoped `DataContext`.
+
+## Framework-Agnostic Layer (Data)
+
+The data layer **does not vary** between UI frameworks. Port it once per
+language and reuse.
+
+### Prerequisites
+
+1. **Schema library** that can both express and emit standard JSON Schema
+   (Zod in TS, Pydantic in Python; `Codable` structs work as a last resort).
+2. **Observable library** providing:
+   - Event streams (publish/subscribe for discrete events).
+   - Stateful streams / signals (hold a value, notify on change, expose
+     `dispose()` for unsubscribe).
+
+### Design principles
+
+- **"Add" pattern** — separate construction from composition. Children are
+  built independently, then attached via `parent.addChild(child)`.
+- **Standard observer pattern** — every model exposes
+  subscribe/unsubscribe; multi-cast; payload-bearing; uniform across the
+  model classes.
+- **Granular reactivity** — structure changes via `SurfaceComponentsModel`;
+  property changes via `ComponentModel.onUpdated`; data changes only notify
+  subscribers of the specific path that changed.
+
+### Protocol models
+
+Don't pass raw `Map<String,Any>` into the state. Define strict native types
+(data classes, structs, Zod-validated interfaces) mirroring the JSON schemas:
+
+- `A2uiMessage` (union/protocol type) with `CreateSurfaceMessage`,
+  `UpdateComponentsMessage`, `UpdateDataModelMessage`, `DeleteSurfaceMessage`.
+- `ClientEvent` (union) with `ActionMessage`, `ErrorMessage`.
+- Metadata types: `A2uiClientCapabilities`, `InlineCatalog`,
+  `FunctionDefinition`, `ClientDataModel`.
+
+Inbound parsing must throw `A2uiValidationError` **before** the message
+reaches the state. Outbound stringifying serializes from the strict types
+into wire JSON.
+
+### State models
+
+- **`SurfaceGroupModel`** — root container for active surfaces.
+  `addSurface`, `deleteSurface`, `getSurface`. Exposes
+  `onSurfaceCreated`, `onSurfaceDeleted`, `onAction`.
+- **`SurfaceModel`** — one surface. Holds `catalog`, `dataModel`,
+  `componentsModel`, `theme`, `sendDataModel`. Has `dispatchAction(payload,
+  sourceComponentId)`.
+- **`SurfaceComponentsModel`** — flat `Map<id, ComponentModel>`. Notifies
+  on `onCreated` / `onDeleted`.
+- **`ComponentModel`** — id + type + mutable `properties`; notifies on
+  `onUpdated`.
+
+### `DataModel`
+
+```typescript
+class DataModel {
+  get(path: string): any;                        // JSON Pointer resolution
+  set(path: string, value: any): void;           // atomic update
+  subscribe<T>(path: string, onChange: (v: T | undefined) => void): Subscription<T>;
+  dispose(): void;
+}
+```
+
+Implementation rules:
+
+1. **JSON Pointer + relative paths** — A2UI extends RFC 6901 to allow paths
+   without a leading `/`; those resolve against the current evaluation
+   scope.
+2. **Auto-vivification** — when `set` at a nested path encounters a missing
+   intermediate, create it. If the next segment is numeric (e.g. `0`),
+   create an array; otherwise an object.
+3. **Bubble + cascade notification** — when a path changes, notify exact
+   subscribers, bubble up to all ancestor paths, and cascade down to all
+   descendant paths.
+4. **Undefined handling** — setting an object key to `undefined` removes
+   the key; setting an array index to `undefined` keeps length and empties
+   the slot (sparse array).
+
+Type coercion baseline:
+
+| Input | Target | Result |
+| :--- | :--- | :--- |
+| `"true"` / `"false"` (case-insensitive) | Boolean | true/false; any other string → false |
+| Non-zero Number | Boolean | true |
+| `0` | Boolean | false |
+| Anything | String | locale-neutral string repr |
+| `null`/`undefined` | String | `""` |
+| `null`/`undefined` | Number | `0` |
+| Numeric string | Number | parsed value (or `0`) |
+
+### Context layer
+
+Transient objects created on demand during rendering. Solves scope and
+binding resolution.
+
+```typescript
+class DataContext {
+  constructor(dataModel: DataModel, path: string);
+  readonly path: string;
+  set(path: string, value: unknown): void;
+  resolveDynamicValue<V>(v: DynamicValue): V;
+  subscribeDynamicValue<V>(v: DynamicValue, onChange: (v: V | undefined) => void): Subscription<V>;
+  nested(relativePath: string): DataContext;
+}
+
+class ComponentContext<T extends ComponentApi> {
+  constructor(surface: SurfaceModel<T>, componentId: string, basePath?: string);
+  readonly componentModel: ComponentModel;
+  readonly dataContext: DataContext;
+  readonly surfaceComponents: SurfaceComponentsModel;  // escape hatch
+  dispatchAction(action: Record<string, any>): Promise<void>;
+}
+```
+
+The escape hatch (`ctx.surfaceComponents`) lets a layout engine peek at
+siblings (e.g. a `Row` checking each child's `weight`). Use sparingly.
+
+### `MessageProcessor`
+
+The "controller." Accepts validated `A2uiMessage`s, mutates models, and
+aggregates client state for sync.
+
+```typescript
+class MessageProcessor<T extends ComponentApi> {
+  readonly model: SurfaceGroupModel<T>;
+  constructor(catalogs: Catalog<T>[], actionHandler: ActionListener);
+  processMessages(messages: A2uiMessage[]): void;
+  addLifecycleListener(l: SurfaceLifecycleListener<T>): () => void;
+  getClientCapabilities(options?: CapabilitiesOptions): A2uiClientCapabilities;
+  getClientDataModel(): A2uiClientDataModel | undefined;
+}
+```
+
+Surface/component lifecycle rules the processor must enforce:
+
+- **`createSurface` for an already-active `surfaceId` is an error** — throw
+  or report `VALIDATION_FAILED`.
+- **`updateComponents` reusing an `id` with a different `type`** — remove
+  the old `ComponentModel` and create a fresh one, so framework renderers
+  reset internal state.
+
+### Client capabilities / inline catalog generation
+
+`getClientCapabilities()` returns the wire payload. To emit `inlineCatalogs`
+the processor converts internal schemas to standard JSON Schema. Common types
+(like `DynamicString`) must surface as external `$ref`s. The reference
+implementation uses a tagged-description convention:
+`REF:common_types.json#/$defs/DynamicString` — the processor strips the tag
+and replaces the node with a `$ref` object during emission.
+
+### `sendDataModel` flow
+
+When a surface is created with `sendDataModel: true`:
+
+1. `MessageProcessor` tracks the flag per surface.
+2. `getClientDataModel()` iterates active surfaces and returns
+   `{ surfaces: { <surfaceId>: <dataModel> } }` for those with the flag.
+3. The transport layer calls `getClientDataModel()` **before** sending each
+   outbound message.
+4. If non-empty, the payload is attached as transport metadata (A2A:
+   `a2uiClientDataModel` field).
+
+## The Catalog & Functions API
+
+```typescript
+interface FunctionApi {
+  readonly name: string;
+  readonly returnType: 'string' | 'number' | 'boolean' | 'array' | 'object' | 'any' | 'void';
+  readonly schema: Schema;
+}
+
+interface FunctionImplementation extends FunctionApi {
+  execute(args: Record<string, any>, context: DataContext): unknown | Observable<unknown>;
+}
+
+class Catalog<T extends ComponentApi> {
+  readonly id: string;
+  readonly components: ReadonlyMap<string, T>;
+  readonly functions?: ReadonlyMap<string, FunctionImplementation>;
+  readonly themeSchema?: Schema;
+}
+```
+
+Function patterns:
+
+- **Pure logic** (e.g. `add`, `concat`) — synchronous, returns a static
+  value.
+- **External state** (e.g. `clock()`, `networkStatus()`) — returns a
+  long-lived reactive stream that pushes updates independently of data
+  changes.
+- **Effect functions** (e.g. `openUrl`, `closeModal`) — return `void`;
+  triggered by user actions, not interpolation.
+
+Reactive functions MUST use a listening mechanism that supports
+unsubscription. To play nicely with capability generation, every function
+SHOULD include a schema.
+
+### Composing custom catalogs
+
+Catalogs compose. You can mix Basic Catalog elements with your own:
+
+```python
+myCustomCatalog = Catalog(
+  id="https://mycompany.com/catalogs/custom_catalog.json",
+  functions=basicCatalog.functions,
+  components=basicCatalog.components + [MyCompanyLogoComponent()],
+  themeSchema=basicCatalog.themeSchema  # inherit theme schema
+)
+```
+
+## Framework-Specific Layer (View)
+
+Three strategies for connecting a `ComponentImplementation` to the reactive
+data model.
+
+### Strategy 1 — Direct / Binderless
+
+The component manually observes streams inside its `build` method, using
+the framework's native reactive tools.
+
+```dart
+// Flutter binderless example
+Widget build(ComponentContext context, ChildBuilderCallback buildChild) {
+  return StreamBuilder(
+    stream: context.dataContext.observeDynamicValue(
+      context.componentModel.properties['label']
+    ),
+    builder: (_, snap) => ElevatedButton(
+      onPressed: () => context.dispatchAction(context.componentModel.properties['action']),
+      child: Text(snap.data?.toString() ?? ''),
+    ),
+  );
+}
+```
+
+Simple but scatters A2UI subscription code across every component.
+
+### Strategy 2 — Binder Layer
+
+An intermediate abstraction. The Binder reads raw `properties` and emits a
+single stream of fully-typed `ResolvedProps`. Views subscribe to that
+stream.
+
+```typescript
+interface ComponentBinding<ResolvedProps> {
+  readonly propsStream: StatefulStream<ResolvedProps>;
+  dispose(): void;
+}
+
+interface ComponentBinder<ResolvedProps> {
+  readonly schema: Schema;
+  bind(context: ComponentContext<any>): ComponentBinding<ResolvedProps>;
+}
+```
+
+### Strategy 3 — Generic Binders (dynamic languages)
+
+With runtime reflection (TS/Zod, Python/Pydantic), you can write **one**
+generic factory that inspects a component's schema and auto-creates the
+binder — inferring strict prop types.
+
+```typescript
+// Inferred prop type from ButtonSchema:
+interface ButtonResolvedProps {
+  label?: string;
+  action: () => void;
+  child?: string;
+}
+
+const ReactButton = createReactComponent(ButtonBinder, ({ props, buildChild }) => (
+  <button onClick={props.action}>
+    {props.child ? buildChild(props.child) : props.label}
+  </button>
+));
+```
+
+Type errors (e.g. typoing `props.action` as `props.onClick`) get caught at
+compile time.
+
+### Framework adapter sketches
+
+**React** — `useEffect` to call `binder.bind(context)` on mount,
+`useState` to track `propsStream`, return cleanup that calls
+`binding.dispose()` on unmount.
+
+**Angular** — `resource()` plus `toSignal(binding.propsStream)`; use
+`inject(DestroyRef).onDestroy(...)` to dispose.
+
+### Data props vs structural props
+
+- **Data props** (`label`, `value`) — the binder resolves them and emits
+  a new props object reference whenever any value changes (so declarative
+  frameworks with strict equality detect the change).
+- **Structural props** (`child`, `children`) — the binder **does not**
+  resolve them into UI trees. It emits child *descriptors*:
+  - `ComponentId` → `{ id, basePath }`.
+  - `ChildList` with a template → an iterated list of `ChildNode` streams,
+    each carrying the right `basePath` (via
+    `context.dataContext.nested(/users/0)` and so on).
+- The framework adapter recursively calls `buildChild(id, basePath)` for
+  each descriptor.
+
+**Critical**: the recursive `buildChild` helper must inherit the **current**
+component's data-context path by default, so nested components using
+relative paths resolve against the right scope. Forgetting this is the most
+common cause of "empty" data in list templates.
+
+## Lifecycles, Subscriptions, and Memory
+
+Ownership contract:
+
+- **Data layer (MessageProcessor) owns `ComponentModel`** — created,
+  updated, destroyed in response to incoming messages.
+- **Framework adapter owns `ComponentContext` and `ComponentBinding`** —
+  creates them on mount, must call `binding.dispose()` on unmount.
+
+Subscription rules:
+
+1. **Lazy subscription** — bind only when the component is actually
+   mounted.
+2. **Path stability** — when a property changes path,
+   **unsubscribe from the old path before subscribing to the new one**.
+3. **Cleanup** — when a component leaves the UI (`deleteSurface` or
+   parent unmounted), hook the native unmount callback to dispose all
+   subscriptions.
+
+### Reactive validation (`Checkable` trait)
+
+For components with `checks` (`TextField`, `Button`, …):
+
+- Subscribe to each `CheckRule.condition`.
+- Reactively render the `message` of the first failing check.
+- For action sources (`Button`), reactively disable/block the action when
+  any check fails.
+
+## The Gallery App (Reference Tooling)
+
+The Gallery App is the recommended integration-test harness. Three-column
+layout:
+
+1. **Left** — list of sample stream files.
+2. **Center** — surface preview + the raw JSON message list + an "Advance"
+   stepper that processes one message at a time (so you can verify
+   progressive rendering).
+3. **Right** — live data-model view + action log.
+
+Integration tests should at minimum cover: static rendering, layout
+integrity, two-way binding (typing into a `TextField` reflects in the data
+model viewer), reactive logic (changes in one component update dependents),
+and action context scoping (actions emitted from inside list templates
+carry correctly resolved paths).
+
+## Step-by-Step Renderer Build Plan
+
+If you're building a new renderer from scratch, the spec recommends this
+sequence:
+
+1. **Ingest context** — read
+   `specification/v0_9/docs/a2ui_protocol.md`,
+   `specification/v0_9/json/common_types.json`,
+   `specification/v0_9/json/server_to_client.json`,
+   `specification/v0_9/json/catalogs/minimal/minimal_catalog.json`,
+   `specification/v0_9/docs/basic_catalog_implementation_guide.md`.
+2. **Write a design doc** — pick the schema library, reactive library
+   (must support both event streams and stateful signals), component
+   architecture, surface architecture, and binding strategy. **Pause for
+   approval.**
+3. **Core model layer** — implement event streams, signals, strict
+   protocol models with JSON validation, `DataModel` (with pointer
+   resolution and cascade/bubble), `ComponentModel`,
+   `SurfaceComponentsModel`, `SurfaceModel`, `SurfaceGroupModel`,
+   `DataContext`, `ComponentContext`, and `MessageProcessor` (plus
+   capabilities generation). Unit-test everything.
+4. **Framework layer** — define the concrete `ComponentImplementation`
+   base, the `Surface` view that recurses through children, and the
+   subscription lifecycle.
+5. **Minimal catalog support** — target
+   `specification/v0_9/json/catalogs/minimal/minimal_catalog.json` first.
+   Implement `Text`, `Row`, `Column`, `Button`, `TextField`, and the
+   `capitalize` function.
+6. **Gallery app** — build the three-column tool against the minimal
+   catalog examples. Verify progressive rendering and reactivity. **Pause
+   for approval.**
+7. **Basic Catalog support** — implement the rest of `basic_catalog.json`
+   per `basic-catalog-guide.md`. Remember:
+   **string interpolation belongs only inside `formatString`** — do **not**
+   apply it to all strings.
+
+Reference TS implementation: `renderers/web_core/`.
+
+---
+
+Source: `submodules/A2UI/specification/v0_9/docs/renderer_guide.md`.

--- a/.agents/skills/a2ui-knowledge/references/v1.0/a2a-extension.md
+++ b/.agents/skills/a2ui-knowledge/references/v1.0/a2a-extension.md
@@ -1,0 +1,161 @@
+# A2UI v1.0 — A2A Extension
+
+How A2UI v1.0 is advertised and transported over the A2A (Agent-to-Agent)
+protocol. The shape matches v0.9 / v0.9.1: a per-version URI, a `data` field
+carrying a **list** of messages, and capabilities referencing the
+`server_capabilities.json` / `client_capabilities.json` schemas. The MIME type
+is the standardized `application/a2ui+json`.
+
+## Extension URI
+
+```text
+https://a2ui.org/a2a-extension/a2ui/v1.0
+```
+
+This is the only URI accepted for the v1.0 extension.
+
+## Core concepts
+
+- **Surfaces** — independently controllable UI regions identified by
+  `surfaceId`. A single agent can manage many in parallel.
+- **Catalog Definition Document** — components, functions, and the
+  `surfaceProperties` schema live in a catalog the client and server agree on
+  per session.
+- **Capabilities exchange** — agents advertise capabilities via Agent Card
+  `params` (matching `server_capabilities.json`); clients reply via
+  `a2uiClientCapabilities` in message metadata (matching
+  `client_capabilities.json`).
+
+Primary schemas backing the extension:
+
+| Schema | Purpose |
+| :--- | :--- |
+| Catalog Definition | A library of components, functions, and a `surfaceProperties` schema |
+| Server-to-Client Message List | Wire format for `createSurface`, `updateComponents`, `updateDataModel`, `deleteSurface`, `callFunction`, `actionResponse` |
+| Client-to-Server Message List | Wire format for `action`, `functionResponse`, `error` |
+| Server Capabilities | `a2uiServerCapabilities` (UI generation capabilities) |
+| Client Capabilities | `a2uiClientCapabilities` (supported catalogs + inline catalogs) |
+
+## Agent Card declaration
+
+Inside `AgentCapabilities.extensions`:
+
+```json
+{
+  "uri": "https://a2ui.org/a2a-extension/a2ui/v1.0",
+  "description": "Ability to render A2UI v1.0",
+  "required": false,
+  "params": {
+    "supportedCatalogIds": [
+      "https://a2ui.org/specification/v1_0/catalogs/basic/catalog.json",
+      "https://my-company.com/a2ui/v0_1/my_custom_catalog.json"
+    ],
+    "acceptsInlineCatalogs": true
+  }
+}
+```
+
+### Parameters
+
+| Param | Type | Required | Meaning |
+| :--- | :--- | :--- | :--- |
+| `supportedCatalogIds` | `string[]` | optional | IDs of catalogs the agent can generate UI for. Not necessarily resolvable URIs — just stable identifiers. |
+| `acceptsInlineCatalogs` | `boolean` | optional, default `false` | Whether the agent can use catalogs the client supplies at runtime via `a2uiClientCapabilities.inlineCatalogs`. |
+
+The `params` object corresponds directly to the `v1.0` object in
+`server_capabilities.json`.
+
+## Extension activation
+
+Clients activate the extension via the standard A2A activation mechanism:
+
+- **JSON-RPC / HTTP**: `X-A2A-Extensions` HTTP header.
+- **gRPC**: `X-A2A-Extensions` metadata value.
+
+Activating the extension means the agent may emit A2UI server messages (e.g.
+`createSurface`, `callFunction`) and the client is expected to send A2UI client
+messages (e.g. `action`, `functionResponse`) back.
+
+## Data encoding — list semantics
+
+A2UI v1.0 messages travel as an A2A `DataPart`:
+
+- `metadata.mimeType` = `application/a2ui+json`
+- `data` is an **array of A2UI messages**, not a single message.
+
+```json
+{
+  "data": [
+    {
+      "version": "v1.0",
+      "createSurface": {
+        "surfaceId": "example_surface",
+        "catalogId": "https://a2ui.org/specification/v1_0/catalogs/basic/catalog.json"
+      }
+    },
+    {
+      "version": "v1.0",
+      "updateComponents": {
+        "surfaceId": "example_surface",
+        "components": [{ "component": "Text", "id": "root", "text": "Hello!" }]
+      }
+    }
+  ],
+  "kind": "data",
+  "metadata": { "mimeType": "application/a2ui+json" }
+}
+```
+
+### Processing rules
+
+The message list is **not transactional**. Receivers (both clients and
+agents) must:
+
+- process messages **sequentially**,
+- if any individual message fails to validate or apply, log/report the error
+  for that message but **continue** processing the rest,
+- treat atomicity as a per-message property only.
+
+However, **renderers should not repaint until the whole list is processed** —
+that avoids flashing intermediate states across a batch update.
+
+## Client-to-server events
+
+The same DataPart format, but `data` validates against the Client-to-Server
+Message List Schema (`client_to_server.json`):
+
+```json
+{
+  "data": [{
+    "version": "v1.0",
+    "action": {
+      "name": "submit_form",
+      "surfaceId": "contact_form_1",
+      "sourceComponentId": "submit_button",
+      "timestamp": "2026-01-15T12:00:00Z",
+      "context": { "email": "user@example.com" }
+    }
+  }],
+  "kind": "data",
+  "metadata": { "mimeType": "application/a2ui+json" }
+}
+```
+
+## Metadata fields
+
+Two A2UI-defined objects ride in A2A `Message.metadata`:
+
+| Field | Schema | When |
+| :--- | :--- | :--- |
+| `a2uiClientCapabilities` | `client_capabilities.json` | every client → server message |
+| `a2uiClientDataModel` | `client_data_model.json` | client → server, when an active surface was created with `sendDataModel: true` |
+
+## Context mapping
+
+A2UI sessions typically map to an A2A `contextId`. Messages for a set of
+related surfaces should share the same `contextId`.
+
+---
+
+Source: `specification/v1_0/docs/a2ui_extension_specification.md` in
+`a2ui-project/a2ui`.

--- a/.agents/skills/a2ui-knowledge/references/v1.0/basic-catalog-guide.md
+++ b/.agents/skills/a2ui-knowledge/references/v1.0/basic-catalog-guide.md
@@ -1,0 +1,204 @@
+# A2UI v1.0 — Basic Catalog Implementation Guide
+
+Per-component implementation reference for renderer / client developers
+targeting the v1.0 Basic Catalog. Use it when wiring framework adapters
+(Layer 3 in `renderer-guide.md`) over the generic A2UI bindings. The
+per-component behavior is the same as v0.9; this guide highlights the v1.0
+deltas inline.
+
+## What Changed from v0.9
+
+- **`Video.posterUrl`** — preview image shown before playback.
+- **`TextField.placeholder`** — placeholder text for the input.
+- **`Slider.steps`** — integer (≥1) number of discrete divisions; the slider
+  snaps to discrete values when set.
+- **Custom SVG `Icon`** — the icon override object property `svgPath` was
+  renamed to **`path`** (`{ "name": { "path": "M3 12 …" } }`).
+- **`surfaceProperties`** replaces the catalog `theme`; `primaryColor` is gone.
+- The catalog carries inline **`instructions`** (Markdown), replacing
+  `rules.txt`.
+- All catalog entity names must comply with **UAX #31** (see below).
+
+## Mandatory Identifier Rules
+
+All entity names in a v1.0 catalog — component types, function names, and
+argument/property keys — MUST comply with UAX #31:
+
+- Begin with `XID_Start` or underscore (`_`); never a digit.
+- Continue with `XID_Continue`.
+- Exclude whitespace and `Pattern_Syntax` symbols (other than `_`).
+
+Canonical regex: `^[\p{XID_Start}_][\p{XID_Continue}]*$`
+
+## Components
+
+### Text
+
+Displays text; supports simple Markdown. Render through a Markdown parser when
+available, else fall back to raw text (stripping `**`, `#` for legibility).
+Variants: `h1`–`h5` (suggested 2.5x / 2x / 1.75x / 1.5x / 1.25x base),
+`caption` (~0.8x, lighter/italic), `body` (default).
+
+### Image
+
+Image from a URL; default to flexible width filling the container. Map `fit` to
+the platform content-scale mode. Variants: `icon` (~24dp square), `avatar`
+(small rounded), `smallFeature` (~100dp), `mediumFeature` (default),
+`largeFeature`, `header` (full-width banner, cover/crop).
+
+### Icon
+
+System icon by `name` (e.g. `accountCircle` → `account_circle`). Default 24dp,
+inherit text color. A custom vector icon can be supplied as
+`{ "path": "<SVG path data>" }` — note the property is **`path`** in v1.0
+(renamed from `svgPath`).
+
+### Video
+
+Native video player with controls; full container width; support scrubbing.
+**`posterUrl`** (new) supplies a preview image displayed before the video
+plays.
+
+### AudioPlayer
+
+Native audio player with controls; full container width; support scrubbing.
+
+### Row
+
+Horizontal layout. `justify` → main axis (`start`, `center`, `end`,
+`spaceBetween`); `align` → cross axis. Fill available width.
+
+### Column
+
+Vertical layout. Mirrors `Row`, with `justify` vertical and `align` horizontal.
+
+### List
+
+Scrollable list. `direction` defaults to `vertical`; for `horizontal`, hide the
+scrollbar where possible and give children a bounded max width.
+
+### Card
+
+Card-styled container — distinct background, rounded corners, subtle elevation,
+inner padding (~16dp). **Accepts exactly one child** (wrap multiples in a
+`Column` or `Row`).
+
+### Tabs
+
+Selectable headers above the active tab's child. Keep a local `selectedIndex`
+(default `0`); on tap, update it and render that index's child; indicate the
+active tab visually.
+
+### Divider
+
+`axis: horizontal` (default) — 1dp tall, full width. `axis: vertical` — 1dp
+wide, full height.
+
+### Modal
+
+A dialog that is a modal **entry point**: render only the `trigger` child in
+the tree; on tap, open the modal and render the `content` child. Provide a
+close affordance.
+
+### Button
+
+Dispatches an action when tapped; always renders its `child`. Variants:
+`default`, `primary`, `borderless`. Action context resolves at interaction time
+(reflecting the latest inputs). `checks` that fail disable the button. Since
+`primaryColor` was removed, the `primary` variant should use the native
+framework's accent/primary color rather than a catalog-supplied hex.
+
+### TextField
+
+Native text input establishing two-way binding (writes to the bound `value`
+path on each keystroke). Variants: `shortText` (default), `longText`, `number`,
+`obscured`. **`placeholder`** (new) supplies placeholder text. `label` is
+required.
+
+### CheckBox
+
+Native checkbox/toggle alongside its label; two-way binds a boolean to the
+`value` path.
+
+### ChoicePicker
+
+Selects one or more options. `variant: "mutuallyExclusive"` (single) or
+`"multipleSelection"`. Binds to an array of selected string values.
+
+### Slider
+
+Native slider/seek bar. `min`/`max` set the range; the value is a `number`, so
+decimal ranges are valid. **`steps`** (new, integer ≥1) sets the number of
+discrete divisions; when present, the slider snaps to discrete values
+(`value` and `max` are required). Two-way bind on drag.
+
+### DateTimeInput
+
+Native date/time picker. `enableDate` + `enableTime` toggle which pickers show.
+Read/write **ISO 8601 strings** to the data model.
+
+## Surface Properties
+
+v1.0 replaces the catalog `theme` with `surfaceProperties` (set in
+`createSurface`). The Basic Catalog defines:
+
+| Property | Type | Use |
+| :--- | :--- | :--- |
+| `iconUrl` | URI | Agent/tool avatar shown next to the surface |
+| `agentDisplayName` | string | Text identity shown next to the surface |
+
+`primaryColor` was **removed** — branding is deferred to the native framework's
+theme. `surfaceProperties` allows additional properties
+(`additionalProperties: true`), so custom catalogs can extend it.
+
+In multi-agent systems an orchestrator should set/verify `iconUrl` and
+`agentDisplayName` so malicious sub-agents can't spoof a trusted identity.
+
+## Client-Side Functions
+
+Most functions are pure logic — they take resolved args and return a value;
+the Binder layer wraps execution in a reactive stream. `formatString` parses
+its own `${...}` expression to find dependencies. The Basic Catalog functions
+are: `required`, `regex`, `length`, `numeric`, `email` (validation);
+`formatString`, `formatNumber`, `formatCurrency`, `formatDate`, `pluralize`
+(formatting); `and`, `or`, `not` (logic); `openUrl` (effect); plus the system
+`@index`.
+
+### `@index`
+
+Returns the 0-based index of the current item during list-template rendering;
+add `offset` for 1-based numbering. Only valid in a collection scope — error
+otherwise. It is a system function (`@` prefix) available in every catalog.
+
+### `formatString`
+
+The only place `${expression}` is valid. Parse `${...}` blocks (handle `\${`
+escapes), tokenize literals / data paths / function calls, resolve through the
+data context to reactive streams, and concatenate with type coercion
+(number/boolean → string; null/undefined → `""`; object/array → JSON).
+
+### Validation and formatting functions
+
+`required` (not null/undefined/empty), `regex` (`pattern` test), `length`
+(min/max), `numeric` (range), `email` (standard email regex). `formatNumber` /
+`formatCurrency` use native locale formatting; `formatDate` uses a Unicode
+TR35 pattern; `pluralize` selects a localized string by numeric category.
+`openUrl` is a side-effecting `void` function; `and` / `or` / `not` are
+short-circuited boolean operators.
+
+## Layout Spacing & Color
+
+The v0.9 guidance still applies in v1.0:
+
+- **Leaf-Margin strategy** — structural containers (`Row`, `Column`, `List`)
+  contribute zero spacing; leaf and outlined components carry a uniform
+  external margin. This keeps spacing predictable under deep nesting.
+- **Color/contrast** — don't thread color through the tree; rely on native
+  theme/context inheritance. Leaf `Text` / `Icon` never hardcode color unless a
+  property says so. For nested containers, prefer transparent `Card`
+  backgrounds with a 1dp outline.
+
+---
+
+Source: `specification/v1_0/docs/basic_catalog_implementation_guide.md` and
+`specification/v1_0/catalogs/basic/catalog.json` in `a2ui-project/a2ui`.

--- a/.agents/skills/a2ui-knowledge/references/v1.0/custom-catalog-guide.md
+++ b/.agents/skills/a2ui-knowledge/references/v1.0/custom-catalog-guide.md
@@ -1,0 +1,121 @@
+# A2UI v1.0 — Custom Catalog Guide
+
+The end-to-end workflow for defining a custom catalog — the negotiation
+handshake, versioning, two-phase validation, graceful degradation, security,
+and agent-side ADK integration — is the same as v0.9. Read
+`references/v0.9/custom-catalog-guide.md` for that workflow. This guide covers
+the **v1.0 catalog-schema changes** you must apply.
+
+## v1.0 Catalog Schema Changes
+
+### `functions` is a map, not a list
+
+In v1.0 the catalog `functions` field is an **object keyed by function name**,
+where each value is a `FunctionDefinition`. This gives O(1) lookup and matches
+how `components` is already keyed.
+
+```json
+{
+  "catalogId": "https://my-company.com/a2ui/v1_0/catalog.json",
+  "functions": {
+    "trim": {
+      "returnType": "string",
+      "callableFrom": "clientOrRemote",
+      "properties": { "call": { "const": "trim" }, "args": { "...": "..." } },
+      "required": ["call", "args"]
+    }
+  }
+}
+```
+
+### `callableFrom` and `returnType` are catalog metadata
+
+Each `FunctionDefinition` carries:
+
+- `returnType` (required) — `string` / `number` / `boolean` / `array` /
+  `object` / `any` / `void`.
+- `callableFrom` (optional, default `clientOnly`) — `clientOnly` /
+  `remoteOnly` / `clientOrRemote`. Governs whether the server may invoke the
+  function via `callFunction`.
+
+These live **only** in the catalog/capabilities metadata. They are **removed
+from the wire `FunctionCall`**, so do not emit them in streamed messages. The
+client enforces `callableFrom` at runtime, rejecting invalid remote calls with
+`INVALID_FUNCTION_CALL`. See `custom-functions.md`.
+
+### `theme` → `surfaceProperties`
+
+Rename the `$defs/theme` definition to `$defs/surfaceProperties` and remove
+`primaryColor`. The envelope references it as
+`$ref: "catalog.json#/$defs/surfaceProperties"`. `surfaceProperties` typically
+uses `additionalProperties: true` so you can add app-specific surface fields.
+
+### Inline `instructions` replaces `rules.txt`
+
+Add an optional top-level `instructions` field (Markdown string) to embed
+design guidelines and component usage rules directly in the catalog. This
+replaces the external `rules.txt` prompt fragment used in v0.9.
+
+```json
+{
+  "catalogId": "https://my-company.com/a2ui/v1_0/catalog.json",
+  "instructions": "Use Row and Column for layout. Buttons MUST define an action.",
+  "components": { "...": "..." },
+  "functions": { "...": "..." }
+}
+```
+
+### Standard JSON Schema metadata is allowed
+
+`$schema`, `$id`, `title`, and `description` are now permitted on the catalog
+object even though it uses `additionalProperties: false`. This lets inline
+catalogs carry standard schema metadata without failing validation.
+
+### UAX #31 identifier naming
+
+All component names, function names, and argument/property keys MUST conform to
+Unicode Standard Annex #31:
+
+- Begin with `XID_Start` or `_`; never a digit.
+- Continue with `XID_Continue`.
+- No whitespace or `Pattern_Syntax` symbols (other than `_`).
+
+Canonical regex: `^[\p{XID_Start}_][\p{XID_Continue}]*$`. The `@` prefix is
+reserved for system functions (e.g. `@index`) — custom catalogs MUST NOT define
+`@`-prefixed names.
+
+## Validator-Compliance Rules (unchanged)
+
+As in v0.9, so automated validators can verify the component tree:
+
+- Any property holding another component's id MUST use
+  `$ref: "common_types.json#/$defs/ComponentId"` — not raw `"type": "string"`.
+- Any list of children or template MUST use
+  `$ref: "common_types.json#/$defs/ChildList"`.
+
+The envelope references the catalog through the relative `catalog.json`
+placeholder (`$ref: "catalog.json#/$defs/anyComponent"` and
+`$ref: "catalog.json#/$defs/surfaceProperties"`); alias it to your real catalog
+to validate. Ship production catalogs freestanding (no external `$ref`s).
+
+## Negotiation, Versioning, Degradation, Security, ADK
+
+These are unchanged from v0.9 — see `references/v0.9/custom-catalog-guide.md`:
+
+- **Negotiation** — `supportedCatalogIds`, `acceptsInlineCatalogs`,
+  client-supplied `inlineCatalogs` in `a2uiClientCapabilities`.
+- **Versioning** — embed a version in `catalogId`; treat removed/renamed
+  components or props as breaking.
+- **Two-phase validation** — structural (envelope) then semantic (catalog).
+- **Graceful degradation** — render placeholders for unknown components and
+  report a `VALIDATION_FAILED` error so the agent can self-correct.
+- **Security** — only registered components render; an orchestrator should
+  set/verify `surfaceProperties` identity fields.
+- **Agent-side ADK integration** — `A2uiSchemaManager`,
+  `SendA2uiToClientToolset`, `A2uiEventConverter`.
+
+---
+
+Source: `specification/v1_0/json/client_capabilities.json`,
+`specification/v1_0/catalogs/basic/catalog.json`, and
+`specification/v1_0/docs/a2ui_protocol.md` in `a2ui-project/a2ui`.

--- a/.agents/skills/a2ui-knowledge/references/v1.0/custom-functions.md
+++ b/.agents/skills/a2ui-knowledge/references/v1.0/custom-functions.md
@@ -1,0 +1,197 @@
+# A2UI v1.0 — Custom Functions
+
+A2UI functions are first-class members of a Catalog alongside components. When
+you define a custom catalog you can add functions for your application — e.g.
+a string `trim` or a hardware-query helper like `getScreenResolution`.
+
+This reference covers the v1.0 specifics. Two things changed from v0.9:
+
+1. The catalog `functions` field is a **map** keyed by function name (it was a
+   list-style `oneOf` in v0.9).
+2. Functions carry **`callableFrom`** (execution boundary) and **`returnType`**
+   as catalog metadata. These are removed from the wire `FunctionCall` — they
+   are verified at runtime against the catalog, not on the wire.
+
+## 1. Add functions to the catalog (a map)
+
+Use a `functions` object keyed by function name. Each entry is a
+`FunctionDefinition`: the `FunctionCall` validation shape (`call` + `args`)
+plus the metadata fields `returnType` (required) and optional `callableFrom`.
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/schemas/custom_catalog.json",
+  "title": "Custom Function Catalog",
+  "description": "Adds string trimming and screen-resolution functions.",
+  "functions": {
+    "trim": {
+      "type": "object",
+      "description": "Removes whitespace from the beginning and end of a string.",
+      "returnType": "string",
+      "callableFrom": "clientOrRemote",
+      "properties": {
+        "call": { "const": "trim" },
+        "args": {
+          "type": "object",
+          "properties": {
+            "value": {
+              "$ref": "common_types.json#/$defs/DynamicString",
+              "description": "The string to trim."
+            },
+            "chars": {
+              "$ref": "common_types.json#/$defs/DynamicString",
+              "description": "Optional. Characters to remove. Defaults to whitespace."
+            }
+          },
+          "required": ["value"],
+          "unevaluatedProperties": false
+        }
+      },
+      "required": ["call", "args"],
+      "unevaluatedProperties": false
+    },
+    "getScreenResolution": {
+      "type": "object",
+      "description": "Queries hardware for screen resolution.",
+      "returnType": "array",
+      "callableFrom": "remoteOnly",
+      "properties": {
+        "call": { "const": "getScreenResolution" },
+        "args": {
+          "type": "object",
+          "properties": {
+            "screenIndex": {
+              "$ref": "common_types.json#/$defs/DynamicNumber",
+              "description": "Optional. Defaults to 0 (primary screen)."
+            }
+          },
+          "unevaluatedProperties": false
+        }
+      },
+      "required": ["call", "args"],
+      "unevaluatedProperties": false
+    }
+  }
+}
+```
+
+Conventions:
+
+- `call` is a constant matching the map key — the validator's discriminator.
+- `args` reuses `common_types.json` types (`DynamicString`, `DynamicNumber`, …)
+  so the same binding semantics apply.
+- `returnType` is one of `string`, `number`, `boolean`, `array`, `object`,
+  `any`, `void`.
+- `callableFrom` is `clientOnly` (default), `remoteOnly`, or `clientOrRemote`.
+- Function names must conform to **UAX #31** and MUST NOT start with `@`
+  (reserved for system functions like `@index`).
+
+## 2. Expose them via `anyFunction`
+
+The wire `FunctionCall` refers to a catalog-agnostic `anyFunction`. Your
+catalog defines that reference to enumerate which functions exist:
+
+```json
+{
+  "$defs": {
+    "anyFunction": {
+      "oneOf": [
+        { "$ref": "#/functions/trim" },
+        { "$ref": "#/functions/getScreenResolution" }
+      ]
+    }
+  }
+}
+```
+
+To extend rather than replace the built-ins, `oneOf`-in the Basic Catalog's
+`anyFunction`:
+
+```json
+{
+  "$defs": {
+    "anyFunction": {
+      "oneOf": [
+        { "$ref": "#/functions/trim" },
+        { "$ref": "#/functions/getScreenResolution" },
+        { "$ref": "catalogs/basic/catalog.json#/$defs/anyFunction" }
+      ]
+    }
+  }
+}
+```
+
+For production, ship a freestanding catalog (no external `$ref`s) by inlining
+dependencies.
+
+## 3. Execution boundaries (`callableFrom`)
+
+`callableFrom` governs where a function may run. The boundary is **enforced at
+runtime by the client**, not on the wire:
+
+- When a server sends a `callFunction`, the client looks up the function in its
+  active catalog and reads `callableFrom`. If omitted, the boundary defaults to
+  `clientOnly`.
+- A remote `callFunction` targeting a `clientOnly` function — or a function not
+  registered at all — MUST be rejected with a client-to-server `error` whose
+  `code` is `INVALID_FUNCTION_CALL` (carrying the `functionCallId`).
+
+```json
+{
+  "version": "v1.0",
+  "error": {
+    "code": "INVALID_FUNCTION_CALL",
+    "message": "Function 'validateLocalInput' is clientOnly and cannot be invoked remotely.",
+    "functionCallId": "call_123"
+  }
+}
+```
+
+## 4. Server-initiated calls (`callFunction` / `functionResponse`)
+
+A `remoteOnly` or `clientOrRemote` function can be invoked by the server:
+
+```json
+{
+  "version": "v1.0",
+  "functionCallId": "res_1",
+  "wantResponse": true,
+  "callFunction": { "call": "getScreenResolution", "args": { "screenIndex": 0 } }
+}
+```
+
+If `wantResponse` is `true`, the client replies with a `functionResponse`
+(copying `functionCallId` and `call` verbatim) or an `error`:
+
+```json
+{
+  "version": "v1.0",
+  "functionResponse": { "functionCallId": "res_1", "call": "getScreenResolution", "value": [1920, 1080] }
+}
+```
+
+## 5. How validation works
+
+When a `FunctionCall` is validated:
+
+1. **Discriminator lookup** — the validator reads `call`.
+2. **Schema matching** — `call: "length"` matches the built-in `length`;
+   `call: "trim"` matches your custom `trim`; `call: "unknownFunc"` fails
+   immediately (strict mode).
+3. **Args validation** — the matched schema's `args` enforce argument types.
+
+Note the wire `FunctionCall` carries only `call` and `args`; `callableFrom` and
+`returnType` are not on the wire and are checked at runtime.
+
+## 6. Implementing the function (renderer side)
+
+The schema describes the contract; the renderer registers a runtime
+implementation (see `renderer-guide.md`). Pure-logic functions (e.g. `trim`)
+return a static value; external-state functions (e.g. `getScreenResolution`)
+return a reactive stream; effect functions (e.g. `openUrl`) return `void`.
+
+---
+
+Source: `specification/v1_0/docs/a2ui_custom_functions.md` and
+`specification/v1_0/json/client_capabilities.json` in `a2ui-project/a2ui`.

--- a/.agents/skills/a2ui-knowledge/references/v1.0/evolution-guide.md
+++ b/.agents/skills/a2ui-knowledge/references/v1.0/evolution-guide.md
@@ -1,0 +1,171 @@
+# A2UI Evolution Guide — v0.9 → v0.9.1 → v1.0
+
+Use this reference when migrating an existing v0.9 / v0.9.1 implementation to
+v1.0, or when deciding which version to target. For the v0.8 → v0.9 diff, see
+`references/v0.9/evolution-guide.md`.
+
+## Version status at a glance
+
+| Version | Status | Summary |
+| :--- | :--- | :--- |
+| v0.9 | Prior (legacy) | Prompt-first redesign; `createSurface` family |
+| v0.9.1 | Current (stable) | v0.9 plus MIME standardization and relaxed surface uniqueness |
+| v1.0 | Candidate (release) | Bidirectional RPC, `surfaceProperties`, catalog refinements |
+
+## Part 1 — v0.9 → v0.9.1
+
+v0.9.1 is a **minor refinement** of v0.9, fully compatible with v0.9 payloads
+(version fields accept both `"v0.9"` and `"v0.9.1"`). Two changes:
+
+1. **MIME type standardization** — all references to the payload MIME type are
+   standardized to `application/a2ui+json`, replacing the legacy
+   `application/json+a2ui`.
+2. **Surface ID uniqueness relaxation** — `surfaceId` no longer needs to be
+   unique for the renderer's full lifetime; it must only be unique among
+   **currently active** surfaces. It remains an error to `createSurface` on an
+   ID that already exists without first deleting it.
+
+Message names and structures are otherwise identical, so the v0.9 protocol
+reference stays accurate for v0.9.1. Migration: update any hardcoded MIME type
+references to `application/a2ui+json`.
+
+> Note: v1.0 restores the stronger "globally unique for the renderer's
+> lifetime" wording for `surfaceId` (the v0.9.1 relaxation was specific to
+> v0.9.1).
+
+## Part 2 — v0.9 (incl. 0.9.1) → v1.0
+
+### Executive summary
+
+- **Bidirectional RPC** — synchronous server responses to client actions
+  (`actionResponse`, keyed by `actionId`) and server-initiated function
+  execution (`callFunction` / `functionResponse`), with execution boundaries
+  and return types verified at runtime against catalog definitions rather than
+  on the wire.
+- `theme` (catalog and `createSurface`) is replaced by `surfaceProperties`;
+  `primaryColor` is removed, separating layout from branding.
+- Initial `components` and `dataModel` may be embedded directly in
+  `createSurface`, enabling a whole UI in one message.
+- The catalog `functions` field becomes a **map** keyed by function name
+  (was a list).
+- Standard JSON Schema metadata (`$schema`, `$id`, `title`, `description`) is
+  allowed in catalogs.
+- All catalog entity names must conform to UAX #31.
+- The `@index` built-in function retrieves the iteration index during list
+  template rendering; the `@` prefix is reserved for system context.
+
+### Catalog definition schema
+
+- Renamed `$defs/theme` → `$defs/surfaceProperties`; removed `primaryColor`.
+- `functions` changed from a list to a map keyed by function name.
+- Added `callableFrom` (enum: `clientOnly`, `remoteOnly`, `clientOrRemote`) to
+  `FunctionDefinition` to restrict where a function may be invoked.
+- Added an optional `instructions` field (inline Markdown) to the catalog,
+  replacing the external `rules.txt`.
+- Allowed standard JSON Schema metadata fields despite
+  `additionalProperties: false`.
+- Enforced UAX #31 naming (`XID_Start` / `XID_Continue`) across component
+  names, function names, and argument keys.
+
+### Standard catalogs (basic and minimal)
+
+- Added `posterUrl` to `Video` (preview image before playback).
+- Added `placeholder` to `TextField`.
+- Added `steps` to `Slider` (snap to discrete intervals).
+- Added inline catalog `instructions` (replacing `rules.txt`).
+- Renamed the custom SVG icon `svgPath` property to `path`.
+- Renamed `$defs/theme` → `$defs/surfaceProperties` in both catalogs.
+
+### Server-to-client messages
+
+- Added `actionResponse` (`ActionResponseMessage`): server responds to a
+  specific action call via `actionId` with a `value` or `error`.
+- Added `callFunction` (`CallFunctionMessage`): server-initiated function
+  execution. `callableFrom` and `returnType` were removed from the wire
+  payload, relying on runtime catalog verification.
+- Updated `createSurface`: renamed `theme` → `surfaceProperties`; allowed
+  inline `components` and `dataModel`.
+- Updated all version envelopes from `v0.9` / `v0.9.1` to `v1.0`.
+
+### Client-to-server events
+
+- Added `actionId` to the `action` message — the client generates it when
+  `wantResponse: true`.
+- Added `functionResponse` (`FunctionResponseMessage`) returning the `value`
+  of a server-initiated function call.
+- Client `error` messages now support `functionCallId` for function execution
+  failures, mutually exclusive with `surfaceId`.
+
+### Client capabilities schema
+
+- Added an optional `instructions` field (plain Markdown) to the catalog
+  definition in `client_capabilities.json`.
+- Renamed the `theme` capability block to `surfaceProperties`.
+- Added static `callableFrom` and `returnType` metadata to
+  `FunctionDefinition` to advertise execution boundaries and return types to
+  the server.
+
+### Agent card and transport metadata
+
+- Standardized the MIME type to `application/a2ui+json` (IANA-conformant).
+- Updated capabilities namespace and A2A metadata params from
+  `v0.9` / `v0.9.1` to `v1.0`.
+- Extension URI: `https://a2ui.org/a2a-extension/a2ui/v1.0`.
+
+### Data encoding
+
+- **Deletion semantics**: setting a path's value to `null` in
+  `updateDataModel` deletes the key. Omitting keys no longer deletes them.
+- Removed `callableFrom` / `returnType` from the wire `FunctionCall` and
+  dynamic-value schemas — boundary and return-type checks are runtime-only.
+- Added the built-in `@index` function (optional `offset`) under
+  `FunctionCall`; reserved the `@` prefix for system context.
+
+### Processing rules
+
+- `surfaceId` must be globally unique per client session; creating an existing
+  ID without deleting it first is an error.
+- Function execution boundaries and return types are looked up at runtime. A
+  remote call to a `clientOnly` (or unregistered) function is rejected with
+  `INVALID_FUNCTION_CALL`.
+- Catalog entity names must comply with UAX #31.
+- `@index` is restricted to template instantiation loops (collection scope);
+  calling it elsewhere is an evaluation error.
+
+## Migration checklist
+
+### For agents and servers
+
+1. Set `version` to `"v1.0"` in all streamed envelopes.
+2. Change the transport MIME type from `application/json+a2ui` to
+   `application/a2ui+json` (if not already done for v0.9.1).
+3. Rename `theme` → `surfaceProperties` in `createSurface`; remove
+   `primaryColor`. Optionally inline `components` / `dataModel`.
+4. Convert catalog `functions` from an array to a name-keyed map.
+5. Rename `$defs/theme` → `$defs/surfaceProperties`; remove `primaryColor`.
+6. Ensure all catalog entity names conform to UAX #31.
+7. Do not put `callableFrom` / `returnType` in wire `FunctionCall` payloads;
+   keep them as catalog metadata.
+8. Rename custom SVG icon `svgPath` → `path`; adopt optional `Video.posterUrl`,
+   `TextField.placeholder`, `Slider.steps`.
+9. Delete data-model keys by setting them to `null` (never by omission).
+
+### For renderers and clients
+
+1. Parse `callFunction`: check `callableFrom` in the catalog, reject invalid
+   calls with `INVALID_FUNCTION_CALL`, and return `functionResponse`.
+2. Support `actionResponse`: generate an `actionId` for actions with
+   `wantResponse: true`, and write returned values to the data model (using
+   `responsePath` when present).
+3. Route payloads by inspecting the `version` field (`"v1.0"`).
+4. Enforce surface uniqueness — error on a duplicate `createSurface`.
+5. Handle `functionCallId` in error reporting; enforce mutual exclusivity with
+   `surfaceId`.
+6. Verify catalog entity names against UAX #31.
+7. Support `@index` during list template rendering (collection scope),
+   adjusted by any `offset`.
+
+---
+
+Source: `specification/v1_0/docs/evolution_guide.md` and
+`specification/v0_9_1/docs/evolution_guide.md` in `a2ui-project/a2ui`.

--- a/.agents/skills/a2ui-knowledge/references/v1.0/protocol.md
+++ b/.agents/skills/a2ui-knowledge/references/v1.0/protocol.md
@@ -1,0 +1,493 @@
+# A2UI v1.0 Protocol Reference
+
+A2UI v1.0 is the **release candidate** ("Candidate" status in the roadmap).
+For production today, prefer v0.9.1 (the current stable release); reach for
+v1.0 when you want its release-candidate features: bidirectional RPC,
+`surfaceProperties`, single-message UI instantiation, and the catalog
+refinements below.
+
+v1.0 keeps v0.9's prompt-first philosophy and adjacency-list component model.
+It adds a return channel from server to client (and back) on top of the
+existing unidirectional rendering stream.
+
+## Table of Contents
+
+- [Message Types](#message-types)
+- [What Changed from v0.9 / v0.9.1](#what-changed-from-v09--v091)
+- [The Schema Layout](#the-schema-layout)
+- [`createSurface`](#createsurface)
+- [`updateComponents`](#updatecomponents)
+- [`updateDataModel`](#updatedatamodel)
+- [`deleteSurface`](#deletesurface)
+- [`callFunction`](#callfunction)
+- [`actionResponse`](#actionresponse)
+- [Components and the Adjacency List Model](#components-and-the-adjacency-list-model)
+- [Identifier Naming (UAX #31)](#identifier-naming-uax-31)
+- [Actions](#actions)
+- [Data Model: Binding and Scope](#data-model-binding-and-scope)
+- [The `@index` Function](#the-index-function)
+- [`formatString` String Interpolation](#formatstring-string-interpolation)
+- [Functions and Validation](#functions-and-validation)
+- [Client-to-Server Messages](#client-to-server-messages)
+- [Capabilities and Metadata](#capabilities-and-metadata)
+- [Prompt → Generate → Validate Loop](#prompt--generate--validate-loop)
+
+## Message Types
+
+### Server-to-client
+
+The `server_to_client.json` envelope is a top-level `oneOf` over **six**
+message types. Every message also carries a `version` field set to `"v1.0"`.
+
+| Message | Purpose |
+| :--- | :--- |
+| `createSurface` | Create a surface; may inline `components` + `dataModel` |
+| `updateComponents` | Add or replace components (flat list, ID references) |
+| `updateDataModel` | Upsert or (with `null`) delete a value at a JSON-Pointer path |
+| `deleteSurface` | Remove a surface and all its state |
+| `callFunction` | Server-initiated RPC: execute a registered client function |
+| `actionResponse` | Synchronous reply to a client `action` that set `wantResponse` |
+
+### Client-to-server
+
+The `client_to_server.json` schema permits exactly one of three top-level
+keys (plus `version`):
+
+| Message | Purpose |
+| :--- | :--- |
+| `action` | A user interaction; may carry `wantResponse` + `actionId` |
+| `functionResponse` | Result (`value`) of a server-initiated `callFunction` |
+| `error` | A client-side error (`VALIDATION_FAILED`, `INVALID_FUNCTION_CALL`, …) |
+
+## What Changed from v0.9 / v0.9.1
+
+See `evolution-guide.md` for the full migration. The headline changes:
+
+- **Bidirectional RPC** — `actionResponse` (server replies to a client
+  action), and `callFunction` / `functionResponse` (server invokes a client
+  function and gets the result back).
+- **`surfaceProperties` replaces `theme`** in `createSurface` and the catalog;
+  `primaryColor` is removed (branding is deferred to the native framework).
+- **Single-message UI** — `createSurface` may embed `components` and
+  `dataModel` directly, so an entire UI can ship in one message.
+- **Catalog `functions` is a name-keyed map** (was a list); `callableFrom`
+  and `returnType` are catalog metadata only and were removed from the wire
+  `FunctionCall`.
+- **Catalog `instructions`** (inline Markdown) replaces the external
+  `rules.txt`.
+- **UAX #31 identifier naming** enforced for component, function, and argument
+  names; the `@` prefix is reserved for system functions.
+- **`@index`** built-in template function (optional `offset`).
+- **`null`-based deletion** in `updateDataModel`; omitting keys no longer
+  deletes.
+
+## The Schema Layout
+
+v1.0 keeps the three-schema split:
+
+1. **`common_types.json`** — `DynamicString` / `DynamicNumber` /
+   `DynamicBoolean` / `DynamicStringList`, `ChildList`, `ComponentId`,
+   `CallId`, `FunctionCall`, `Action`, plus the built-in `indexSystemFunction`
+   (`@index`).
+2. **`server_to_client.json`** — the envelope (`oneOf` over the six message
+   types). It references the catalog through a relative `catalog.json`
+   placeholder (`$ref: "catalog.json#/$defs/anyComponent"` and
+   `$ref: "catalog.json#/$defs/surfaceProperties"`).
+3. **`catalogs/basic/catalog.json`** — the Basic Catalog: components,
+   functions (a map), and the `surfaceProperties` schema.
+
+To validate a payload, alias `catalog.json` to whichever real catalog applies.
+That indirection is what makes catalogs swappable. v1.0 catalogs may also
+carry standard JSON Schema metadata (`$schema`, `$id`, `title`, `description`)
+without tripping `additionalProperties: false`.
+
+## `createSurface`
+
+Signals the client to create a surface. Once created, `surfaceId` and
+`catalogId` are fixed; to change them, delete and recreate. `surfaceId` must
+be globally unique for the renderer's lifetime, and it is an error to create a
+surface whose ID already exists without first deleting it.
+
+> **Note on `surfaceId` uniqueness:** v0.9.1 relaxed this to active surfaces
+> only, but the v1.0 protocol restored the stronger "globally unique for the
+> renderer's lifetime" wording. Orchestrators are expected to namespace IDs
+> (e.g. prefix a subagent name, or require UUIDs) to avoid collisions.
+
+**Properties:**
+
+- `surfaceId` (string, required) — globally unique for the renderer's lifetime.
+- `catalogId` (string, required) — identifier of the catalog. Recommended to
+  prefix with a domain you own; the URI is purely an identifier, not fetched.
+- `surfaceProperties` (object, optional) — values for the catalog's
+  `surfaceProperties` schema (e.g. `agentDisplayName`, `iconUrl`). **Replaces
+  the v0.9 `theme` object.**
+- `sendDataModel` (boolean, optional, default `false`) — if `true`, the client
+  attaches the surface's full data model to the metadata of every message it
+  sends to the surface owner.
+- `components` (array, optional) — inline UI components, built immediately on
+  creation. Conforms to `ComponentsList`. **New in v1.0.**
+- `dataModel` (object, optional) — the initial root data model. **New in v1.0.**
+
+Exactly one component in the resulting tree must have id `root`.
+
+```json
+{
+  "version": "v1.0",
+  "createSurface": {
+    "surfaceId": "user_profile_card",
+    "catalogId": "https://a2ui.org/specification/v1_0/catalogs/basic/catalog.json",
+    "surfaceProperties": { "agentDisplayName": "Weather Bot" },
+    "sendDataModel": true,
+    "components": [
+      { "id": "root", "component": "Column", "children": ["user_name"] },
+      { "id": "user_name", "component": "Text", "text": { "path": "/name" } }
+    ],
+    "dataModel": { "name": "John Doe" }
+  }
+}
+```
+
+## `updateComponents`
+
+A flat list of components; parents reference children by id. Components may
+arrive in any order and may reference children that don't yet exist — clients
+render progressively and fill in as definitions arrive.
+
+```json
+{
+  "version": "v1.0",
+  "updateComponents": {
+    "surfaceId": "user_profile_card",
+    "components": [
+      { "id": "root", "component": "Column", "children": ["user_name", "user_title"] },
+      { "id": "user_name", "component": "Text", "text": "John Doe" },
+      { "id": "user_title", "component": "Text", "text": "Software Engineer" }
+    ]
+  }
+}
+```
+
+## `updateDataModel`
+
+Upserts at a JSON Pointer path. **Deletion is explicit via `null`** — omitting
+keys no longer deletes them.
+
+- If the path exists, the value is updated.
+- If the path does not exist, it is created.
+- If the `value` is `null`, the key at that path is removed.
+- If `path` is omitted (or `/`), the whole model is replaced.
+
+```json
+{
+  "version": "v1.0",
+  "updateDataModel": {
+    "surfaceId": "user_profile_card",
+    "path": "/user/name",
+    "value": "Jane Doe"
+  }
+}
+```
+
+Remove a field by setting it to `null`:
+
+```json
+{
+  "version": "v1.0",
+  "updateDataModel": { "surfaceId": "user_profile_card", "path": "/user/tempData", "value": null }
+}
+```
+
+## `deleteSurface`
+
+```json
+{ "version": "v1.0", "deleteSurface": { "surfaceId": "user_profile_card" } }
+```
+
+## `callFunction`
+
+Server-initiated RPC: the server asks the client to execute a function
+registered in the active catalog. This avoids sending executable code on the
+wire.
+
+**Properties:**
+
+- `version` (`"v1.0"`, required).
+- `functionCallId` (`CallId`, required) — unique per invocation; the client
+  MUST copy it verbatim into its `functionResponse` or `error`.
+- `wantResponse` (boolean, optional, default `false`) — if `true`, the client
+  MUST reply with a `functionResponse` or an `error`.
+- `callFunction` (object, required) — `{ "call": <name>, "args": { … } }`.
+
+```json
+{
+  "version": "v1.0",
+  "functionCallId": "get_device_resolution_123",
+  "wantResponse": true,
+  "callFunction": { "call": "getScreenResolution", "args": { "screenIndex": 0 } }
+}
+```
+
+**Execution boundaries** are enforced at runtime by the client, not on the
+wire. The client looks up the function's `callableFrom` metadata in its active
+catalog (`clientOnly` / `remoteOnly` / `clientOrRemote`; defaults to
+`clientOnly` if omitted). If a remote `callFunction` targets a `clientOnly`
+function, or an unregistered function, the client MUST reject it with an
+`error` whose `code` is `INVALID_FUNCTION_CALL`.
+
+## `actionResponse`
+
+The server's synchronous reply to a client `action` that set
+`wantResponse: true`. The client matches it by `actionId`.
+
+**Properties:**
+
+- `version` (`"v1.0"`, required).
+- `actionId` (string, required) — matches the client's `action.actionId`.
+- `actionResponse` (object, required) — exactly one of:
+  - `value` (any) — the success return value.
+  - `error` (object) — `{ "code": <string>, "message": <string> }`.
+
+```json
+{
+  "version": "v1.0",
+  "actionId": "get_typeahead_suggestions_1",
+  "actionResponse": { "value": ["apple", "application", "approved"] }
+}
+```
+
+If the originating `action.event` set a `responsePath`, the client writes the
+returned `value` into its local data model at that JSON Pointer.
+
+## Components and the Adjacency List Model
+
+A component object is `{ "id": <ComponentId>, "component": <type>, …props }`.
+The UI is a flat list; parents reference children by id, the client stores
+them in a `Map<id, Component>` and builds the tree at render time. Rendering
+begins once a component with id `root` exists; updates before that are
+buffered. This is unchanged from v0.9.
+
+`anyComponent` in the catalog uses a `discriminator` on `component` so a
+JSON-Schema validator can route each object to the right component schema.
+
+## Identifier Naming (UAX #31)
+
+In v1.0, all catalog entity names — **component names, function names, and
+argument/property keys** — MUST conform to Unicode Standard Annex #31:
+
+- Begin with `XID_Start` or underscore (`_`); never a digit.
+- Continue with `XID_Continue`.
+- No whitespace or `Pattern_Syntax` symbols (other than `_`).
+
+Canonical regex: `^[\p{XID_Start}_][\p{XID_Continue}]*$`
+
+Valid: `UserProfileCard`, `submit_form`, `item_id_1`, `_internal_state`.
+Invalid: `User Card`, `1stItem`, `submit-form`, `user#name`.
+
+The `@` prefix is **reserved** for system functions (e.g. `@index`); custom
+catalogs MUST NOT define `@`-prefixed functions.
+
+## Actions
+
+Interactive components use an `action` object — either a server event or a
+local function call.
+
+### Server action
+
+```json
+{
+  "component": "Button",
+  "text": "Submit",
+  "action": {
+    "event": {
+      "name": "submit_form",
+      "context": { "itemId": "123" },
+      "wantResponse": false,
+      "responsePath": "/lastResult"
+    }
+  }
+}
+```
+
+- `wantResponse` (boolean, optional) — if `true`, the client generates an
+  `actionId`, sends it on the `action`, and expects an `actionResponse`.
+- `responsePath` (string, optional) — JSON Pointer where the client saves the
+  returned `value`.
+
+### Local action
+
+```json
+{
+  "component": "Button",
+  "text": "Open Link",
+  "action": { "functionCall": { "call": "openUrl", "args": { "url": "${/url}" } } }
+}
+```
+
+## Data Model: Binding and Scope
+
+Bindings use JSON Pointer ([RFC 6901]). Paths starting with `/` are absolute
+(resolve from the data-model root). Inside a `ChildList` template (a container
+whose `children` is `{ componentId, path }`), each item creates a child scope:
+a path **without** a leading `/` is relative to the current item
+(`firstName` → `/users/0/firstName`, …), while a leading-`/` path still
+escapes to root. Type coercion when interpolating non-strings: numbers /
+booleans use their standard representation, `null`/`undefined` become `""`,
+and objects / arrays are JSON-stringified.
+
+Two-way binding for inputs (`TextField`, `CheckBox`, `Slider`, `ChoicePicker`,
+`DateTimeInput`) is local to the client: edits write immediately to the local
+data model but only reach the server on an `action` (or via `sendDataModel`).
+
+## The `@index` Function
+
+`@index` returns the 0-based index of the current item during list-template
+rendering. It is a universal system function (available in every catalog) and
+MUST only be evaluated inside a collection scope; calling it in the root scope
+is an evaluation error.
+
+- `offset` (number, optional, default `0`) — added to the index, e.g.
+  `@index(offset: 1)` yields 1-based numbering.
+
+```json
+{
+  "id": "todo_index",
+  "component": "Text",
+  "text": { "call": "formatString", "args": { "value": "#${@index(offset: 1)}" } }
+}
+```
+
+## `formatString` String Interpolation
+
+`${...}` interpolation is valid **only** inside the `formatString` function.
+
+- `${/absolute/path}` / `${relative/path}` — data bindings.
+- `${func(arg: value, arg2: ${/nested})}` — function calls (identified by
+  `()`); nest `${...}` for explicit binding or chaining.
+- `\${literal}` — escape a literal `${`.
+
+```json
+{
+  "id": "user_welcome",
+  "component": "Text",
+  "text": {
+    "call": "formatString",
+    "args": { "value": "Hello, ${/user/firstName}! Welcome back to ${/appName}." }
+  }
+}
+```
+
+## Functions and Validation
+
+Functions are referenced by name via a `FunctionCall` object and defined in
+the active catalog. Input components and buttons can carry `checks` — function
+calls returning a boolean, each with a `message`. A failing button check
+disables the button.
+
+```json
+"checks": [
+  { "call": "required", "args": { "value": { "path": "/formData/zip" } }, "message": "Zip code is required" },
+  { "call": "regex", "args": { "value": { "path": "/formData/zip" }, "pattern": "^[0-9]{5}$" }, "message": "Must be a 5-digit zip code" }
+]
+```
+
+In v1.0 the catalog `functions` field is a **map** keyed by function name (see
+`custom-functions.md`). The wire `FunctionCall` carries only `call` and `args`
+— `callableFrom` and `returnType` live in the catalog as metadata.
+
+## Client-to-Server Messages
+
+### `action`
+
+```json
+{
+  "version": "v1.0",
+  "action": {
+    "name": "submitForm",
+    "surfaceId": "contact_form_1",
+    "sourceComponentId": "submit_button",
+    "timestamp": "2026-06-02T08:57:23Z",
+    "context": { "isSubscribed": true },
+    "wantResponse": true,
+    "actionId": "form_submit_773"
+  }
+}
+```
+
+`actionId` is REQUIRED when `wantResponse` is `true`; otherwise optional.
+
+### `functionResponse`
+
+Returned for a server `callFunction` that set `wantResponse: true`.
+
+```json
+{
+  "version": "v1.0",
+  "functionResponse": {
+    "functionCallId": "get_device_resolution_123",
+    "call": "getScreenResolution",
+    "value": [1920, 1080]
+  }
+}
+```
+
+`functionCallId` and `call` are copied verbatim from the server message.
+
+### `error`
+
+Reports a client-side error. `code` and `message` are required.
+`surfaceId` and `functionCallId` are **mutually exclusive**: include
+`surfaceId` for surface/validation errors, `functionCallId` for function
+execution failures.
+
+```json
+{
+  "version": "v1.0",
+  "error": {
+    "code": "INVALID_FUNCTION_CALL",
+    "message": "Function 'deleteLocalFile' is clientOnly and cannot be called from the server.",
+    "functionCallId": "delete_file_call_9"
+  }
+}
+```
+
+A `VALIDATION_FAILED` error instead carries `surfaceId` and `path` (see the
+loop below).
+
+## Capabilities and Metadata
+
+Capabilities ride in transport metadata, not in first-class A2UI messages.
+Both schemas key their structure under a `v1.0` object.
+
+- **Server** (`server_capabilities.json`) — `supportedCatalogIds`
+  (string[], required) and `acceptsInlineCatalogs` (boolean, default `false`).
+  Advertised via the transport identity mechanism (A2A AgentCard params, MCP
+  server capabilities, …).
+- **Client** (`client_capabilities.json`) — `a2uiClientCapabilities` with
+  `supportedCatalogIds` and optional `inlineCatalogs`. Functions inside inline
+  catalogs may declare `callableFrom` to advertise execution boundaries.
+- **Client data model** (`client_data_model.json`) — when `sendDataModel` is
+  on, `a2uiClientDataModel` is `{ "version": "v1.0", "surfaces": { <id>: <model> } }`.
+
+## Prompt → Generate → Validate Loop
+
+The intended runtime pattern is unchanged from v0.9: prompt the LLM with the
+desired UI plus the envelope + catalog schemas; generate JSON; validate it
+against the resolved schema and return a structured error so the LLM can
+self-correct.
+
+```json
+{
+  "error": {
+    "code": "VALIDATION_FAILED",
+    "surfaceId": "user_profile_card",
+    "path": "/components/0/text",
+    "message": "Expected stringOrPath, got integer"
+  }
+}
+```
+
+[RFC 6901]: https://datatracker.ietf.org/doc/html/rfc6901
+
+---
+
+Source: `specification/v1_0/docs/a2ui_protocol.md` in `a2ui-project/a2ui`.

--- a/.agents/skills/a2ui-knowledge/references/v1.0/renderer-guide.md
+++ b/.agents/skills/a2ui-knowledge/references/v1.0/renderer-guide.md
@@ -1,0 +1,95 @@
+# A2UI v1.0 — Renderer Architecture Guide
+
+The v1.0 renderer architecture is the same as v0.9: a **framework-agnostic**
+data layer (`MessageProcessor`, `SurfaceModel`, `DataModel`,
+`ComponentContext`) feeding a **framework-specific** view layer
+(`ComponentImplementation` nodes), with a Binder layer connecting them. For the
+full architecture — the five core interfaces, the three binder strategies
+(direct / binder layer / generic-by-reflection), lifecycle and subscription
+rules, and the step-by-step build plan — read `references/v0.9/renderer-guide.md`.
+That material is unchanged in v1.0.
+
+This guide covers only the **new client responsibilities** v1.0 adds on top of
+that architecture.
+
+## New Message Routing
+
+The `MessageProcessor` must handle two additional server-to-client envelope
+keys beyond `createSurface` / `updateComponents` / `updateDataModel` /
+`deleteSurface`:
+
+- **`callFunction`** — a server-initiated function call (see below).
+- **`actionResponse`** — a synchronous reply to a client `action` (see below).
+
+Route messages by inspecting the `version` field (`"v1.0"`) so a client can run
+v0.9 and v1.0 surfaces side by side through version-specific controllers.
+
+## Single-Message Surface Creation
+
+`createSurface` may now carry inline `components` and `dataModel`. The
+processor should apply them as if an `updateComponents` and an
+`updateDataModel` immediately followed the create — building and populating the
+tree on creation. `theme` is replaced by `surfaceProperties`; map its fields
+(`agentDisplayName`, `iconUrl`, plus any custom ones) to your surface chrome.
+
+## Server-Initiated Functions (`callFunction`)
+
+When a `callFunction` arrives:
+
+1. Look up `call` in the active catalog's function registry.
+2. Read the function's `callableFrom` metadata. If omitted, treat it as
+   `clientOnly`.
+3. If the function is `clientOnly` or unregistered, reject the call: send a
+   client-to-server `error` with `code: "INVALID_FUNCTION_CALL"` and the
+   `functionCallId`.
+4. Otherwise execute the registered implementation with the supplied `args`.
+5. If `wantResponse` is `true`, reply with a `functionResponse` echoing
+   `functionCallId` and `call` and carrying the returned `value`. On failure,
+   reply with an `error` carrying the `functionCallId`.
+
+`functionCallId` and `surfaceId` are mutually exclusive on `error` messages:
+use `functionCallId` for function-execution errors, `surfaceId` for
+surface/validation errors.
+
+## Synchronous Action Responses (`actionResponse`)
+
+For interactive components whose `action.event` sets `wantResponse: true`:
+
+1. The client generates a unique `actionId` and includes it on the outgoing
+   `action` message.
+2. The server replies with an `actionResponse` carrying the same `actionId`
+   and either a `value` or an `error`.
+3. If the originating event declared a `responsePath`, write the returned
+   `value` into the local data model at that JSON Pointer (which reactively
+   updates any bound components). Match responses to pending actions by
+   `actionId`.
+
+This enables patterns like typeahead/autocomplete where a server lookup result
+feeds straight back into the UI.
+
+## The `@index` System Function
+
+Add `@index` to the function evaluation path, but scope it to **collection
+scope** only. While instantiating a `ChildList` template over a bound array,
+track the current iteration index; `@index` returns it (0-based), adjusted by
+an optional `offset` argument. Calling `@index` outside template iteration
+(e.g. in the root scope) is an evaluation error. The `@` prefix is reserved
+for system functions; do not let custom catalogs register `@`-prefixed names.
+
+## Data Model Deletion Semantics
+
+`updateDataModel` now deletes a key **only** when its `value` is `null`.
+Omitting a key no longer deletes it (it is simply left unchanged). Implement
+upsert-with-explicit-`null`-delete accordingly.
+
+## Identifier Validation
+
+When loading a catalog (built-in or inline), verify that every component name,
+function name, and argument/property key conforms to UAX #31
+(`^[\p{XID_Start}_][\p{XID_Continue}]*$`). Reject non-conformant catalogs.
+
+---
+
+Source: `specification/v1_0/docs/renderer_guide.md` (core architecture, shared
+with v0.9) and `specification/v1_0/docs/a2ui_protocol.md` +
+`evolution_guide.md` (v1.0 client responsibilities) in `a2ui-project/a2ui`.

--- a/.agents/skills/ag-ui-knowledge/.sources.json
+++ b/.agents/skills/ag-ui-knowledge/.sources.json
@@ -1,0 +1,10 @@
+{
+  "skill": "ag-ui-knowledge",
+  "sources": [
+    {
+      "repo": "submodules/ag-ui",
+      "synced": "4202bf237179b68e74cec8454bdf884e83db7e41",
+      "paths": ["docs"]
+    }
+  ]
+}

--- a/.agents/skills/ag-ui-knowledge/SKILL.md
+++ b/.agents/skills/ag-ui-knowledge/SKILL.md
@@ -1,0 +1,243 @@
+---
+name: ag-ui-knowledge
+description: >
+  Expert guidance for AG-UI (Agent–User Interaction Protocol) — the open,
+  event-based protocol connecting AI agents to user-facing apps. Covers
+  the run lifecycle, event types (lifecycle, text, tool-call, state,
+  activity, reasoning), RunAgentInput, AbstractAgent/HttpAgent, multimodal
+  messages, shared state via STATE_SNAPSHOT/STATE_DELTA (RFC 6902 JSON
+  Patch), frontend-defined tools, interrupt-aware HITL with
+  RunAgentInput.resume, encrypted reasoning for ZDR, capability discovery,
+  middleware, serialization with parentRunId branching, the TypeScript
+  (`@ag-ui/client`, `@ag-ui/core`) and Python (`ag-ui-protocol`) SDKs plus
+  community SDKs. Use whenever someone builds or consumes AG-UI, wires up
+  CopilotKit, LangGraph, CrewAI, Mastra, Pydantic AI, LlamaIndex, Agno,
+  AG2, Microsoft Agent Framework, Google ADK, AWS Strands, or Bedrock
+  AgentCore, or mentions AG-UI, ag_ui, RunStartedEvent, STATE_DELTA,
+  TOOL_CALL_START, REASONING_*, AbstractAgent, HttpAgent, or EventEncoder.
+  Always invoke.
+license: MIT
+metadata:
+  author: "Ikuma Yamashita"
+  version: "1.2.0"
+---
+
+# AG-UI Knowledge
+
+You are an expert in the **AG-UI (Agent–User Interaction Protocol)** — the open,
+event-based protocol that standardizes how AI agents communicate with
+user-facing applications in real time.
+
+## What AG-UI Is
+
+AG-UI sits at the **Agent ↔ User Interaction** layer of the agentic-protocol
+stack, alongside two siblings:
+
+| Layer                | Protocol                         | Purpose                                                        |
+| -------------------- | -------------------------------- | -------------------------------------------------------------- |
+| Agent ↔ Tools / Data | **MCP** (Model Context Protocol) | Securely connect agents to tools, workflows, and data sources  |
+| Agent ↔ Agent        | **A2A** (Agent to Agent)         | Coordinate work across distributed agents                      |
+| **Agent ↔ User**     | **AG-UI**                        | Stream events between an agent runtime and the user-facing app |
+
+A single agent often uses all three. AG-UI is built by CopilotKit in partnership
+with LangGraph and CrewAI.
+
+### Design principles
+
+- **Event-driven** — every interaction is a stream of typed, discriminated
+  events (see [Event categories](#event-categories)).
+- **Transport-agnostic** — events flow over SSE, WebSockets, HTTP binary
+  (protobuf), or anything else. AG-UI does not mandate a transport.
+- **Framework-agnostic** — any backend (LangGraph, CrewAI, Mastra, custom) can
+  emit AG-UI events; any frontend can consume them.
+- **Bidirectional shared state** — agent and frontend share a JSON state model
+  via snapshots and JSON-Patch deltas.
+- **Human-in-the-loop is first-class** — agents pause mid-run by ending with
+  an interrupt outcome; clients resume by starting a new run carrying the user's
+  response.
+
+## Core concepts (quick reference)
+
+Most everyday AG-UI questions can be answered from this section without opening
+a reference file. Open `references/` for full schemas, examples, or edge cases.
+
+### Run lifecycle
+
+Every agent interaction is a **run** on a **thread**:
+
+1. Client POSTs a `RunAgentInput` to the agent's HTTP endpoint.
+2. Agent emits `RUN_STARTED { threadId, runId }`.
+3. Agent streams events (text, tool calls, state, reasoning, …).
+4. Agent emits `RUN_FINISHED` or `RUN_ERROR`.
+5. `RUN_FINISHED` carries an optional `outcome`:
+   - omitted → legacy normal completion
+   - `{ type: "success" }` → normal completion
+   - `{ type: "interrupt", interrupts: [...] }` → paused for human input.
+     Client resumes by starting a new run with
+     `RunAgentInput.resume = [{ interruptId, status, payload? }, …]`.
+
+A `parentRunId` on `RUN_STARTED` creates a git-like branching log within the
+same thread (time travel, alternative paths).
+
+### Event categories
+
+| Category                  | Events                                                                                                       |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| Lifecycle                 | `RUN_STARTED`, `RUN_FINISHED`, `RUN_ERROR`, `STEP_STARTED`, `STEP_FINISHED`                                  |
+| Text message              | `TEXT_MESSAGE_START`, `TEXT_MESSAGE_CONTENT`, `TEXT_MESSAGE_END`, `TEXT_MESSAGE_CHUNK`                       |
+| Tool call                 | `TOOL_CALL_START`, `TOOL_CALL_ARGS`, `TOOL_CALL_END`, `TOOL_CALL_RESULT`, `TOOL_CALL_CHUNK`                  |
+| State                     | `STATE_SNAPSHOT`, `STATE_DELTA`, `MESSAGES_SNAPSHOT`                                                         |
+| Activity (in-progress UI) | `ACTIVITY_SNAPSHOT`, `ACTIVITY_DELTA`                                                                        |
+| Reasoning                 | `REASONING_START`, `REASONING_MESSAGE_START/CONTENT/END/CHUNK`, `REASONING_END`, `REASONING_ENCRYPTED_VALUE` |
+| Special                   | `RAW`, `CUSTOM`                                                                                              |
+| Draft                     | `META_EVENT`                                                                                                 |
+| Deprecated (→ v1.0.0)     | `THINKING_*` (replaced by `REASONING_*`)                                                                     |
+
+Two recurring patterns:
+
+- **Start-Content-End** for streaming (text messages, tool calls, reasoning).
+  `*_CHUNK` is a convenience event that auto-opens/closes the surrounding
+  Start/End triad.
+- **Snapshot-Delta** for state. Snapshots replace; deltas mutate via RFC 6902
+  JSON Patch.
+
+### Message roles
+
+`user`, `assistant`, `system`, `tool`, `developer`, `activity`, `reasoning`.
+
+- `user` content may be a plain string or an array of multimodal `InputContent`
+  (text, image, audio, video, document — each with a `source` of `data` or
+  `url`).
+- `assistant` may carry `toolCalls` and optional `encryptedContent` for
+  ZDR-style state continuity.
+- `tool` carries `toolCallId` linking back to the originating tool call, plus
+  optional `error`.
+- `activity` is **frontend-only** — never forwarded to the agent. Use it for
+  progress UI (`activityType: "PLAN" | "SEARCH" | …`, structured `content`).
+- `reasoning` represents agent chain-of-thought. May be encrypted via
+  `encryptedValue`; is round-tripped back to the agent on subsequent turns.
+
+### State
+
+- `STATE_SNAPSHOT { snapshot }` — replace the entire state.
+- `STATE_DELTA { delta }` — apply an array of RFC 6902 JSON Patch operations
+  (`add`, `remove`, `replace`, `move`, `copy`, `test`).
+- `MESSAGES_SNAPSHOT { messages }` — replace the full message history.
+
+The reference implementation uses `fast-json-patch`. On patch failure a client
+may request a fresh snapshot. State must be emitted **before** a
+`RUN_FINISHED` interrupt so resume is mode-agnostic (works for both replay-
+style and checkpoint-style continuations).
+
+### Tools
+
+Tools are **defined by the frontend** and passed in `RunAgentInput.tools`. The
+agent calls them via the `TOOL_CALL_*` event triad; the frontend executes and
+returns a `tool`-role message with the matching `toolCallId`. CopilotKit
+exposes this through React's `useCopilotAction` hook.
+
+### Interrupts (human-in-the-loop)
+
+An `Interrupt` carries `{ id, reason, message?, toolCallId?, responseSchema?,
+expiresAt?, metadata? }`. Core `reason` values: `tool_call`, `input_required`,
+`confirmation`. Frameworks namespace custom reasons as `<framework>:<name>`
+(e.g. `langgraph:database_modification`).
+
+Contract: a single `resume` array must address **every** open interrupt;
+`RunAgentInput` on a thread with pending interrupts must include `resume` or
+the agent emits `RUN_ERROR`. For tool-bound interrupts the agent does **not**
+re-emit `TOOL_CALL_START/ARGS/END` after resume — it emits `TOOL_CALL_RESULT`
+against the original `toolCallId`.
+
+### Reasoning
+
+`REASONING_*` events stream visible reasoning summaries; `REASONING_ENCRYPTED_VALUE`
+attaches an opaque chain-of-thought blob (`subtype: "message" | "tool-call"`)
+that the client stores and forwards back on subsequent turns without
+decrypting. This is the ZDR / `store:false` story.
+
+### Capabilities
+
+Agents may expose `getCapabilities(): Promise<AgentCapabilities>` for
+**discovery, not negotiation**. Ten typed sub-objects: `identity`, `transport`,
+`tools`, `output`, `state`, `multiAgent`, `reasoning`, `multimodal`,
+`execution`, `humanInTheLoop`, plus `custom`. Omitted = unknown, never assumed.
+
+## Implementation paths
+
+When implementing AG-UI, pick the role you're playing:
+
+| Role           | When to use                                                                              | Key abstractions                                                                  |
+| -------------- | ---------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| **Server**     | Building a new agent from scratch; want maximum control over emitted events              | FastAPI/Express endpoint, `EventEncoder`, emit events directly                    |
+| **Middleware** | Adapting an existing framework or protocol (LangGraph, CrewAI, an internal SDK) to AG-UI | Extend `AbstractAgent`, translate framework events to AG-UI events inside `run()` |
+| **Client**     | Building a UI (web, mobile, CLI) that talks to an AG-UI agent                            | `HttpAgent` or `AbstractAgent.subscribe`, handle the event stream                 |
+
+Both server and middleware implementations expose the same HTTP contract:
+POST `RunAgentInput`, return an SSE (or binary) stream of `BaseEvent` objects.
+
+## SDKs at a glance
+
+| Language                                        | Package(s)                                                       | Status      | Install                        |
+| ----------------------------------------------- | ---------------------------------------------------------------- | ----------- | ------------------------------ |
+| TypeScript / JavaScript                         | `@ag-ui/core`, `@ag-ui/client`, `@ag-ui/encoder`, `@ag-ui/proto` | 1st-party   | `npm install @ag-ui/client`    |
+| Python                                          | `ag-ui-protocol` (`ag_ui.core`, `ag_ui.encoder`)                 | 1st-party   | `pip install ag-ui-protocol`   |
+| Rust                                            | `ag-ui-client` crate                                             | Community   | `cargo add ag-ui-client`       |
+| Java, Kotlin, Go, Dart, Ruby                    | various                                                          | Community   | see upstream `sdks/community/` |
+| .NET, Nim, Flowise, Langflow, Cloudflare Agents | —                                                                | In progress | tracked as upstream issues     |
+
+Quick start: `npx create-ag-ui-app@latest` scaffolds a project.
+
+## Routing table — which reference file do I open?
+
+There are 17 reference files in `references/`. Open the ones below based on the
+question. Always prefer the most specific file.
+
+### Concepts (`references/concepts/`)
+
+| Question                                                                                                                        | File                              |
+| ------------------------------------------------------------------------------------------------------------------------------- | --------------------------------- |
+| Full event schema, properties of every event type, draft/deprecated events                                                      | `concepts/events.md`              |
+| Architecture overview, transport patterns, middleware layer                                                                     | `concepts/architecture.md`        |
+| `AbstractAgent` shape, agent capabilities (high-level), agent lifecycle                                                         | `concepts/agents.md`              |
+| Message schemas (User/Assistant/System/Tool/Activity/Developer/Reasoning), multimodal input, vendor-neutrality                  | `concepts/messages.md`            |
+| `STATE_SNAPSHOT` vs `STATE_DELTA`, RFC 6902 JSON Patch examples, CopilotKit `useCoAgent`                                        | `concepts/state.md`               |
+| Tool schema, frontend-defined tools, tool-call lifecycle, `useCopilotAction`                                                    | `concepts/tools.md`               |
+| Interrupt-aware run lifecycle, `Interrupt` type, `resume` rules, tool-bound interrupts, approve-with-edits, parallel interrupts | `concepts/interrupts.md`          |
+| Reasoning events, encrypted chain-of-thought, ZDR/store:false, migration from `THINKING_*`                                      | `concepts/reasoning.md`           |
+| `AgentCapabilities` and all ten typed sub-objects                                                                               | `concepts/capabilities.md`        |
+| Middleware pipeline mechanics (`use`, `MiddlewareFunction`, `Middleware` class), built-in `FilterToolCallsMiddleware`           | `concepts/middleware.md`          |
+| Stream compaction, branching with `parentRunId`, normalized input                                                               | `concepts/serialization.md`       |
+| Generative-UI specs (A2UI/Google, Open-JSON-UI/OpenAI, MCP-UI/Microsoft+Shopify); AG-UI is the runtime, not a gen-UI spec       | `concepts/generative-ui-specs.md` |
+
+### Quickstart (`references/quickstart/`)
+
+| Question                                                                       | File                       |
+| ------------------------------------------------------------------------------ | -------------------------- |
+| Building a Python/FastAPI AG-UI endpoint from scratch (OpenAI example)         | `quickstart/server.md`     |
+| Building a JS/TS adapter that wraps an existing framework                      | `quickstart/middleware.md` |
+| Building a client (CLI/web) that consumes AG-UI events; Mastra + tools example | `quickstart/client.md`     |
+
+### SDKs (`references/sdks/`)
+
+| Question                                                                                                                                                    | File                 |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------- |
+| TypeScript: `@ag-ui/client` (`AbstractAgent`, `HttpAgent`, middleware, `AgentSubscriber`), `@ag-ui/core` types and events, `@ag-ui/encoder`, `@ag-ui/proto` | `sdks/typescript.md` |
+| Python: `ag_ui.core` types/events, `ag_ui.encoder.EventEncoder`, FastAPI/SSE patterns, multimodal input                                                     | `sdks/python.md`     |
+| Rust, Java, Kotlin, Go, Dart, Ruby — install hints and pointers into the upstream repo                                                                      | `sdks/others.md`     |
+
+### Integrations (`references/`)
+
+| Question                                                                                                                                                                                                                                                              | File              |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
+| Which agent frameworks support AG-UI (LangGraph, CrewAI, Mastra, Microsoft Agent Framework, Google ADK, AWS Strands, Bedrock AgentCore, Pydantic AI, Agno, LlamaIndex, AG2), which clients (CopilotKit), which related specs (A2A, MCP Apps, A2UI, Oracle Agent Spec) | `integrations.md` |
+
+## Source
+
+All references in this skill are distilled from the upstream AG-UI documentation
+at `submodules/ag-ui/docs/` (102 MDX files, snapshotted at the submodule's
+current commit). When the user needs the absolute latest text — release notes,
+draft specs, brand-new integrations — check the submodule directly or
+[github.com/ag-ui-protocol/ag-ui](https://github.com/ag-ui-protocol/ag-ui).
+Each reference file cites its upstream path at the top so you can verify or
+expand from there.

--- a/.agents/skills/ag-ui-knowledge/references/concepts/agents.md
+++ b/.agents/skills/ag-ui-knowledge/references/concepts/agents.md
@@ -1,0 +1,195 @@
+# Agents
+
+Source: `submodules/ag-ui/docs/concepts/agents.mdx`
+
+The agent abstraction in AG-UI. Open this file for the `AbstractAgent` lifecycle,
+configuration shape, and the common implementation patterns.
+
+## What an agent is
+
+An AG-UI agent is a class that:
+
+1. Manages conversation state and message history.
+2. Processes incoming messages and context.
+3. Generates responses through an event-driven streaming interface.
+4. Follows the AG-UI protocol for communication.
+
+Backends behind an agent can be anything: an LLM (GPT-4o, Claude), a RAG
+system, a multi-agent orchestrator, or a custom service.
+
+## Base class — `AbstractAgent`
+
+All agents extend `AbstractAgent` (from `@ag-ui/client` in TypeScript). It
+provides state management, message-history tracking, event-stream processing,
+and tool wiring; subclasses implement `run()`.
+
+```typescript
+import { AbstractAgent } from "@ag-ui/client"
+
+class MyAgent extends AbstractAgent {
+  run(input: RunAgentInput): RunAgent {
+    // emit events
+  }
+}
+```
+
+### Components every agent has
+
+| Component | Purpose |
+| --- | --- |
+| **Configuration** | `agentId`, `threadId`, `initialMessages`, `initialState` |
+| **Messages** | Conversation history (`user`, `assistant`, `system`, `tool`, `developer`, `activity`, `reasoning`) |
+| **State** | Structured JSON that persists across interactions, shared with the frontend |
+| **Events** | Standardized stream emitted by `run()` |
+| **Tools** | Functions defined by the frontend and passed in `RunAgentInput.tools` |
+
+## Built-in implementations
+
+### `AbstractAgent`
+
+Base class to extend for custom agents.
+
+### `HttpAgent`
+
+Concrete subclass that connects to an HTTP endpoint:
+
+```typescript
+import { HttpAgent } from "@ag-ui/client"
+
+const agent = new HttpAgent({
+  url: "https://your-agent-endpoint.com/agent",
+  headers: { Authorization: "Bearer your-api-key" },
+})
+```
+
+See `references/sdks/typescript.md` for the full `HttpAgent` API.
+
+### Custom agents
+
+Extend `AbstractAgent`; implement `run(input)`. Pattern below.
+
+## Minimal `run()` implementation (TypeScript)
+
+```typescript
+import {
+  AbstractAgent,
+  RunAgent,
+  RunAgentInput,
+  EventType,
+  BaseEvent,
+} from "@ag-ui/client"
+import { Observable } from "rxjs"
+
+class SimpleAgent extends AbstractAgent {
+  run(input: RunAgentInput): RunAgent {
+    const { threadId, runId } = input
+
+    return () =>
+      new Observable<BaseEvent>((observer) => {
+        observer.next({ type: EventType.RUN_STARTED, threadId, runId })
+
+        const messageId = Date.now().toString()
+        observer.next({ type: EventType.TEXT_MESSAGE_START, messageId, role: "assistant" })
+        observer.next({ type: EventType.TEXT_MESSAGE_CONTENT, messageId, delta: "Hello, world!" })
+        observer.next({ type: EventType.TEXT_MESSAGE_END, messageId })
+
+        observer.next({ type: EventType.RUN_FINISHED, threadId, runId })
+        observer.complete()
+      })
+  }
+}
+```
+
+## Configuration
+
+```typescript
+interface AgentConfig {
+  agentId?: string         // unique identifier
+  description?: string     // human-readable description (also used by the LLM)
+  threadId?: string        // conversation thread
+  initialMessages?: Message[]
+  initialState?: State
+}
+
+const agent = new HttpAgent({
+  agentId: "my-agent-123",
+  description: "A helpful assistant",
+  threadId: "thread-456",
+  initialMessages: [{ id: "1", role: "system", content: "You are a helpful assistant." }],
+  initialState: { preferredLanguage: "English" },
+})
+```
+
+To add custom config to a subclass, extend `AgentConfig` and call `super(config)`:
+
+```typescript
+interface MyAgentConfig extends AgentConfig {
+  myConfigOption: string
+}
+
+class MyAgent extends AbstractAgent {
+  private myConfigOption: string
+  constructor(config: MyAgentConfig) {
+    super(config)
+    this.myConfigOption = config.myConfigOption
+  }
+}
+```
+
+## Capabilities at a glance
+
+Agents in AG-UI can support:
+
+- **Streaming responses** — token-by-token via the `TEXT_MESSAGE_*` triad.
+- **Tool use** — frontend-defined tools passed in `RunAgentInput.tools`; the
+  agent calls them via `TOOL_CALL_*` events.
+- **Shared state** — `STATE_SNAPSHOT` / `STATE_DELTA` events; client and agent
+  both read and update it.
+- **Multi-agent collaboration** — handoffs and delegation, with state and
+  context flowing across agents.
+- **Human-in-the-loop** — interrupt-aware run lifecycle (see `interrupts.md`).
+- **Conversational memory** — `agent.messages` is the canonical history.
+- **Metadata/instrumentation** — emit reasoning events, custom events for
+  metrics, etc.
+
+## Using an agent
+
+```typescript
+const agent = new HttpAgent({ url: "https://your-agent-endpoint.com/agent" })
+
+agent.messages = [{ id: "1", role: "user", content: "Hello, how can you help?" }]
+
+agent.runAgent({ runId: "run_123", tools: [], context: [] }).subscribe({
+  next: (event) => {
+    if (event.type === EventType.TEXT_MESSAGE_CONTENT) {
+      console.log("Content:", event.delta)
+    }
+  },
+  error: (e) => console.error(e),
+  complete: () => console.log("done"),
+})
+```
+
+State and messages are exposed as live properties on the agent instance
+(`agent.state`, `agent.messages`). `agent.clone()` deep-copies the agent with
+its current state.
+
+## When you write a custom agent
+
+- Emit `RUN_STARTED` first and exactly one terminal event (`RUN_FINISHED` or
+  `RUN_ERROR`).
+- Emit any state required for resume **before** a `RUN_FINISHED` with an
+  interrupt outcome (see `interrupts.md`).
+- Use `*_CHUNK` events (`TEXT_MESSAGE_CHUNK`, `TOOL_CALL_CHUNK`) for the
+  simplest streaming code — they auto-open/close their triads.
+- For long-running runs, emit `STEP_STARTED`/`STEP_FINISHED` around each phase
+  so the UI can show progress.
+
+## See also
+
+- `events.md` — every event the agent can emit
+- `messages.md` — message schema and roles
+- `state.md` — shared-state mechanics
+- `tools.md` — frontend-defined tool flow
+- `interrupts.md` — human-in-the-loop lifecycle
+- `references/sdks/typescript.md` — concrete `AbstractAgent`/`HttpAgent` API

--- a/.agents/skills/ag-ui-knowledge/references/concepts/architecture.md
+++ b/.agents/skills/ag-ui-knowledge/references/concepts/architecture.md
@@ -1,0 +1,135 @@
+# Architecture
+
+Source: `submodules/ag-ui/docs/concepts/architecture.mdx`
+
+AG-UI's design rationale and component model. Open this file when reasoning
+about transport choices, where middleware sits, or how the moving pieces fit
+together.
+
+## Design principles
+
+1. **Event-driven communication.** Agents emit any of ~16 standardized event
+   types during execution, creating a stream the client processes.
+2. **Bidirectional interaction.** Agents accept user input through tools,
+   interrupts, and shared state — collaboration, not one-shot RPC.
+3. **Built-in middleware layer.** Two consequences:
+   - **Flexible event structure.** Events don't need to match AG-UI's wire
+     format exactly — just be AG-UI-compatible. Existing frameworks can adapt
+     their native events with minimal effort.
+   - **Transport agnostic.** AG-UI doesn't mandate how events are delivered
+     (SSE, WebSockets, webhooks, HTTP binary, anything else).
+
+This pragmatism is why AG-UI integrates with so many agent frameworks without
+forcing rewrites.
+
+## Architectural overview
+
+```text
+┌────────────── Frontend ──────────────┐      ┌─────── Backend ────────┐
+│                                      │      │                        │
+│   Application  <───►  AG-UI Client   │◄────►│   AI Agent A           │
+│                                      │      │                        │
+└──────────────────────────────────────┘  ┌──►│   Secure Proxy ───► AI Agent B
+                                          │   │                  └── AI Agent C
+                                          │   └────────────────────────┘
+                                          │
+                                          │ (proxies AG-UI for multiple agents)
+```
+
+- **Application** — user-facing app (chat, copilot, custom UI).
+- **AG-UI Client** — `HttpAgent` or a specialized client for a sister protocol.
+- **Agent** — backend AI agent processing requests and emitting events.
+- **Secure proxy** — optional layer that fronts multiple agents and adds
+  cross-cutting concerns (auth, rate limiting, multi-tenant routing).
+
+## Core abstractions
+
+### Protocol layer
+
+The single contract:
+
+```typescript
+type RunAgent = () => Observable<BaseEvent>
+
+class MyAgent extends AbstractAgent {
+  run(input: RunAgentInput): RunAgent {
+    return () =>
+      from([
+        { type: EventType.RUN_STARTED, threadId: input.threadId, runId: input.runId },
+        { type: EventType.MESSAGES_SNAPSHOT, messages: [{ id: "msg_1", role: "assistant", content: "Hello, world!" }] },
+        { type: EventType.RUN_FINISHED, threadId: input.threadId, runId: input.runId },
+      ])
+  }
+}
+```
+
+Implementing `run(input: RunAgentInput) -> Observable<BaseEvent>` (or its
+language equivalent) is the entire surface area.
+
+### Standard HTTP client (`HttpAgent`)
+
+Connects to any endpoint that:
+
+- Accepts a POST with body `RunAgentInput`.
+- Returns a stream of `BaseEvent`.
+
+Supports two transports out of the box:
+
+- **HTTP SSE** — text-based, debuggable, broadly compatible.
+- **HTTP binary** — protobuf-encoded for performance.
+
+### Message types
+
+Five families (see `events.md` for the full per-event table):
+
+- Lifecycle: `RUN_STARTED`, `RUN_FINISHED`, `RUN_ERROR`, `STEP_STARTED`, `STEP_FINISHED`
+- Text: `TEXT_MESSAGE_START`, `TEXT_MESSAGE_CONTENT`, `TEXT_MESSAGE_END`
+- Tool call: `TOOL_CALL_START`, `TOOL_CALL_ARGS`, `TOOL_CALL_END`
+- State: `STATE_SNAPSHOT`, `STATE_DELTA`, `MESSAGES_SNAPSHOT`
+- Special: `RAW`, `CUSTOM`
+
+## Running agents (TypeScript)
+
+```typescript
+const agent = new HttpAgent({
+  url: "https://your-agent-endpoint.com/agent",
+  agentId: "unique-agent-id",
+  threadId: "conversation-thread",
+})
+
+agent.runAgent({
+  tools: [...],
+  context: [...],
+}).subscribe({
+  next: (event) => {
+    switch (event.type) {
+      case EventType.TEXT_MESSAGE_CONTENT:
+        // append event.delta to UI
+        break
+      // …
+    }
+  },
+  error: (err) => console.error(err),
+  complete: () => console.log("done"),
+})
+```
+
+## Key architectural decisions worth remembering
+
+- **All events inherit `BaseEvent`** — `{ type, timestamp?, rawEvent? }`. Lets
+  middleware tag, transform, or wrap events without changing core code.
+- **State uses snapshot + JSON Patch deltas.** Optimizes both completeness
+  (snapshots) and efficiency (deltas).
+- **Tool calls are streamed.** The `TOOL_CALL_*` triad lets the UI show the
+  agent constructing arguments in real time, not just the finished call.
+- **The protocol layer doesn't know about transports.** SSE is the most common
+  but not privileged. A WebSocket-based AG-UI agent is still an AG-UI agent.
+- **No mandatory negotiation.** Capability discovery is one-way (see
+  `capabilities.md`); the agent declares, the client adapts.
+
+## See also
+
+- `events.md` — full event reference
+- `agents.md` — `AbstractAgent` / `HttpAgent` shape
+- `middleware.md` — pipeline mechanics
+- `serialization.md` — compaction, branching, lineage

--- a/.agents/skills/ag-ui-knowledge/references/concepts/capabilities.md
+++ b/.agents/skills/ag-ui-knowledge/references/concepts/capabilities.md
@@ -1,0 +1,207 @@
+# Capabilities
+
+Source: `submodules/ag-ui/docs/concepts/capabilities.mdx`
+
+Dynamic capability discovery. Open this file to look up the typed sub-objects
+on `AgentCapabilities` or to remember the discovery-not-negotiation contract.
+
+## How discovery works
+
+`AbstractAgent` exposes an optional `getCapabilities(): Promise<AgentCapabilities>`
+that returns a live typed snapshot of what the agent supports.
+
+```typescript
+const agent = new HttpAgent({ url: "https://my-agent.example.com/api" })
+const capabilities = await agent.getCapabilities?.()
+
+if (capabilities?.tools?.supported) {
+  console.log(`Agent provides ${capabilities.tools.items?.length} tools`)
+}
+
+if (capabilities?.reasoning?.supported) {
+  showReasoningPanel()
+}
+```
+
+### Contract
+
+- **Discovery only** — the agent declares; there is no negotiation.
+- **Dynamic** — reflects current state (e.g. tools registered after the agent
+  was created appear on the next call).
+- **Optional** — agents that don't implement it return `undefined`.
+- **Absent = unknown** — only declare what you support; omitted fields mean
+  the capability is undeclared, not "not supported".
+
+## The `AgentCapabilities` interface
+
+```typescript
+interface AgentCapabilities {
+  identity?:       IdentityCapabilities
+  transport?:      TransportCapabilities
+  tools?:          ToolsCapabilities
+  output?:         OutputCapabilities
+  state?:          StateCapabilities
+  multiAgent?:     MultiAgentCapabilities
+  reasoning?:      ReasoningCapabilities
+  multimodal?:     MultimodalCapabilities
+  execution?:      ExecutionCapabilities
+  humanInTheLoop?: HumanInTheLoopCapabilities
+  custom?:         Record<string, unknown>  // escape hatch
+}
+```
+
+## Sub-object reference
+
+### `identity`
+
+| Field | Notes |
+| --- | --- |
+| `name?` | Display name |
+| `type?` | Framework/platform (`"langgraph"`, `"mastra"`, `"crewai"`) |
+| `description?` | What this agent does — helps users and routing pick |
+| `version?` | Semver of the agent |
+| `provider?` | Maintaining org or team |
+| `documentationUrl?` | Docs/homepage URL |
+| `metadata?` | Free-form key/value |
+
+### `transport`
+
+Set `true` only for transports you actually support.
+
+| Field | Meaning |
+| --- | --- |
+| `streaming?` | Streams responses via SSE |
+| `websocket?` | Accepts persistent WebSocket connections |
+| `httpBinary?` | Supports the AG-UI binary protocol (protobuf over HTTP) |
+| `pushNotifications?` | Can send async updates via webhooks after a run finishes |
+| `resumable?` | Supports resuming interrupted streams via sequence numbers |
+
+### `tools`
+
+| Field | Meaning |
+| --- | --- |
+| `supported?` | Whether the agent can make tool calls at all |
+| `items?` | Tools this agent provides (full JSON Schema), distinct from client-provided tools in `RunAgentInput.tools` |
+| `parallelCalls?` | Can invoke multiple tools concurrently within a single step |
+| `clientProvided?` | Accepts and uses client-provided tools at runtime |
+
+### `output`
+
+| Field | Meaning |
+| --- | --- |
+| `structuredOutput?` | Can produce structured JSON conforming to a schema |
+| `supportedMimeTypes?` | MIME types the agent can produce |
+
+### `state`
+
+| Field | Meaning |
+| --- | --- |
+| `snapshots?` | Emits `STATE_SNAPSHOT` events |
+| `deltas?` | Emits `STATE_DELTA` events |
+| `memory?` | Has long-term memory beyond the current thread |
+| `persistentState?` | State preserved across multiple runs within the same thread |
+
+### `multiAgent`
+
+| Field | Meaning |
+| --- | --- |
+| `supported?` | Participates in any multi-agent coordination |
+| `delegation?` | Can delegate subtasks while retaining control |
+| `handoffs?` | Can transfer the conversation entirely to another agent |
+| `subAgents?` | `Array<{ name: string; description?: string }>` |
+
+### `reasoning`
+
+| Field | Meaning |
+| --- | --- |
+| `supported?` | Produces visible reasoning tokens |
+| `streaming?` | Reasoning streamed incrementally vs. returned all at once |
+| `encrypted?` | Reasoning content is encrypted (ZDR mode); expect opaque `encryptedValue` |
+
+### `multimodal`
+
+```typescript
+interface MultimodalCapabilities {
+  input?:  { image?: boolean; audio?: boolean; video?: boolean; pdf?: boolean; file?: boolean }
+  output?: { image?: boolean; audio?: boolean }
+}
+```
+
+Drives UI affordances (file pickers, audio recorders, image uploads).
+
+### `execution`
+
+| Field | Meaning |
+| --- | --- |
+| `codeExecution?` | Can execute code during a run |
+| `sandboxed?` | Code execution is sandboxed (only meaningful with `codeExecution`) |
+| `maxIterations?` | Max tool-call / reasoning iterations per run |
+| `maxExecutionTime?` | Max wall-clock time per run (ms) |
+
+### `humanInTheLoop`
+
+| Field | Meaning |
+| --- | --- |
+| `supported?` | Any HITL interaction |
+| `approvals?` | Can pause for explicit approval (e.g. sending emails) |
+| `interventions?` | Allows humans to modify the plan mid-execution |
+| `feedback?` | Incorporates thumbs up/down / corrections in-session |
+| `interrupts?` | Participates in the AG-UI interrupt protocol (`RunFinished` + `outcome.interrupts`, `RunAgentInput.resume`) |
+| `approveWithEdits?` | Tool-call interrupts accept `editedArgs` in resume payload (only meaningful with `interrupts`) |
+
+See `interrupts.md` for the full interrupt protocol.
+
+### `custom`
+
+Escape hatch for integration-specific capabilities not covered by the
+standard categories.
+
+```typescript
+const capabilities = await agent.getCapabilities?.()
+const rateLimit = capabilities?.custom?.rateLimit as { maxRequestsPerMinute: number } | undefined
+if (rateLimit) configureThrottling(rateLimit.maxRequestsPerMinute)
+```
+
+## Implementing `getCapabilities()`
+
+```typescript
+import { AbstractAgent, AgentCapabilities } from "@ag-ui/client"
+
+class MyAgent extends AbstractAgent {
+  async getCapabilities(): Promise<AgentCapabilities> {
+    return {
+      identity:  { name: "my-agent", description: "Custom agent with tool support", version: "1.0.0" },
+      transport: { streaming: true },
+      tools:     { supported: true, items: this.getRegisteredTools(), clientProvided: true },
+      state:     { snapshots: true, deltas: true },
+    }
+  }
+}
+```
+
+Capabilities are a live snapshot — register a new tool, the next
+`getCapabilities()` call reflects it.
+
+## Client usage patterns
+
+### Adaptive UI
+
+```typescript
+const capabilities = await agent.getCapabilities?.()
+if (capabilities?.reasoning?.supported)        showReasoningPanel()
+if (capabilities?.multiAgent?.subAgents?.length) showSubAgentSelector(capabilities.multiAgent.subAgents)
+if (capabilities?.humanInTheLoop?.approvals)   enableApprovalWorkflow()
+```
+
+### Feature gating
+
+```typescript
+const canUseStructuredOutput = capabilities?.output?.structuredOutput ?? false
+const canStream             = capabilities?.transport?.streaming ?? false
+```
+
+## See also
+
+- `agents.md` — where `getCapabilities()` lives on `AbstractAgent`
+- `interrupts.md` — `humanInTheLoop.interrupts` and `approveWithEdits` semantics
+- `events.md` — events governed by the transport/state/reasoning categories

--- a/.agents/skills/ag-ui-knowledge/references/concepts/events.md
+++ b/.agents/skills/ag-ui-knowledge/references/concepts/events.md
@@ -1,0 +1,194 @@
+# Events
+
+Source: `submodules/ag-ui/docs/concepts/events.mdx`
+
+The full event taxonomy. AG-UI is event-based — every interaction between an
+agent and a frontend is a stream of typed, discriminated events. Open this file
+when you need exact field names, property tables, or to confirm event ordering.
+
+## Base shape
+
+Every event inherits from `BaseEvent`:
+
+```typescript
+interface BaseEvent {
+  type: EventType   // discriminator (e.g. "RUN_STARTED")
+  timestamp?: number
+  rawEvent?: any    // original event when transformed from another protocol
+}
+```
+
+Two recurring patterns:
+
+- **Start-Content-End** — streaming content (text messages, tool calls,
+  reasoning). A `*_CHUNK` convenience event auto-opens/closes the triad.
+- **Snapshot-Delta** — state synchronization. Snapshot replaces; delta mutates
+  via RFC 6902 JSON Patch.
+
+Events with the same correlation ID (`messageId`, `toolCallId`) belong to one
+logical stream and should be processed in order received.
+
+## Lifecycle
+
+`RUN_STARTED` and exactly one terminal event (`RUN_FINISHED` or `RUN_ERROR`)
+bound a run. `STEP_STARTED`/`STEP_FINISHED` pairs are optional but recommended
+for observability.
+
+```text
+RunStarted → [StepStarted/StepFinished]* → (RunFinished | RunError)
+```
+
+### RunStarted
+
+| Field | Notes |
+| --- | --- |
+| `threadId` | Conversation thread id |
+| `runId` | This run's id |
+| `parentRunId?` | Lineage pointer for branching / time travel within the thread |
+| `input?` | Exact `RunAgentInput` for this run (may omit messages already in history) |
+
+### RunFinished
+
+| Field | Notes |
+| --- | --- |
+| `threadId`, `runId` | required |
+| `result?` | Free-form completion payload (root for back-compat) |
+| `outcome?` | Discriminated union: `{ type: "success" }` or `{ type: "interrupt", interrupts: Interrupt[] }`. Omitted = legacy normal completion |
+
+When `outcome.type === "interrupt"`, the run paused; the client must start a
+new run with `RunAgentInput.resume` addressing every interrupt id. See
+`interrupts.md`.
+
+### RunError
+
+| Field | Notes |
+| --- | --- |
+| `message` | Human-readable error message |
+| `code?` | Optional error code |
+
+Terminal — no further events for this run.
+
+### StepStarted / StepFinished
+
+Both carry `{ stepName }`. Step names must match across the pair. Stepping
+isn't mandatory but enables progress UIs.
+
+## Text messages
+
+```text
+TextMessageStart → TextMessageContent* → TextMessageEnd
+```
+
+| Event | Fields |
+| --- | --- |
+| `TextMessageStart` | `messageId`, `role` (`developer` \| `system` \| `assistant` \| `user` \| `tool`) |
+| `TextMessageContent` | `messageId`, `delta` (non-empty text chunk) |
+| `TextMessageEnd` | `messageId` |
+| `TextMessageChunk` | `messageId?`, `role?`, `delta?` — first chunk must include `messageId`; role defaults to `assistant`. Stream transformer expands chunks into the Start/Content/End triad. End is emitted automatically when the stream switches to a new message id or completes. |
+
+Concatenate deltas in receipt order to reconstruct the full message.
+
+## Tool calls
+
+```text
+ToolCallStart → ToolCallArgs* → ToolCallEnd → (later) ToolCallResult
+```
+
+| Event | Fields |
+| --- | --- |
+| `ToolCallStart` | `toolCallId`, `toolCallName`, `parentMessageId?` |
+| `ToolCallArgs` | `toolCallId`, `delta` (JSON fragment) |
+| `ToolCallEnd` | `toolCallId` |
+| `ToolCallResult` | `messageId`, `toolCallId`, `content`, `role?` (typically `"tool"`) |
+| `ToolCallChunk` | `toolCallId?`, `toolCallName?`, `parentMessageId?`, `delta?` — first chunk must include `toolCallId` + `toolCallName` |
+
+The `delta` deltas concatenate into a JSON-encoded arguments object.
+`ToolCallResult` is sent as a complete unit (not streamed).
+
+## State management
+
+```text
+StateSnapshot → StateDelta* → (occasional) StateSnapshot → StateDelta* → MessagesSnapshot
+```
+
+| Event | Fields |
+| --- | --- |
+| `StateSnapshot` | `snapshot` (complete state object — replace, don't merge) |
+| `StateDelta` | `delta` (`JsonPatchOperation[]`, RFC 6902) |
+| `MessagesSnapshot` | `messages` (full conversation history) |
+
+JSON Patch operations: `add`, `remove`, `replace`, `move`, `copy`, `test`,
+each with `path` (RFC 6901 JSON Pointer) and `value`/`from` as needed.
+
+On patch failure, request a fresh snapshot rather than guessing. The reference
+implementation uses the `fast-json-patch` library and applies patches without
+mutating the original document.
+
+## Activity events
+
+Structured, in-progress UI updates between chat messages. **Frontend-only**:
+never round-tripped to the agent. Follow the snapshot/delta pattern.
+
+| Event | Fields |
+| --- | --- |
+| `ActivitySnapshot` | `messageId`, `activityType` (e.g. `"PLAN"`, `"SEARCH"`), `content` (structured JSON), `replace?` (default `true`; if `false`, skip when the message already exists) |
+| `ActivityDelta` | `messageId`, `activityType`, `patch` (RFC 6902 ops to apply to the activity content) |
+
+Use to render checklists, search-in-progress UI, multi-step plan trackers.
+
+## Reasoning
+
+Surface LLM chain-of-thought while supporting privacy/ZDR. See `reasoning.md`
+for the full story.
+
+```text
+ReasoningStart → ReasoningMessageStart → ReasoningMessageContent* → ReasoningMessageEnd → (optional) ReasoningEncryptedValue → ReasoningEnd
+```
+
+| Event | Fields |
+| --- | --- |
+| `ReasoningStart` | `messageId` |
+| `ReasoningMessageStart` | `messageId`, `role` (`"reasoning"`) |
+| `ReasoningMessageContent` | `messageId`, `delta` |
+| `ReasoningMessageEnd` | `messageId` |
+| `ReasoningMessageChunk` | `messageId`, `delta` — empty delta closes the message |
+| `ReasoningEnd` | `messageId` |
+| `ReasoningEncryptedValue` | `subtype` (`"message"` \| `"tool-call"`), `entityId`, `encryptedValue` (opaque blob the client stores and forwards back unchanged) |
+
+## Special events
+
+| Event | Fields | Purpose |
+| --- | --- | --- |
+| `Raw` | `event` (original payload), `source?` | Pass through events from external systems |
+| `Custom` | `name`, `value` | Application-specific events not covered by the standard set |
+
+Use `Custom` (not `Raw`) for app extensions you control — `Raw` is a passthrough
+container for interop.
+
+## Draft events
+
+### MetaEvent
+
+Side-band annotations independent of agent runs (e.g. `"thumbs_up"`, `"tag"`).
+Fields: `metaType`, `payload`. Draft — may change before finalization.
+
+## Deprecated (removed in v1.0.0)
+
+`THINKING_*` events are deprecated. Map to `REASONING_*`:
+
+| Deprecated | Replacement |
+| --- | --- |
+| `THINKING_START` | `REASONING_START` |
+| `THINKING_END` | `REASONING_END` |
+| `THINKING_TEXT_MESSAGE_START` | `REASONING_MESSAGE_START` |
+| `THINKING_TEXT_MESSAGE_CONTENT` | `REASONING_MESSAGE_CONTENT` |
+| `THINKING_TEXT_MESSAGE_END` | `REASONING_MESSAGE_END` |
+
+## Implementation notes
+
+- Process events in receipt order.
+- Be resilient to out-of-order delivery on flaky transports; correlate by id.
+- Custom events should follow Start/Content/End or Snapshot/Delta patterns for
+  consistency.
+- `parentRunId` on `RunStarted` creates a git-like append-only log for
+  branching/time travel.

--- a/.agents/skills/ag-ui-knowledge/references/concepts/generative-ui-specs.md
+++ b/.agents/skills/ag-ui-knowledge/references/concepts/generative-ui-specs.md
@@ -1,0 +1,44 @@
+# Generative UI Specs
+
+Source: `submodules/ag-ui/docs/concepts/generative-ui-specs.mdx`
+
+AG-UI's relationship to the generative-UI specifications. Open this file when
+someone asks how AG-UI compares to A2UI, Open-JSON-UI, or MCP-UI, or whether
+AG-UI is itself a generative-UI spec (it is not).
+
+## AG-UI is not a generative-UI spec
+
+AG-UI is a **User Interaction protocol** that provides the **bidirectional
+runtime connection** between the agent and the application. It does **not**
+define how UI components are structured or serialized.
+
+The distinction:
+
+- Generative-UI specs define *how* UI components are structured and transmitted.
+- AG-UI defines the *two-way communication mechanism* that makes agent ↔ user
+  interaction possible — the runtime that carries those components.
+
+AG-UI **natively supports all three** major generative-UI specs below, and also
+lets developers implement their own custom generative-UI standards.
+
+## The three major specs
+
+| Spec | Author(s) | Description |
+| ---- | --------- | ----------- |
+| **A2UI** | Google | A declarative, LLM-friendly generative-UI spec. JSONL-based and streaming, designed for platform-agnostic rendering. Lets agents deliver dynamic interface components alongside text responses. |
+| **Open-JSON-UI** | OpenAI | An open standardization of OpenAI's internal declarative generative-UI schema, bringing their proprietary approach to a publicly available format. |
+| **MCP-UI** | Microsoft + Shopify | A fully open, iframe-based generative-UI standard that extends MCP for user-facing experiences. |
+
+## Key points
+
+- **A2UI = Google**, **Open-JSON-UI = OpenAI**, **MCP-UI = Microsoft + Shopify**.
+  Keep these attributions precise.
+- AG-UI is complementary to all three, not a competitor or alternative.
+- Because AG-UI is transport- and payload-agnostic at the application layer, a
+  generative-UI payload (A2UI, Open-JSON-UI, MCP-UI, or custom) rides over AG-UI
+  events without AG-UI needing to understand the payload format.
+
+## See also
+
+- `../integrations.md` — protocol landscape, sister specs, generative-UI table
+- `architecture.md` — why AG-UI is transport- and payload-agnostic

--- a/.agents/skills/ag-ui-knowledge/references/concepts/interrupts.md
+++ b/.agents/skills/ag-ui-knowledge/references/concepts/interrupts.md
@@ -1,0 +1,308 @@
+# Interrupts
+
+Source: `submodules/ag-ui/docs/concepts/interrupts.mdx`
+
+The interrupt-aware run lifecycle for human-in-the-loop pauses. Open this file
+for the `Interrupt` type, contract rules, error handling, the reason taxonomy,
+and worked examples (approve, approve-with-edits, parallel, non-tool input).
+
+## Core idea
+
+Agents sometimes need to pause: to get human approval before a sensitive
+action, to request structured input, to wait on an out-of-band policy decision.
+AG-UI exposes this as a **terminal model** — the run ends with an interrupt
+outcome, and the client starts a **new run** that carries per-interrupt
+responses.
+
+This is intentionally simple: no separate `PAUSE`/`RESUME` events, no mid-run
+state-machine. A run either succeeds, errors, or terminates with an interrupt;
+resuming is just another `RunStarted`.
+
+## Lifecycle
+
+```text
+Agent emits state/messages required for resume
+      ↓
+Agent emits RunFinished { outcome: { type: "interrupt", interrupts: [...] } }
+      ↓
+User resolves the interrupts in the UI
+      ↓
+Client posts RunAgentInput { threadId, resume: [{ interruptId, status, payload? }, ...] }
+      ↓
+Agent emits RunStarted (new runId), continues, emits ToolCallResult (for tool-bound
+interrupts), emits RunFinished { outcome: { type: "success" } }
+```
+
+## Run outcomes (revisited)
+
+`RunFinished` carries an optional `outcome` field — a discriminated union:
+
+```typescript
+type RunFinishedOutcome =
+  | { type: "success" }
+  | { type: "interrupt"; interrupts: Interrupt[] }
+
+type RunFinishedEvent = {
+  type: "RUN_FINISHED"
+  threadId: string
+  runId: string
+  result?: unknown        // root-level for back-compat with legacy producers
+  outcome?: RunFinishedOutcome
+}
+```
+
+- **omitted** — legacy/back-compat normal completion. Clients only inspect
+  `outcome` when they care about interrupts.
+- `{ type: "success" }` — normal completion.
+- `{ type: "interrupt", interrupts: [...] }` — paused.
+
+## The `Interrupt` type
+
+```typescript
+type Interrupt = {
+  id: string
+  reason: string
+  message?: string
+  toolCallId?: string
+  responseSchema?: JsonSchema
+  expiresAt?: string             // ISO 8601
+  metadata?: Record<string, any>
+}
+```
+
+| Field | Purpose |
+| --- | --- |
+| `id` | Correlation across interrupt, resume, idempotency, audit. |
+| `reason` | Categorical routing hint — see [Reason taxonomy](#reason-taxonomy). |
+| `message` | Human-readable prompt. Universal fallback UI content. |
+| `toolCallId` | Binds the interrupt to a prior `ToolCall*` sequence. |
+| `responseSchema` | JSON Schema for the expected `resume.payload`. |
+| `expiresAt` | Optional TTL. Stale resumes produce `RunError`. |
+| `metadata` | Framework-specific free-form (e.g. LangGraph checkpoint IDs). |
+
+## Resuming a run
+
+```typescript
+type RunAgentInput = {
+  // ... existing fields
+  resume?: Array<{
+    interruptId: string
+    status: "resolved" | "cancelled"
+    payload?: any
+  }>
+}
+```
+
+- `resolved` — user responded. `payload` is validated against the interrupt's
+  `responseSchema`. **Denials live inside the payload** (e.g.
+  `{ approved: false }`), not as a separate status.
+- `cancelled` — user abandoned without meaningful input. `payload` omitted.
+
+## Contract rules (memorize these)
+
+1. **Same thread.** Resume must use the same `threadId` as the interrupted run.
+2. **Resume linkage.** Each `resume[].interruptId` must reference an `id` from
+   the interrupted run's `interrupts[]`. `parentRunId` is orthogonal (retains
+   AG-UI branching/time-travel semantics).
+3. **Cover all open interrupts.** A single `resume` array must address every
+   open interrupt from the interrupted run. **No partial resumes.**
+4. **Pending interrupts block new input.** Any `RunAgentInput` on a thread
+   with unresolved interrupts must include a `resume`. Otherwise the agent
+   must emit `RunError`.
+5. **Idempotency.** A resume with the same `(threadId, interruptId, status,
+   payload)` must be safe to replay.
+6. **Payload validation.** If `responseSchema` is set, the agent may validate
+   and emit `RunError` on mismatch. Clients should validate first.
+7. **Expiry enforcement.** Clients must not submit resumes past `expiresAt`.
+   Stale resumes → `RunError`.
+8. **Graceful handling.** Agents emit `RunError` on missing/invalid resume
+   payloads — never fail silently.
+
+## State at the interrupt boundary
+
+At the moment of interrupt, the agent emits the state required for resume via
+`StateSnapshot` and `MessagesSnapshot` **before** the `RunFinished` carrying
+the interrupt outcome.
+
+This makes the protocol resume-mode-agnostic: both replay-style (rebuild
+context from messages + state) and checkpoint-style (restore a suspended
+coroutine) continuations produce identical observable behavior. Framework-
+native checkpointing is an implementation optimization, not a protocol
+contract.
+
+## Error handling
+
+`RunError` is the only error event. `outcome` does not carry an `"error"`
+variant. Interrupt-specific conditions that produce `RunError`:
+
+- Resume arrives past `expiresAt`.
+- Resume payload fails validation against `responseSchema`.
+- Resume references an `interruptId` the agent can't correlate.
+- Resume fails to address every open interrupt (rule 3 violated).
+- `RunAgentInput` on a pending-interrupt thread omits `resume` (rule 4
+  violated).
+
+## Reason taxonomy
+
+`reason` is a required string. A small set of core values are spec-defined;
+other strings are valid extensions.
+
+### Core values
+
+| Value | Semantics | Companion fields |
+| --- | --- | --- |
+| `tool_call` | Interrupt bound to a specific tool call awaiting decision | `toolCallId` must be set |
+| `input_required` | Agent needs structured input to continue | `responseSchema` should be set |
+| `confirmation` | Free-standing yes/no not bound to a tool | `responseSchema` optional; boolean default |
+
+### Custom reasons
+
+Any string. Agents should namespace as `<framework>:<name>` —
+`langgraph:database_modification`, `mastra:workflow_suspend`. The `core:`
+prefix is reserved for future spec additions.
+
+### Client routing
+
+- Switch on known core values for dedicated UI.
+- For unknown reasons, **don't error** — render from `message`,
+  `responseSchema`, and `metadata`.
+
+## Tool-bound interrupts
+
+When `reason: "tool_call"` and `toolCallId` are set, the call and its
+resolution span two runs:
+
+1. `ToolCallArgs` from the interrupted run — the agent's proposal.
+2. `RunAgentInput.resume` payload from the resumed run — user decision and
+   edits.
+3. `ToolCallResult` from the resumed run — actual execution outcome.
+
+The agent does **not** re-emit `ToolCallStart`/`ToolCallArgs`/`ToolCallEnd`
+after resume — it emits `ToolCallResult` against the original `toolCallId`.
+
+### Approve-with-edits pattern
+
+Recommended `responseSchema` for tool-bound interrupts:
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "approved": { "type": "boolean" },
+    "editedArgs": {
+      "type": "object",
+      "description": "Full replacement of the tool args. Not merged."
+    }
+  },
+  "required": ["approved"]
+}
+```
+
+`editedArgs` is a **full replacement, not a merge**. Its presence in the schema
+is the capability signal that the client may offer edit UI.
+
+## Worked examples
+
+### Minimal tool approval
+
+Interrupt:
+
+```json
+{
+  "type": "RUN_FINISHED",
+  "threadId": "thread-1",
+  "runId": "run-1",
+  "outcome": {
+    "type": "interrupt",
+    "interrupts": [{
+      "id": "int-abc123",
+      "reason": "tool_call",
+      "message": "Send email to a@b.com with subject 'Hi'?",
+      "toolCallId": "tc-001",
+      "responseSchema": {
+        "type": "object",
+        "properties": { "approved": { "type": "boolean" } },
+        "required": ["approved"]
+      }
+    }]
+  }
+}
+```
+
+Resume:
+
+```json
+{
+  "threadId": "thread-1",
+  "runId": "run-2",
+  "resume": [{ "interruptId": "int-abc123", "status": "resolved", "payload": { "approved": true } }]
+}
+```
+
+Agent then emits `ToolCallResult` against `tc-001` followed by
+`RunFinished { outcome: { type: "success" } }`.
+
+### Approve with edits
+
+Interrupt declares `editedArgs` in the schema. Client resume payload:
+
+```json
+{
+  "interruptId": "int-email-edit",
+  "status": "resolved",
+  "payload": {
+    "approved": true,
+    "editedArgs": { "to": "a@b.com", "subject": "Hi", "body": "Hi (revised)" }
+  }
+}
+```
+
+Audit trail for the tool call: original args (run 1) → user edits (resume) →
+actual outcome (run 2 `ToolCallResult`).
+
+### Parallel interrupts
+
+Three tool-call interrupts in a single run; client approves two, cancels one:
+
+```json
+{
+  "threadId": "thread-3",
+  "runId": "run-21",
+  "resume": [
+    { "interruptId": "i-1", "status": "resolved",  "payload": { "approved": true } },
+    { "interruptId": "i-2", "status": "resolved",  "payload": { "approved": true } },
+    { "interruptId": "i-3", "status": "cancelled" }
+  ]
+}
+```
+
+Agent emits `ToolCallResult` for the two approved tool calls; the cancelled
+one is treated as not-executed.
+
+### Non-tool structured input
+
+```json
+{
+  "interrupts": [{
+    "id": "int-form",
+    "reason": "input_required",
+    "message": "Provide the quarterly filing details.",
+    "responseSchema": {
+      "type": "object",
+      "properties": {
+        "quarter": { "type": "string", "enum": ["Q1", "Q2", "Q3", "Q4"] },
+        "year": { "type": "integer", "minimum": 2000 },
+        "revenue": { "type": "number" }
+      },
+      "required": ["quarter", "year", "revenue"]
+    },
+    "expiresAt": "2026-04-20T17:00:00Z"
+  }]
+}
+```
+
+## See also
+
+- `events.md` — how `RunFinished` fits into the broader event stream
+- `capabilities.md` — `humanInTheLoop.interrupts` / `approveWithEdits` flags
+- `tools.md` — simpler tool round-trip when you don't need a full pause

--- a/.agents/skills/ag-ui-knowledge/references/concepts/messages.md
+++ b/.agents/skills/ag-ui-knowledge/references/concepts/messages.md
@@ -1,0 +1,227 @@
+# Messages
+
+Source: `submodules/ag-ui/docs/concepts/messages.mdx`
+
+Message structure, roles, and multimodal input. Open this file for the exact
+schemas of every message role, or when mapping between AG-UI and provider-
+specific formats.
+
+## Base shape
+
+```typescript
+interface BaseMessage {
+  id: string
+  role: "user" | "assistant" | "system" | "tool" | "developer" | "activity" | "reasoning"
+  content?: string
+  name?: string
+  encryptedContent?: string  // privacy-preserving state continuity (ZDR / store:false)
+}
+```
+
+`role` is the discriminator. Concrete types extend this with what they need.
+`encryptedContent` lets sensitive content (e.g. reasoning chains) travel
+between turns without ever being readable on the client.
+
+AG-UI messages are **vendor-neutral**: they map cleanly to OpenAI, Anthropic,
+and other providers without re-architecting your app when you switch.
+
+## Message types
+
+### UserMessage
+
+```typescript
+interface UserMessage {
+  id: string
+  role: "user"
+  content: string | InputContent[]  // text OR multimodal array
+  name?: string
+}
+```
+
+`InputContent` supports text, image, audio, video, document — each with a
+`source` that's either inline data or a URL:
+
+```typescript
+type InputContent =
+  | TextInputContent
+  | ImageInputContent
+  | AudioInputContent
+  | VideoInputContent
+  | DocumentInputContent
+
+interface InputContentDataSource { type: "data"; value: string; mimeType: string }
+interface InputContentUrlSource  { type: "url";  value: string; mimeType?: string }
+type InputContentSource = InputContentDataSource | InputContentUrlSource
+
+interface TextInputContent     { type: "text";     text: string }
+interface ImageInputContent    { type: "image";    source: InputContentSource; metadata?: Record<string, unknown> }
+interface AudioInputContent    { type: "audio";    source: InputContentSource; metadata?: Record<string, unknown> }
+interface VideoInputContent    { type: "video";    source: InputContentSource; metadata?: Record<string, unknown> }
+interface DocumentInputContent { type: "document"; source: InputContentSource; metadata?: Record<string, unknown> }
+```
+
+> In Python, the older `BinaryInputContent` model is deprecated and kept as a
+> temporary compatibility shim.
+
+### AssistantMessage
+
+```typescript
+interface AssistantMessage {
+  id: string
+  role: "assistant"
+  content?: string            // optional when the message is purely tool calls
+  name?: string
+  toolCalls?: ToolCall[]
+  encryptedContent?: string
+}
+```
+
+### SystemMessage
+
+```typescript
+interface SystemMessage {
+  id: string
+  role: "system"
+  content: string
+  name?: string
+}
+```
+
+### ToolMessage
+
+Result returned by the frontend after executing a tool call.
+
+```typescript
+interface ToolMessage {
+  id: string
+  role: "tool"
+  content: string         // result of execution
+  toolCallId: string      // links back to the originating ToolCallStart
+  error?: string          // populated on failure
+  encryptedValue?: string // encrypted reasoning about how the result was interpreted
+}
+```
+
+### ActivityMessage
+
+**Frontend-only.** Never forwarded to the agent — used purely for live UI like
+progress indicators, plan checklists, search-in-progress views.
+
+```typescript
+interface ActivityMessage {
+  id: string
+  role: "activity"
+  activityType: string            // e.g. "PLAN", "SEARCH", "SCRAPE"
+  content: Record<string, any>    // structured payload rendered by the frontend
+}
+```
+
+Emitted via `ACTIVITY_SNAPSHOT` / `ACTIVITY_DELTA` events (see `events.md`).
+Customize `activityType` and render a matching component. Because activity
+messages aren't sent to the LLM, you don't have to worry about polluting the
+context window with UI metadata.
+
+### DeveloperMessage
+
+Internal messages for development/debugging.
+
+```typescript
+interface DeveloperMessage {
+  id: string
+  role: "developer"
+  content: string
+  name?: string
+}
+```
+
+### ReasoningMessage
+
+Agent chain-of-thought, kept separate from final assistant output so it doesn't
+pollute history.
+
+```typescript
+interface ReasoningMessage {
+  id: string
+  role: "reasoning"
+  content: string         // visible-to-client reasoning summary
+  encryptedValue?: string // opaque chain-of-thought blob for state continuity
+}
+```
+
+Unlike `ActivityMessage`, reasoning **is** round-tripped back to the agent on
+subsequent turns — that's how reasoning state persists across turns under
+`store: false` / ZDR policies. See `reasoning.md`.
+
+## Vendor neutrality (example: AG-UI → OpenAI)
+
+```typescript
+const openaiMessages = agUiMessages
+  .filter((msg) => ["user", "system", "assistant"].includes(msg.role))
+  .map((msg) => ({
+    role: msg.role as "user" | "system" | "assistant",
+    content: msg.content || "",
+    ...(msg.role === "assistant" && msg.toolCalls
+      ? {
+          tool_calls: msg.toolCalls.map((tc) => ({
+            id: tc.id,
+            type: tc.type,
+            function: { name: tc.function.name, arguments: tc.function.arguments },
+          })),
+        }
+      : {}),
+  }))
+```
+
+The mapping is mechanical because AG-UI doesn't invent new field names — it
+standardizes the union of what providers already use.
+
+## Message synchronization
+
+Two complementary mechanisms (full details in `events.md`):
+
+- **`MESSAGES_SNAPSHOT`** — complete view of all messages. Use for init, after
+  connection interruptions, or to reset client state.
+- **Streaming triads** — `TEXT_MESSAGE_START` → `TEXT_MESSAGE_CONTENT*` →
+  `TEXT_MESSAGE_END` for real-time text. Same pattern for `TOOL_CALL_*` and
+  `REASONING_MESSAGE_*`.
+
+## Tool integration in messages
+
+Tool calls are embedded inside assistant messages:
+
+```typescript
+interface ToolCall {
+  id: string
+  type: "function"
+  function: { name: string; arguments: string }  // arguments is JSON-encoded
+}
+```
+
+A full tool round-trip in the history:
+
+```typescript
+[
+  { id: "msg_1", role: "user", content: "What's the weather in NYC?" },
+  {
+    id: "msg_2",
+    role: "assistant",
+    content: "Let me check.",
+    toolCalls: [{
+      id: "call_1",
+      type: "function",
+      function: { name: "get_weather", arguments: '{"location":"New York","unit":"celsius"}' },
+    }],
+  },
+  { id: "result_1", role: "tool", content: '{"temperature":22,"condition":"Partly Cloudy"}', toolCallId: "call_1" },
+  { id: "msg_3", role: "assistant", content: "Partly cloudy, 22°C." },
+]
+```
+
+Streaming variants (`TOOL_CALL_START` / `ARGS` / `END`) let the UI show the
+arguments being constructed in real time.
+
+## See also
+
+- `events.md` — `TEXT_MESSAGE_*`, `TOOL_CALL_*`, `REASONING_*`, `MESSAGES_SNAPSHOT`
+- `tools.md` — how tools are defined and round-tripped
+- `reasoning.md` — visibility and encryption of reasoning messages

--- a/.agents/skills/ag-ui-knowledge/references/concepts/middleware.md
+++ b/.agents/skills/ag-ui-knowledge/references/concepts/middleware.md
@@ -1,0 +1,191 @@
+# Middleware
+
+Source: `submodules/ag-ui/docs/concepts/middleware.mdx` (and
+`submodules/ag-ui/docs/sdk/js/client/middleware.mdx`)
+
+Pipeline mechanics for transforming, filtering, and augmenting event streams.
+Open this file when wrapping an agent with cross-cutting behavior like logging,
+auth, filtering, or metrics.
+
+## What middleware does
+
+Middleware sits between agent execution and the event consumer. With it you
+can:
+
+1. **Transform events** — modify or enhance events on the fly.
+2. **Filter events** — selectively allow or block specific event types.
+3. **Add metadata** — inject tracking info.
+4. **Handle errors** — custom error-recovery strategies.
+5. **Monitor execution** — logging, metrics, debugging.
+
+## Pipeline model
+
+```typescript
+import { AbstractAgent } from "@ag-ui/client"
+
+const agent = new MyAgent()
+
+// chain: logging → auth → filter → agent
+agent.use(loggingMiddleware, authMiddleware, filterMiddleware)
+
+await agent.runAgent()
+```
+
+Middleware added with `agent.use(...)` is applied in `runAgent()`. (Note:
+`connectAgent()` currently calls `connect()` directly and does **not** run
+middleware.)
+
+## Function-based middleware
+
+For simple transformations:
+
+```typescript
+import { MiddlewareFunction } from "@ag-ui/client"
+import { EventType } from "@ag-ui/core"
+import { map } from "rxjs/operators"
+
+const prefixMiddleware: MiddlewareFunction = (input, next) => {
+  return next.run(input).pipe(
+    map(event => {
+      if (
+        event.type === EventType.TEXT_MESSAGE_CHUNK ||
+        event.type === EventType.TEXT_MESSAGE_CONTENT
+      ) {
+        return { ...event, delta: `[AI]: ${event.delta}` }
+      }
+      return event
+    })
+  )
+}
+
+agent.use(prefixMiddleware)
+```
+
+## Class-based middleware
+
+For stateful or configurable middleware:
+
+```typescript
+import { Middleware } from "@ag-ui/client"
+import { Observable } from "rxjs"
+import { tap, finalize } from "rxjs/operators"
+
+class MetricsMiddleware extends Middleware {
+  private eventCount = 0
+
+  constructor(private metricsService: MetricsService) { super() }
+
+  run(input: RunAgentInput, next: AbstractAgent): Observable<BaseEvent> {
+    const startTime = Date.now()
+    return this.runNext(input, next).pipe(
+      tap(event => {
+        this.eventCount++
+        this.metricsService.recordEvent(event.type)
+      }),
+      finalize(() => {
+        this.metricsService.recordDuration(Date.now() - startTime)
+        this.metricsService.recordEventCount(this.eventCount)
+      })
+    )
+  }
+}
+
+agent.use(new MetricsMiddleware(metricsService))
+```
+
+Inside class middleware prefer the helpers:
+
+- `runNext(input, next)` — normalizes chunk events into full `TEXT_MESSAGE_*` /
+  `TOOL_CALL_*` triads, so downstream code only sees the canonical events.
+- `runNextWithState(input, next)` — additionally provides accumulated
+  `messages` and `state` after each event, useful for middleware that needs
+  context.
+
+## Built-in middleware
+
+### `FilterToolCallsMiddleware`
+
+Allow- or deny-list filtering of tool calls:
+
+```typescript
+import { FilterToolCallsMiddleware } from "@ag-ui/client"
+
+const allowedFilter = new FilterToolCallsMiddleware({ allowedToolCalls: ["search", "calculate"] })
+const blockedFilter = new FilterToolCallsMiddleware({ disallowedToolCalls: ["delete", "modify"] })
+
+agent.use(allowedFilter)
+```
+
+Note: this filters emitted `TOOL_CALL_*` events. It does **not** block tool
+execution in the upstream model/runtime — those calls still happen on the
+backend; you just don't see them on the client.
+
+## Combining middleware
+
+```typescript
+const logMiddleware: MiddlewareFunction = (input, next) => next.run(input)
+const metricsMiddleware = new MetricsMiddleware(metricsService)
+const filterMiddleware  = new FilterToolCallsMiddleware({ allowedToolCalls: ["search"] })
+
+agent.use(logMiddleware, metricsMiddleware, filterMiddleware)
+```
+
+## Execution order
+
+```text
+agent.use(middleware1, middleware2, middleware3)
+
+  → middleware1
+    → middleware2
+      → middleware3
+        → agent.run()
+      ← events flow back through middleware3
+    ← events flow back through middleware2
+  ← events flow back through middleware1
+```
+
+The first middleware sees the original input and the final emitted events.
+Each can modify input on the way down and events on the way up.
+
+## Common patterns
+
+### Conditional middleware
+
+```typescript
+const conditionalMiddleware: MiddlewareFunction = (input, next) => {
+  if (input.forwardedProps?.debug === true) {
+    return next.run(input).pipe(tap(event => console.debug(event)))
+  }
+  return next.run(input)
+}
+```
+
+### Auth injection
+
+Pass credentials in `RunAgentParameters.forwardedProps` and have middleware
+attach them to outgoing calls — keeps secrets out of the agent's interface.
+
+### Rate limiting
+
+Class-based middleware with internal token-bucket state; throw or delay when
+the limit is exceeded.
+
+### Logging
+
+Function middleware with a `tap` operator at the top of the chain.
+
+## Best practices
+
+1. **Single responsibility** — one concern per middleware.
+2. **Handle errors gracefully** — use RxJS `catchError`.
+3. **No blocking I/O** — use async patterns or push work to RxJS.
+4. **Document side effects** — make state mutations explicit.
+5. **Unit-test middleware in isolation.**
+6. **Mind the cost** — every middleware runs on every event in the stream.
+
+## See also
+
+- `architecture.md` — middleware's role in the overall design
+- `events.md` — events flowing through the pipeline
+- `references/sdks/typescript.md` — `Middleware` class and `MiddlewareFunction`
+  type definitions

--- a/.agents/skills/ag-ui-knowledge/references/concepts/reasoning.md
+++ b/.agents/skills/ag-ui-knowledge/references/concepts/reasoning.md
@@ -1,0 +1,233 @@
+# Reasoning
+
+Source: `submodules/ag-ui/docs/concepts/reasoning.mdx`
+
+Chain-of-thought visibility, encrypted state continuity, and the deprecation
+path from `THINKING_*` events. Open this file when surfacing reasoning to
+users, implementing ZDR/`store: false`, or migrating older code.
+
+## Three problems reasoning solves
+
+| Challenge | AG-UI solution |
+| --- | --- |
+| **Visibility** — surface reasoning to users without exposing raw chain-of-thought | Stream a visible summary via `REASONING_MESSAGE_CONTENT`; keep details encrypted |
+| **State continuity** — preserve reasoning across turns under `store: false` / ZDR | `REASONING_ENCRYPTED_VALUE` carries an opaque blob the client forwards back |
+| **Privacy compliance** — meet enterprise privacy requirements | Reasoning never stored plaintext on client; encrypted values let server discard or rotate |
+
+## `ReasoningMessage`
+
+```typescript
+interface ReasoningMessage {
+  id: string
+  role: "reasoning"
+  content: string         // visible reasoning
+  encryptedValue?: string // opaque encrypted chain-of-thought for state continuity
+}
+```
+
+Key characteristics:
+
+- **Separate from assistant messages** — keeps reasoning out of the final
+  response history.
+- **Streamable** — content arrives via the `REASONING_MESSAGE_*` triad.
+- **Optional encryption** — when `encryptedValue` is present, the client
+  treats it as opaque and forwards it back on subsequent turns.
+
+Unlike `ActivityMessage`, reasoning **is** round-tripped back to the agent on
+subsequent turns. That's how reasoning state persists across turns under
+`store: false` / ZDR policies.
+
+## Reasoning events
+
+```text
+ReasoningStart → ReasoningMessageStart → ReasoningMessageContent* → ReasoningMessageEnd
+              → (optional) ReasoningEncryptedValue
+              → ReasoningEnd
+```
+
+| Event | Purpose |
+| --- | --- |
+| `ReasoningStart` | Marks the start of a reasoning phase |
+| `ReasoningMessageStart` | Begins a streaming reasoning message |
+| `ReasoningMessageContent` | Delivers reasoning content chunks |
+| `ReasoningMessageEnd` | Completes a reasoning message |
+| `ReasoningMessageChunk` | Auto-managed convenience event; empty `delta` closes the message |
+| `ReasoningEnd` | Marks completion of reasoning |
+| `ReasoningEncryptedValue` | Attaches encrypted chain-of-thought to a message or tool call |
+
+`ReasoningEncryptedValue` carries `{ subtype: "message" | "tool-call",
+entityId, encryptedValue }`. The `entityId` is the message id or tool-call id
+the reasoning belongs to.
+
+## Privacy patterns
+
+### Zero data retention (ZDR)
+
+1. Encrypt reasoning server-side before sending.
+2. Only emit a short visible summary via `REASONING_MESSAGE_*`.
+3. Attach the full chain-of-thought as `REASONING_ENCRYPTED_VALUE`.
+4. Client stores only the encrypted blob (cannot decrypt) and the summary
+   (non-sensitive).
+5. Full reasoning is never persisted in plaintext anywhere on the client.
+
+### Visibility levels
+
+- **Full visibility** — stream the complete chain via `REASONING_MESSAGE_CONTENT`.
+- **Summary only** — short visible summary + detailed `encryptedValue`.
+- **Hidden** — `REASONING_ENCRYPTED_VALUE` only, no visible streaming.
+
+### Compliance crosswalk
+
+| Requirement | How reasoning supports it |
+| --- | --- |
+| GDPR right to erasure | Encrypted content can be discarded without losing capability |
+| SOC 2 data handling | Reasoning never stored plaintext on the client |
+| HIPAA minimum necessary | Expose summaries; keep detail encrypted |
+| Audit logging | `ReasoningStart`/`ReasoningEnd` create audit trail without exposing content |
+
+## Examples
+
+### Basic visible reasoning
+
+```typescript
+yield { type: "REASONING_START", messageId: "reasoning-001" }
+
+yield { type: "REASONING_MESSAGE_START",   messageId: "msg-123", role: "reasoning" }
+yield { type: "REASONING_MESSAGE_CONTENT", messageId: "msg-123", delta: "Let me " }
+yield { type: "REASONING_MESSAGE_CONTENT", messageId: "msg-123", delta: "think through " }
+yield { type: "REASONING_MESSAGE_CONTENT", messageId: "msg-123", delta: "this step by step..." }
+yield { type: "REASONING_MESSAGE_END",     messageId: "msg-123" }
+
+yield { type: "REASONING_END", messageId: "reasoning-001" }
+```
+
+### Encrypted continuation across turns
+
+```typescript
+yield { type: "REASONING_START", messageId: "reasoning-002" }
+
+// Public summary
+yield { type: "REASONING_MESSAGE_START",   messageId: "msg-456", role: "reasoning" }
+yield { type: "REASONING_MESSAGE_CONTENT", messageId: "msg-456", delta: "Analyzing your request..." }
+yield { type: "REASONING_MESSAGE_END",     messageId: "msg-456" }
+
+// Private chain-of-thought
+yield {
+  type: "REASONING_ENCRYPTED_VALUE",
+  subtype: "message",
+  entityId: "msg-456",
+  encryptedValue: "eyJhbGciOiJBMjU2R0NNIiwiZW5jIjoiQTI1NkdDTSJ9...",
+}
+
+yield { type: "REASONING_END", messageId: "reasoning-002" }
+
+// Client stores msg-456 with encryptedValue and forwards it back next turn
+```
+
+### Encrypted reasoning attached to a tool call
+
+```typescript
+yield { type: "TOOL_CALL_START", toolCallId: "tool-123", toolCallName: "search_database", parentMessageId: "msg-789" }
+yield { type: "TOOL_CALL_ARGS",  toolCallId: "tool-123", delta: '{"query": "user preferences"}' }
+yield { type: "TOOL_CALL_END",   toolCallId: "tool-123" }
+
+yield {
+  type: "REASONING_ENCRYPTED_VALUE",
+  subtype: "tool-call",
+  entityId: "tool-123",
+  encryptedValue: "encrypted-reasoning-about-tool-selection...",
+}
+```
+
+Use to capture why the agent chose specific args or how it interpreted
+results.
+
+### Convenience chunk event
+
+```typescript
+yield { type: "REASONING_MESSAGE_CHUNK", messageId: "msg-789", delta: "Analyzing the problem space..." }
+yield { type: "REASONING_MESSAGE_CHUNK", messageId: "msg-789", delta: " Considering multiple approaches..." }
+yield { type: "REASONING_MESSAGE_CHUNK", messageId: "msg-789", delta: "" }  // empty closes the message
+```
+
+## Client handling
+
+```typescript
+import { EventType, type BaseEvent } from "@ag-ui/core"
+
+function handleEvent(event: BaseEvent) {
+  switch (event.type) {
+    case EventType.REASONING_START:
+      showThinkingIndicator()
+      break
+    case EventType.REASONING_MESSAGE_CONTENT:
+      appendReasoningText(event.messageId, event.delta)
+      break
+    case EventType.REASONING_ENCRYPTED_VALUE:
+      if (event.subtype === "message") {
+        storeMessageEncryptedValue(event.entityId, event.encryptedValue)
+      } else if (event.subtype === "tool-call") {
+        storeToolCallEncryptedValue(event.entityId, event.encryptedValue)
+      }
+      break
+    case EventType.REASONING_END:
+      hideThinkingIndicator()
+      break
+  }
+}
+```
+
+When making subsequent requests, include the stored encrypted values in the
+message history:
+
+```typescript
+await agent.run({
+  threadId: "thread-123",
+  messages: [
+    ...previousMessages,
+    {
+      id: "reasoning-002",
+      role: "reasoning",
+      content: "Analyzing your request...",     // visible summary
+      encryptedValue: storedEncryptedBlob,      // opaque to client
+    },
+    { id: "user-msg-001", role: "user", content: "Follow up question..." },
+  ],
+})
+```
+
+## Migration from `THINKING_*`
+
+> `THINKING_*` events are deprecated and will be removed in v1.0.0.
+
+| Deprecated | Replacement |
+| --- | --- |
+| `THINKING_START` | `REASONING_START` |
+| `THINKING_END` | `REASONING_END` |
+| `THINKING_TEXT_MESSAGE_START` | `REASONING_MESSAGE_START` |
+| `THINKING_TEXT_MESSAGE_CONTENT` | `REASONING_MESSAGE_CONTENT` |
+| `THINKING_TEXT_MESSAGE_END` | `REASONING_MESSAGE_END` |
+
+Migration steps:
+
+1. Replace event types.
+2. Use `ReasoningMessage` with `role: "reasoning"` instead of any
+   thinking-specific message types.
+3. Consider adding `ReasoningEncryptedValue` for privacy compliance.
+4. Re-test the streaming UX end-to-end.
+
+## Best practices
+
+- Always pair `ReasoningStart` with `ReasoningEnd`.
+- Use `ReasoningEncryptedValue` for sensitive reasoning; keep summaries terse.
+- Provide visible feedback even when reasoning is encrypted — users need to
+  know the agent is working.
+- Be resilient to incomplete event streams.
+- For very long reasoning, prefer summaries over streaming full content.
+
+## See also
+
+- `events.md` — full reasoning event reference
+- `messages.md` — `ReasoningMessage` schema
+- `serialization.md` — state continuity and lineage
+- `capabilities.md` — `reasoning.{supported, streaming, encrypted}` flags

--- a/.agents/skills/ag-ui-knowledge/references/concepts/serialization.md
+++ b/.agents/skills/ag-ui-knowledge/references/concepts/serialization.md
@@ -1,0 +1,159 @@
+# Serialization
+
+Source: `submodules/ag-ui/docs/concepts/serialization.mdx`
+
+Stream serialization, compaction, branching, and lineage tracking. Open this
+file when persisting event streams, rebuilding history, or implementing
+time-travel/branching.
+
+## Why serialize
+
+A serialized event stream lets you:
+
+- Restore chat history and UI state after reloads or reconnects.
+- Attach to running agents and continue receiving events.
+- Branch from any prior run (time travel, alternative paths).
+- Compact stored history to reduce size without losing meaning.
+
+## Core concepts
+
+- **Stream serialization** — convert the full event history to/from a portable
+  representation (JSON) for database/file/log storage.
+- **Event compaction** — reduce verbose streams to snapshots while preserving
+  semantics (merge content chunks, collapse deltas into snapshots).
+- **Run lineage** — track branches via `parentRunId`, forming a git-like
+  append-only log.
+
+## Updated event fields
+
+`RunStarted` (full shape):
+
+```typescript
+type RunStartedEvent = BaseEvent & {
+  type: EventType.RUN_STARTED
+  threadId: string
+  runId: string
+  parentRunId?: string  // branching / time-travel pointer within the thread
+  input?: AgentInput    // exact agent input for this run; may omit messages already in history
+}
+```
+
+`parentRunId` enables lineage; `input` lets implementations record exactly
+what was passed to the agent independent of previously recorded messages.
+
+## Event compaction
+
+Reduce noise without changing the observable outcome:
+
+```typescript
+declare function compactEvents(events: BaseEvent[]): BaseEvent[]
+```
+
+Common rules:
+
+- **Message streams** — combine `TEXT_MESSAGE_*` sequences into a single
+  message snapshot; concatenate adjacent `TEXT_MESSAGE_CONTENT` for the same
+  message id.
+- **Tool calls** — collapse `TOOL_CALL_START`/`ARGS`/`END` into a compact
+  record.
+- **State** — merge consecutive `STATE_DELTA` into a final `STATE_SNAPSHOT`;
+  discard superseded updates.
+- **Run input normalization** — remove from `RunStarted.input.messages` any
+  messages already present earlier in the stream.
+
+### Example
+
+Before:
+
+```typescript
+[
+  { type: "TEXT_MESSAGE_START",   messageId: "msg1", role: "user" },
+  { type: "TEXT_MESSAGE_CONTENT", messageId: "msg1", delta: "Hello " },
+  { type: "TEXT_MESSAGE_CONTENT", messageId: "msg1", delta: "world" },
+  { type: "TEXT_MESSAGE_END",     messageId: "msg1" },
+  { type: "STATE_DELTA", patch: { op: "add",     path: "/foo", value: 1 } },
+  { type: "STATE_DELTA", patch: { op: "replace", path: "/foo", value: 2 } },
+]
+```
+
+After:
+
+```typescript
+[
+  { type: "MESSAGES_SNAPSHOT", messages: [{ id: "msg1", role: "user", content: "Hello world" }] },
+  { type: "STATE_SNAPSHOT",    state: { foo: 2 } },
+]
+```
+
+## Branching with `parentRunId`
+
+Setting `parentRunId` on `RunStarted` creates a git-like lineage. The stream
+becomes immutable and append-only — each run can branch from any previous run.
+
+```text
+  run1
+   │
+  run2
+   ├── run3 (parent: run2)
+   │   └── run4
+   └── run5 (parent: run2)
+       └── run6
+```
+
+Benefits:
+
+- Multiple branches in the same serialized log.
+- Immutable history.
+- Deterministic time travel to any point.
+
+### Example
+
+```typescript
+// Original
+{ type: "RUN_STARTED", threadId: "thread1", runId: "run1",
+  input: { messages: ["Tell me about Paris"] } }
+
+// Branch from run1
+{ type: "RUN_STARTED", threadId: "thread1", runId: "run2",
+  parentRunId: "run1",
+  input: { messages: ["Actually, tell me about London instead"] } }
+```
+
+## Normalized input
+
+Avoid re-serializing messages already in history:
+
+```typescript
+{ type: "RUN_STARTED", runId: "run1",
+  input: { messages: [{ id: "msg1", role: "user", content: "Hello" }] } }
+
+{ type: "RUN_STARTED", runId: "run2",
+  input: { messages: [{ id: "msg2", role: "user", content: "How are you?" }] } }
+  // msg1 omitted — it's already in history from run1
+```
+
+## Basic (de)serialization
+
+```typescript
+const events: BaseEvent[] = [/* … */]
+const serialized = JSON.stringify(events)
+await storage.save(threadId, serialized)
+
+// Restore and compact later
+const restored = JSON.parse(await storage.load(threadId))
+const compacted = compactEvents(restored)
+```
+
+## Implementation notes
+
+- Provide SDK helpers for compaction and (de)serialization rather than
+  hand-rolling in every app.
+- Store streams **append-only** — prefer incremental writes.
+- Consider compression for long histories.
+- Index by `threadId`, `runId`, and timestamps for fast retrieval.
+
+## See also
+
+- `events.md` — `RUN_STARTED` field reference including `parentRunId` and `input`
+- `state.md` — snapshot/delta interaction with compaction
+- `interrupts.md` — state captured before an interrupt boundary

--- a/.agents/skills/ag-ui-knowledge/references/concepts/state.md
+++ b/.agents/skills/ag-ui-knowledge/references/concepts/state.md
@@ -1,0 +1,187 @@
+# State Management
+
+Source: `submodules/ag-ui/docs/concepts/state.mdx`
+
+Shared-state architecture and JSON-Patch delta mechanics. Open this file when
+implementing snapshot/delta synchronization, designing a state object, or
+debugging patch failures.
+
+## Shared-state model
+
+State in AG-UI is a structured JSON object that:
+
+1. Persists across interactions with an agent.
+2. Is accessible to both the agent and the frontend.
+3. Updates in real time as the run progresses.
+4. Provides context for decisions on both sides.
+
+It's a bidirectional channel — agents read application state to make informed
+decisions; frontends observe agent state changes to react in the UI.
+
+## Two synchronization mechanisms
+
+### `STATE_SNAPSHOT`
+
+Complete state representation at a point in time.
+
+```typescript
+interface StateSnapshotEvent {
+  type: EventType.STATE_SNAPSHOT
+  snapshot: any  // entire state object
+}
+```
+
+Use for:
+
+- Initial state at the start of an interaction.
+- Recovery after connection interruptions.
+- Major state changes that warrant a full refresh.
+- Establishing a new baseline for future deltas.
+
+On receipt the frontend **replaces** its state — don't merge.
+
+### `STATE_DELTA`
+
+Incremental updates as RFC 6902 JSON Patch operations.
+
+```typescript
+interface StateDeltaEvent {
+  type: EventType.STATE_DELTA
+  delta: JsonPatchOperation[]
+}
+```
+
+Bandwidth-efficient — send only what changed. Best for:
+
+- Frequent small updates during streaming.
+- Large state objects where most fields are stable.
+- High-frequency updates that would be wasteful as full snapshots.
+
+## JSON Patch (RFC 6902)
+
+```typescript
+interface JsonPatchOperation {
+  op: "add" | "remove" | "replace" | "move" | "copy" | "test"
+  path: string   // JSON Pointer (RFC 6901)
+  value?: any    // for add, replace
+  from?: string  // for move, copy
+}
+```
+
+Examples:
+
+```json
+{ "op": "add",     "path": "/user/preferences", "value": { "theme": "dark" } }
+{ "op": "replace", "path": "/conversation_state", "value": "paused" }
+{ "op": "remove",  "path": "/temporary_data" }
+{ "op": "move",    "from": "/pending_items/0", "path": "/completed_items" }
+```
+
+Apply in order. If a patch fails (e.g. `replace` on a missing path), request a
+fresh `STATE_SNAPSHOT` rather than guessing.
+
+## Reference implementation
+
+The AG-UI client uses `fast-json-patch`:
+
+```typescript
+case EventType.STATE_DELTA: {
+  const { delta } = event as StateDeltaEvent
+  try {
+    const result = applyPatch(state, delta, true, false)  // validate, no mutate
+    state = result.newDocument
+    return emitUpdate({ state })
+  } catch (error) {
+    console.warn(`Failed to apply state patch: ${error}`)
+    return emitNoUpdate()
+  }
+}
+```
+
+Atomic application, no mutation of the original document, errors caught
+gracefully.
+
+## `MESSAGES_SNAPSHOT`
+
+Separate snapshot specifically for conversation history:
+
+```typescript
+interface MessagesSnapshotEvent {
+  type: EventType.MESSAGES_SNAPSHOT
+  messages: Message[]
+}
+```
+
+Use to (re)initialize chat history or sync after a reconnect.
+
+## Human-in-the-loop collaboration
+
+Shared state is the substrate for human-in-the-loop UX:
+
+- **Visibility** — users see the agent's current intent.
+- **Contextual awareness** — agent reads user actions/preferences.
+- **Collaborative decisions** — both contribute to the evolving state.
+- **Feedback loops** — humans can correct or guide by editing state.
+
+Example: agent proposes an action via state, user reviews/edits/approves.
+
+```json
+{
+  "proposal": {
+    "action": "send_email",
+    "recipient": "client@example.com",
+    "content": "Draft email content..."
+  }
+}
+```
+
+Critical: at an interrupt boundary the agent must emit any state required for
+resume via `STATE_SNAPSHOT` and `MESSAGES_SNAPSHOT` **before** the
+`RUN_FINISHED` interrupt event. This keeps the protocol resume-mode-agnostic
+(both replay-style and checkpoint-style continuations work). See
+`interrupts.md`.
+
+## CopilotKit integration
+
+CopilotKit exposes shared state via React's `useCoAgent`:
+
+```jsx
+const { state: agentState, setState: setAgentState } = useCoAgent({
+  name: "agent",
+  initialState: { someProperty: "initialValue" },
+})
+```
+
+On the agent side (LangGraph example):
+
+```python
+async def tool_node(self, state: ResearchState, config: RunnableConfig):
+    tool_state = {
+        "title": new_state.get("title", ""),
+        "outline": new_state.get("outline", {}),
+        "sections": new_state.get("sections", []),
+    }
+    await copilotkit_emit_state(config, tool_state)
+    return tool_state
+```
+
+These calls produce `STATE_SNAPSHOT` / `STATE_DELTA` events under the hood.
+
+## Best practices
+
+1. Use **snapshots sparingly** — only when establishing a baseline. Otherwise
+   prefer deltas.
+2. **Structure state for patches.** Flat-ish objects with stable keys patch
+   better than deeply nested arrays.
+3. **Handle conflicts.** If both sides can write, define resolution rules
+   (last-write-wins, server-authoritative, CRDT, etc.).
+4. **Recover gracefully.** Detect divergence and resync via snapshot.
+5. **Don't store secrets** in shared state — it's visible to the frontend.
+6. **Emit state before interrupts.** Required for resume; see `interrupts.md`.
+
+## See also
+
+- `events.md` — `STATE_SNAPSHOT`, `STATE_DELTA`, `MESSAGES_SNAPSHOT` field tables
+- `interrupts.md` — state at the interrupt boundary
+- `messages.md` — message history sync
+- `serialization.md` — compacting state deltas across long sessions

--- a/.agents/skills/ag-ui-knowledge/references/concepts/tools.md
+++ b/.agents/skills/ag-ui-knowledge/references/concepts/tools.md
@@ -1,0 +1,239 @@
+# Tools
+
+Source: `submodules/ag-ui/docs/concepts/tools.mdx`
+
+How tools work in AG-UI and the rationale for the frontend-defined model. Open
+this file when defining tool schemas, implementing the tool-call round-trip,
+or designing human-in-the-loop confirmation flows.
+
+## Why tools matter
+
+Tools let agents:
+
+1. Request specific information.
+2. Perform actions in external systems.
+3. Ask for human input or confirmation.
+4. Access specialized capabilities.
+
+They're the bridge between agent reasoning and real-world effects.
+
+## Schema
+
+```typescript
+interface Tool {
+  name: string
+  description: string
+  parameters: {
+    type: "object"
+    properties: { /* tool-specific */ }
+    required: string[]
+  }
+}
+```
+
+`parameters` is JSON Schema (<https://json-schema.org/>). Both the agent (when
+generating valid calls) and the frontend (when validating before execution)
+rely on it.
+
+## Frontend-defined tools
+
+In AG-UI, **tools are defined in the frontend and passed to the agent at
+run-time** via `RunAgentInput.tools`:
+
+```typescript
+const userConfirmationTool = {
+  name: "confirmAction",
+  description: "Ask the user to confirm a specific action before proceeding",
+  parameters: {
+    type: "object",
+    properties: {
+      action: { type: "string", description: "The action that needs confirmation" },
+      importance: {
+        type: "string",
+        enum: ["low", "medium", "high", "critical"],
+        description: "Importance level",
+      },
+    },
+    required: ["action"],
+  },
+}
+
+agent.runAgent({ tools: [userConfirmationTool] })
+```
+
+This inversion-of-control matters because:
+
+| Benefit | What it buys you |
+| --- | --- |
+| **Frontend control** | The UI decides what capabilities are available — even per user, per session. |
+| **Dynamic capabilities** | Add/remove tools based on permissions, context, feature flags. |
+| **Separation of concerns** | Agents focus on reasoning; frontends own tool execution. |
+| **Security** | Sensitive operations live in the app, not the model. |
+
+## Tool-call lifecycle
+
+The agent emits a streaming triad of events when invoking a tool:
+
+```text
+ToolCallStart → ToolCallArgs* → ToolCallEnd
+```
+
+```typescript
+{ type: EventType.TOOL_CALL_START,
+  toolCallId: "tool-123",
+  toolCallName: "confirmAction",
+  parentMessageId: "msg-456" }
+
+{ type: EventType.TOOL_CALL_ARGS, toolCallId: "tool-123", delta: '{"act'      }
+{ type: EventType.TOOL_CALL_ARGS, toolCallId: "tool-123", delta: 'ion":"Depl' }
+{ type: EventType.TOOL_CALL_ARGS, toolCallId: "tool-123", delta: 'oy"}'        }
+
+{ type: EventType.TOOL_CALL_END, toolCallId: "tool-123" }
+```
+
+Concatenate the `delta` chunks in order to get the full JSON-encoded arguments.
+
+The convenience `TOOL_CALL_CHUNK` event collapses this into auto-managed
+chunks (first chunk must include `toolCallId` + `toolCallName`).
+
+## Returning tool results
+
+After execution, the frontend posts a `tool`-role message into the next
+`RunAgentInput`:
+
+```typescript
+{
+  id: "result-789",
+  role: "tool",
+  content: "true",            // result as string
+  toolCallId: "tool-123",     // references the originating tool call
+}
+```
+
+This becomes part of the conversation history; the agent references it in
+subsequent reasoning.
+
+## Human-in-the-loop pattern
+
+The classic flow:
+
+1. Agent needs an important decision.
+2. Agent calls `confirmAction` with details.
+3. Frontend shows a confirmation dialog.
+4. User responds.
+5. Frontend returns the decision as a `tool` message.
+6. Agent continues, aware of the user's choice.
+
+Variants enabled by this pattern: approval workflows, data verification,
+collaborative decision-making, supervised learning loops. For richer flows
+with edit-before-approve and parallel decisions, use the interrupt protocol
+(see `interrupts.md`) — it complements tools rather than replacing them.
+
+## CopilotKit integration
+
+`useCopilotAction` is the React-side ergonomic wrapper:
+
+```tsx
+useCopilotAction({
+  name: "confirmAction",
+  description: "Ask the user to confirm an action",
+  parameters: {
+    type: "object",
+    properties: { action: { type: "string", description: "The action to confirm" } },
+    required: ["action"],
+  },
+  handler: async ({ action }) => {
+    const confirmed = await showConfirmDialog(action)
+    return confirmed ? "approved" : "rejected"
+  },
+})
+```
+
+## Common tool shapes
+
+### Confirmation
+
+```typescript
+{
+  name: "confirmAction",
+  description: "Ask the user to confirm an action",
+  parameters: {
+    type: "object",
+    properties: {
+      action: { type: "string", description: "The action to confirm" },
+      importance: { type: "string", enum: ["low", "medium", "high", "critical"] },
+    },
+    required: ["action"],
+  },
+}
+```
+
+### Data retrieval
+
+```typescript
+{
+  name: "fetchUserData",
+  description: "Retrieve data about a specific user",
+  parameters: {
+    type: "object",
+    properties: {
+      userId: { type: "string" },
+      fields: { type: "array", items: { type: "string" } },
+    },
+    required: ["userId"],
+  },
+}
+```
+
+### UI control
+
+```typescript
+{
+  name: "navigateTo",
+  description: "Navigate to a different page or view",
+  parameters: {
+    type: "object",
+    properties: {
+      destination: { type: "string" },
+      params: { type: "object" },
+    },
+    required: ["destination"],
+  },
+}
+```
+
+### Content generation
+
+```typescript
+{
+  name: "generateImage",
+  description: "Generate an image based on a description",
+  parameters: {
+    type: "object",
+    properties: {
+      prompt: { type: "string" },
+      style: { type: "string" },
+      dimensions: { type: "object", properties: { width: { type: "number" }, height: { type: "number" } } },
+    },
+    required: ["prompt"],
+  },
+}
+```
+
+## Design tips
+
+- **Action-oriented names** — `confirmAction`, `fetchUserData`, `navigateTo`.
+- **Thorough descriptions** — the agent picks tools based on these; don't be
+  terse.
+- **Precise schemas** — use `enum`, `format`, descriptions, and minimal
+  `required`.
+- **Robust error handling in the executor** — return informative messages so
+  the agent can self-correct.
+- **Design the UI around the tool** — when a tool is a human gate, the user
+  must have enough context to decide well.
+
+## See also
+
+- `events.md` — `TOOL_CALL_*` event field tables
+- `messages.md` — how `ToolCall` and `ToolMessage` fit into history
+- `interrupts.md` — richer human-gate flow when tools aren't enough

--- a/.agents/skills/ag-ui-knowledge/references/integrations.md
+++ b/.agents/skills/ag-ui-knowledge/references/integrations.md
@@ -1,0 +1,147 @@
+# Integrations
+
+Source: `submodules/ag-ui/docs/integrations.mdx` and
+`submodules/ag-ui/docs/introduction.mdx`
+
+The AG-UI ecosystem: frontends, agent frameworks, deployment platforms, and
+sister specs. Open this file when someone asks "does AG-UI support X?",
+"how do I integrate with X?", or "what client should I use?".
+
+## Frontends (clients)
+
+| Client | Status | Notes |
+| --- | --- | --- |
+| **CopilotKit** | 1st-party | The reference React client. Exposes `useCopilotAction` (tools), `useCoAgent` (shared state), and pre-built chat UI. The recommended client for most production apps. |
+| **Terminal + Agent** | Community | The CLI client walkthrough in `quickstart/client.md`. Good template for custom clients. |
+| React Native | Help wanted | Tracked as upstream issue #510 |
+
+## Agent frameworks
+
+### Partnerships (AG-UI was born from these)
+
+| Framework | Status | Docs |
+| --- | --- | --- |
+| **LangGraph** | Supported | `docs.copilotkit.ai/langgraph/` |
+| **CrewAI** | Supported | `docs.copilotkit.ai/crewai-flows` |
+
+### 1st-party (built-in support)
+
+| Framework | Status | Notes |
+| --- | --- | --- |
+| **Microsoft Agent Framework** | Supported | Python + .NET |
+| **Google ADK** | Supported | Gemini-focused |
+| **AWS Strands Agents** | Supported | Model-driven Python SDK |
+| **AWS Bedrock AgentCore** | Supported | Managed deployment platform (see below) |
+| **Mastra** | Supported | TypeScript agent framework |
+| **Pydantic AI** | Supported | Production-ready Python agents |
+| **Agno** | Supported | Multi-agent systems framework |
+| **LlamaIndex** | Supported | RAG-focused; data framework for LLM apps |
+| **AG2** | Supported | Open-source AgentOS |
+| AWS Bedrock Agents | In progress | — |
+
+### Community
+
+| Framework | Status |
+| --- | --- |
+| Claude Agent SDK | Listed on partner site |
+| Langroid | Listed |
+| OpenAI Agent SDK | In progress |
+| Cloudflare Agents | In progress |
+
+### Integration pattern
+
+Each framework integration provides:
+
+1. An `AbstractAgent` subclass (TypeScript or equivalent) that translates the
+   framework's native event stream into AG-UI events.
+2. Often, a server-side companion (Python) that emits AG-UI events from
+   within the framework's run loop.
+3. Examples in the upstream `apps/dojo/` showcasing agentic chat,
+   generative UI, human-in-the-loop, shared state, and tool-based UI.
+
+See `quickstart/middleware.md` for the pattern when you need to build a
+similar adapter for a framework not yet covered.
+
+## Infrastructure / deployment
+
+| Platform | Status | Notes |
+| --- | --- | --- |
+| **Amazon Bedrock AgentCore** | Supported, 1st-party | Fully managed infrastructure for deploying AG-UI agents with native protocol support, managed authentication, session isolation, and auto-scaling. See `aws.amazon.com/bedrock/agentcore/`. |
+
+For self-hosted deployments, the protocol is just HTTP + SSE (or binary), so
+any container / serverless platform works. The dojo (`apps/dojo/`) is a
+Next.js app that can be deployed standalone.
+
+## Specifications and sister protocols
+
+AG-UI is one of three open agentic protocols, each at a different layer:
+
+| Layer | Protocol | Origin |
+| --- | --- | --- |
+| Agent ↔ Tools / Data | **MCP** (Model Context Protocol) | Anthropic |
+| Agent ↔ Agent | **A2A** (Agent to Agent) | Google |
+| **Agent ↔ User** | **AG-UI** | CopilotKit + LangGraph + CrewAI |
+
+A single agent often uses all three simultaneously.
+
+### Handshakes with sister protocols
+
+| Spec | Status |
+| --- | --- |
+| **A2A Middleware** | Supported partnership — AG-UI can front for A2A-served agents |
+
+### Generative UI specs
+
+AG-UI is **not itself a generative-UI spec**. It is the bidirectional
+event/runtime protocol that provides the two-way connection between the agent
+and the application, and it **natively supports all three** generative-UI specs
+below (plus custom ones). Generative-UI specs define *how* UI components are
+structured and transmitted; AG-UI provides the runtime that carries them.
+
+| Spec | Author(s) | Notes |
+| --- | --- | --- |
+| **A2UI** | Google | Declarative, LLM-friendly generative-UI spec — JSONL-based, streaming, platform-agnostic rendering |
+| **Open-JSON-UI** | OpenAI | Open standardization of OpenAI's internal declarative generative-UI schema |
+| **MCP-UI** | Microsoft + Shopify | Fully open, iframe-based generative-UI standard that extends MCP for user-facing experiences |
+
+Don't confuse **A2UI** (a generative-UI widget spec) with **AG-UI** (the
+Agent ↔ User interaction protocol) — different scopes, complementary roles.
+See `concepts/generative-ui-specs.md` for the full breakdown.
+
+### Other standards
+
+| Spec | Status |
+| --- | --- |
+| **Oracle Open Agent Spec** | Supported — portable language for defining agentic systems |
+
+## SDKs (covered separately)
+
+See `sdks/typescript.md`, `sdks/python.md`, and `sdks/others.md` for the
+language coverage matrix.
+
+## Where to get help / engage
+
+- **GitHub**: [github.com/ag-ui-protocol/ag-ui](https://github.com/ag-ui-protocol/ag-ui)
+  for issues, PRs, and discussions.
+- **Discord**: [discord.gg/Jd3FzfdJa8](https://discord.gg/Jd3FzfdJa8) for
+  community chat.
+- **Dojo**: [dojo.ag-ui.com](https://dojo.ag-ui.com/) for live demos of every
+  feature with every supported framework.
+
+## When picking an integration
+
+| Situation | Recommendation |
+| --- | --- |
+| Building a React app, want fastest path to a working chat UI | CopilotKit + your choice of agent framework |
+| Already using LangGraph / CrewAI / Mastra | The 1st-party integration for that framework — they provide the AbstractAgent subclass |
+| Building a new agent from scratch in Python | Server path (`quickstart/server.md`); FastAPI + `ag_ui.encoder` |
+| Building a custom non-React client | Client path (`quickstart/client.md`); the SDK exposes RxJS streams |
+| Deploying to AWS without managing infra | Bedrock AgentCore |
+| Need to coordinate multiple agents | LangGraph or AG2; emit AG-UI events from the orchestrator |
+
+## See also
+
+- `quickstart/server.md` — when you need to build a new server
+- `quickstart/middleware.md` — when you're adapting a framework
+- `quickstart/client.md` — when you're consuming events
+- `concepts/capabilities.md` — how agents advertise what they support

--- a/.agents/skills/ag-ui-knowledge/references/quickstart/client.md
+++ b/.agents/skills/ag-ui-knowledge/references/quickstart/client.md
@@ -1,0 +1,254 @@
+# Quickstart: Client implementation
+
+Source: `submodules/ag-ui/docs/quickstart/clients.mdx`
+
+How to **consume AG-UI events** in a user-facing app. Open this file when
+building a CLI, web, or mobile client that talks to an AG-UI-compatible
+agent. The walkthrough below uses Mastra; the pattern is the same for any
+agent implementation.
+
+## When to build your own client
+
+For most production cases, use a full-featured client like
+[CopilotKit](https://copilotkit.ai). Building your own client is useful when
+you want to:
+
+- Explore or hack on the AG-UI protocol directly.
+- Build a CLI/terminal/mobile experience CopilotKit doesn't cover.
+- Tightly integrate AG-UI into a custom UI framework.
+
+## What the example builds
+
+A Node.js/TypeScript CLI that:
+
+1. Wraps a Mastra agent via `MastraAgent` from `@ag-ui/mastra`.
+2. Uses OpenAI's GPT-4o.
+3. Streams responses to the terminal.
+4. Adds tools (weather, browser) and shows tool-call events.
+
+## Project setup
+
+```bash
+mkdir my-ag-ui-client && cd my-ag-ui-client
+pnpm init
+pnpm add -D typescript @types/node tsx
+```
+
+Minimal `tsconfig.json`:
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}
+```
+
+Scripts:
+
+```json
+{
+  "scripts": {
+    "start": "tsx src/index.ts",
+    "dev":   "tsx --watch src/index.ts",
+    "build": "tsc"
+  }
+}
+```
+
+## Install dependencies
+
+```bash
+pnpm add @ag-ui/client @ag-ui/core @ag-ui/mastra
+pnpm add @mastra/core @mastra/client-js @mastra/memory @mastra/libsql
+pnpm add zod
+```
+
+## Define the agent (`src/agent.ts`)
+
+```typescript
+import { Agent } from "@mastra/core/agent"
+import { MastraAgent } from "@ag-ui/mastra"
+import { Memory } from "@mastra/memory"
+import { LibSQLStore } from "@mastra/libsql"
+
+export const agent = new MastraAgent({
+  resourceId: "cliExample",
+  agent: new Agent({
+    id: "ag-ui-assistant",
+    name: "AG-UI Assistant",
+    instructions: `
+      You are a helpful AI assistant. Be friendly, conversational, and helpful.
+    `,
+    model: "openai/gpt-4o",
+    memory: new Memory({
+      storage: new LibSQLStore({ id: "storage-memory", url: "file:./assistant.db" }),
+    }),
+  }),
+  threadId: "main-conversation",
+})
+```
+
+`MastraAgent` is the AG-UI adapter for Mastra — it implements `AbstractAgent`
+and wires Mastra's event stream into AG-UI events.
+
+## CLI interface (`src/index.ts`)
+
+```typescript
+import * as readline from "readline"
+import { randomUUID } from "@ag-ui/client"
+import { agent } from "./agent"
+
+const rl = readline.createInterface({ input: process.stdin, output: process.stdout })
+
+async function chatLoop() {
+  console.log("AG-UI Assistant started!")
+  console.log("Type a message and press Enter. Ctrl+D to quit.\n")
+
+  return new Promise<void>((resolve) => {
+    const promptUser = () => {
+      rl.question("> ", async (input) => {
+        if (!input.trim()) return promptUser()
+        console.log("")
+        rl.pause()
+
+        agent.messages.push({ id: randomUUID(), role: "user", content: input.trim() })
+
+        try {
+          await agent.runAgent(
+            {},  // no extra runAgent params
+            {
+              onTextMessageStartEvent()                   { process.stdout.write("Assistant: ") },
+              onTextMessageContentEvent({ event })        { process.stdout.write(event.delta) },
+              onTextMessageEndEvent()                     { console.log("\n") },
+            }
+          )
+        } catch (error) {
+          console.error("Error:", error)
+        }
+
+        rl.resume()
+        promptUser()
+      })
+    }
+
+    rl.on("close", () => { console.log("\nBye!"); resolve() })
+    promptUser()
+  })
+}
+
+chatLoop().catch(console.error)
+```
+
+The handler object you pass as the second argument to `runAgent` is an
+`AgentSubscriber` — it's how you observe AG-UI events. See `concepts/agents.md`
+and `references/sdks/typescript.md` for the full event handler list.
+
+## Adding tools
+
+Create `src/tools/weather.tool.ts`:
+
+```typescript
+import { createTool } from "@mastra/core/tools"
+import { z } from "zod"
+
+export const weatherTool = createTool({
+  id: "get-weather",
+  description: "Get current weather for a location",
+  inputSchema:  z.object({ location: z.string().describe("City name") }),
+  outputSchema: z.object({
+    temperature: z.number(),
+    feelsLike: z.number(),
+    humidity: z.number(),
+    windSpeed: z.number(),
+    windGust: z.number(),
+    conditions: z.string(),
+    location: z.string(),
+  }),
+  execute: async ({ location }) => fetchWeather(location),
+})
+```
+
+Register on the agent:
+
+```typescript
+import { weatherTool } from "./tools/weather.tool"
+
+export const agent = new MastraAgent({
+  agent: new Agent({
+    // ... existing config
+    tools: { weatherTool },
+  }),
+  threadId: "main-conversation",
+})
+```
+
+Listen for tool events in the CLI:
+
+```typescript
+await agent.runAgent({}, {
+  // ... existing handlers
+  onToolCallStartEvent({ event })  { console.log("Tool call:", event.toolCallName) },
+  onToolCallArgsEvent({ event })   { process.stdout.write(event.delta) },
+  onToolCallEndEvent()             { console.log("") },
+  onToolCallResultEvent({ event }) { if (event.content) console.log("Result:", event.content) },
+})
+```
+
+## What event flow you're handling
+
+1. **User input** captured by readline.
+2. **Message added** to `agent.messages` (the shared history).
+3. **Agent run** triggers a `RunStartedEvent` → streamed content events →
+   `RunFinishedEvent`.
+4. **Streaming display** via the subscriber callbacks above.
+
+Mapping subscriber method ↔ event:
+
+| Subscriber method | Underlying event |
+| --- | --- |
+| `onRunStartedEvent` | `RUN_STARTED` |
+| `onRunFinishedEvent` / `onRunErrorEvent` | terminal events |
+| `onTextMessageStartEvent` / `ContentEvent` / `EndEvent` | `TEXT_MESSAGE_*` triad |
+| `onToolCallStartEvent` / `ArgsEvent` / `EndEvent` / `ResultEvent` | `TOOL_CALL_*` triad + result |
+| `onStateSnapshotEvent` / `onStateDeltaEvent` | shared state changes |
+| `onReasoningStartEvent` / `ReasoningEndEvent` etc. | `REASONING_*` events |
+
+You can also subscribe to `agent.events$` (an RxJS observable) for the raw
+typed `BaseEvent` stream — useful when you want to switch on `event.type`
+directly.
+
+## Deploying / globalizing the CLI
+
+```bash
+pnpm build
+chmod +x dist/index.js
+# add a shebang in dist/index.js: #!/usr/bin/env node
+pnpm link --global
+```
+
+## Extension ideas
+
+- Calculator, file system, database, or API tools (same `createTool` pattern).
+- Use `chalk` for color output; `ora` for spinners.
+- Persist conversation history (replay `MESSAGES_SNAPSHOT` on startup).
+- Cache expensive tool results.
+
+## See also
+
+- `concepts/agents.md` — `AbstractAgent` lifecycle
+- `concepts/events.md` — every event the agent can emit
+- `concepts/tools.md` — frontend-defined tool round-trip
+- `references/sdks/typescript.md` — `@ag-ui/client` API including
+  `AgentSubscriber`

--- a/.agents/skills/ag-ui-knowledge/references/quickstart/middleware.md
+++ b/.agents/skills/ag-ui-knowledge/references/quickstart/middleware.md
@@ -1,0 +1,184 @@
+# Quickstart: Middleware implementation
+
+Source: `submodules/ag-ui/docs/quickstart/middleware.mdx`
+
+How to **translate an existing protocol or framework into AG-UI events** by
+extending `AbstractAgent`. Open this file when wrapping LangGraph, CrewAI,
+Mastra, an internal SDK, or any other backend you don't fully control.
+
+## When to use this path
+
+Pick a middleware implementation when you:
+
+- Have an **existing protocol or API** you want to expose universally.
+- Work within the confines of an **existing framework**.
+- **Don't have direct control** over the upstream agent framework.
+
+If you're building a brand-new agent from scratch, prefer the server path
+(`quickstart/server.md`) for cleaner control over emitted events.
+
+## Contract
+
+You extend `AbstractAgent` and implement `run(input: RunAgentInput) ->
+Observable<BaseEvent>`. Everything else (state, message history, event
+processing, tool wiring) is provided by the base class.
+
+```typescript
+import { AbstractAgent, BaseEvent, EventType, RunAgentInput } from "@ag-ui/client"
+import { Observable } from "rxjs"
+
+export class MyFrameworkAgent extends AbstractAgent {
+  run(input: RunAgentInput): Observable<BaseEvent> {
+    // emit AG-UI events for each upstream-framework event
+  }
+}
+```
+
+## Stub agent (the starting template)
+
+```typescript
+import { AbstractAgent, BaseEvent, EventType, RunAgentInput } from "@ag-ui/client"
+import { Observable } from "rxjs"
+
+export class OpenAIAgent extends AbstractAgent {
+  run(input: RunAgentInput): Observable<BaseEvent> {
+    const messageId = Date.now().toString()
+    return new Observable<BaseEvent>((observer) => {
+      observer.next({ type: EventType.RUN_STARTED, threadId: input.threadId, runId: input.runId } as any)
+      observer.next({ type: EventType.TEXT_MESSAGE_START, messageId } as any)
+      observer.next({ type: EventType.TEXT_MESSAGE_CONTENT, messageId, delta: "Hello world!" } as any)
+      observer.next({ type: EventType.TEXT_MESSAGE_END, messageId } as any)
+      observer.next({ type: EventType.RUN_FINISHED, threadId: input.threadId, runId: input.runId } as any)
+      observer.complete()
+    })
+  }
+}
+```
+
+That's a valid (if unhelpful) AG-UI agent. Real adapters replace the hardcoded
+events with translations of upstream-framework events.
+
+## Real adapter: OpenAI in-process
+
+```typescript
+import { AbstractAgent, BaseEvent, EventType, RunAgentInput } from "@ag-ui/client"
+import { Observable } from "rxjs"
+import { OpenAI } from "openai"
+
+export class OpenAIAgent extends AbstractAgent {
+  private openai: OpenAI
+
+  constructor(openai?: OpenAI) {
+    super()
+    this.openai = openai ?? new OpenAI() // uses OPENAI_API_KEY
+  }
+
+  run(input: RunAgentInput): Observable<BaseEvent> {
+    return new Observable<BaseEvent>((observer) => {
+      observer.next({
+        type: EventType.RUN_STARTED,
+        threadId: input.threadId,
+        runId: input.runId,
+      } as any)
+
+      this.openai.chat.completions.create({
+        model: "gpt-4o",
+        stream: true,
+        tools: input.tools.map((tool) => ({
+          type: "function",
+          function: {
+            name: tool.name,
+            description: tool.description,
+            parameters: tool.parameters,
+          },
+        })),
+        messages: input.messages.map((message) => ({
+          role: message.role as any,
+          content: message.content ?? "",
+          ...(message.role === "assistant" && message.toolCalls
+            ? { tool_calls: message.toolCalls }
+            : {}),
+          ...(message.role === "tool"
+            ? { tool_call_id: (message as any).toolCallId }
+            : {}),
+        })),
+      })
+      .then(async (response) => {
+        const messageId = Date.now().toString()
+
+        for await (const chunk of response) {
+          if (chunk.choices[0].delta.content) {
+            observer.next({
+              type: EventType.TEXT_MESSAGE_CHUNK,           // auto opens & closes triad
+              messageId,
+              delta: chunk.choices[0].delta.content,
+            } as any)
+          } else if (chunk.choices[0].delta.tool_calls) {
+            const tc = chunk.choices[0].delta.tool_calls[0]
+            observer.next({
+              type: EventType.TOOL_CALL_CHUNK,
+              toolCallId: tc.id,
+              toolCallName: tc.function?.name,
+              parentMessageId: messageId,
+              delta: tc.function?.arguments,
+            } as any)
+          }
+        }
+
+        observer.next({
+          type: EventType.RUN_FINISHED,
+          threadId: input.threadId,
+          runId: input.runId,
+        } as any)
+        observer.complete()
+      })
+      .catch((error) => {
+        observer.next({ type: EventType.RUN_ERROR, message: error.message } as any)
+        observer.error(error)
+      })
+    })
+  }
+}
+```
+
+### Pattern
+
+1. **Set up** — initialize the upstream client; emit `RUN_STARTED`.
+2. **Translate input** — convert AG-UI messages/tools into the upstream
+   framework's format.
+3. **Stream output** — for each upstream chunk, emit the matching AG-UI event
+   (`TEXT_MESSAGE_CHUNK`, `TOOL_CALL_CHUNK`, `STATE_DELTA`, `REASONING_*`).
+4. **Terminate** — emit `RUN_FINISHED` on success or `RUN_ERROR` on failure
+   and complete the observable.
+
+This shape works for nearly any backend: REST/GraphQL APIs, WebSockets, MQTT,
+in-process agent frameworks.
+
+## When you need more than `run()`
+
+- **Custom config** — extend `AgentConfig` and call `super(config)`.
+- **Authentication** — pass credentials via constructor or via
+  `RunAgentParameters.forwardedProps` (the latter is per-run; useful for
+  per-user auth).
+- **Caching / observability** — layer in via `agent.use(middleware)` instead
+  of bloating `run()`. See `concepts/middleware.md`.
+- **Persistent connection** — override `connect()` for streaming use cases
+  where one HTTP request handles multiple runs (e.g. server-sent push). Note
+  `connectAgent()` does not run middleware in the current implementation.
+
+## Tips
+
+- Reach for `TEXT_MESSAGE_CHUNK` / `TOOL_CALL_CHUNK` first — they're easier
+  to emit correctly than the explicit Start/Content/End triads.
+- Make `run()` synchronous in setup, asynchronous in streaming. Don't
+  `await` the entire upstream call before emitting `RUN_STARTED`.
+- For interrupts: emit `STATE_SNAPSHOT` + `MESSAGES_SNAPSHOT` then
+  `RUN_FINISHED { outcome: { type: "interrupt", interrupts: [...] } }`. The
+  next `RunAgentInput.resume` array brings you back. See `concepts/interrupts.md`.
+
+## See also
+
+- `concepts/agents.md` — `AbstractAgent` lifecycle and helpers
+- `concepts/events.md` — events you can emit
+- `concepts/middleware.md` — wrapping the agent with cross-cutting behavior
+- `references/sdks/typescript.md` — full `@ag-ui/client` API

--- a/.agents/skills/ag-ui-knowledge/references/quickstart/server.md
+++ b/.agents/skills/ag-ui-knowledge/references/quickstart/server.md
@@ -1,0 +1,223 @@
+# Quickstart: Server implementation
+
+Source: `submodules/ag-ui/docs/quickstart/server.mdx`
+
+How to build a **native AG-UI server** that emits events directly. Open this
+file when implementing the agent endpoint from scratch (no existing framework
+to adapt), especially in Python/FastAPI.
+
+## When to use this path
+
+Pick a server implementation when you want:
+
+- A **new agent built from scratch** (no existing framework to wrap).
+- **Maximum control** over which events are emitted and when.
+- A **standalone API** exposing your agent.
+
+For wrapping an existing agent framework or in-process orchestrator, use the
+middleware path instead (`quickstart/middleware.md`). For building the
+consuming UI, use `quickstart/client.md`.
+
+## What the contract is
+
+An AG-UI server accepts:
+
+- `POST /` with body `RunAgentInput` (JSON).
+- `Accept: text/event-stream` for SSE (or the binary content-type if
+  supported).
+
+And returns a stream of AG-UI events:
+
+- Lifecycle: `RUN_STARTED`, `RUN_FINISHED`, `RUN_ERROR`.
+- Content: `TEXT_MESSAGE_*`, `TOOL_CALL_*`, `STATE_*`, `REASONING_*`, and so on.
+
+## Minimum viable server (Python / FastAPI)
+
+```python
+from fastapi import FastAPI, Request
+from fastapi.responses import StreamingResponse
+from ag_ui.core import RunAgentInput, EventType, RunStartedEvent
+from ag_ui.encoder import EventEncoder
+import uuid
+
+app = FastAPI(title="AG-UI Endpoint")
+
+@app.post("/")
+async def agentic_chat_endpoint(input_data: RunAgentInput, request: Request):
+    accept_header = request.headers.get("accept")
+    encoder = EventEncoder(accept=accept_header)
+
+    async def event_generator():
+        yield encoder.encode(
+            RunStartedEvent(
+                type=EventType.RUN_STARTED,
+                thread_id=input_data.thread_id,
+                run_id=input_data.run_id,
+            )
+        )
+        # ... (emit more events)
+
+    return StreamingResponse(event_generator(), media_type="text/event-stream")
+```
+
+`EventEncoder` formats events as SSE (`data: {json}\n\n` per event) by default.
+
+## Full streaming chat with OpenAI
+
+This is the canonical end-to-end example: accept `RunAgentInput`, call OpenAI
+with streaming, forward each chunk as an AG-UI event, terminate with
+`RUN_FINISHED` (or `RUN_ERROR` on exception).
+
+```python
+import os, uuid, uvicorn
+from fastapi import FastAPI, Request
+from fastapi.responses import StreamingResponse
+from ag_ui.core import (
+    RunAgentInput, EventType,
+    RunStartedEvent, RunFinishedEvent, RunErrorEvent,
+    TextMessageChunkEvent, ToolCallChunkEvent,
+)
+from ag_ui.encoder import EventEncoder
+from openai import OpenAI
+
+app = FastAPI(title="AG-UI OpenAI Server")
+client = OpenAI()  # uses OPENAI_API_KEY
+
+@app.post("/")
+async def agentic_chat_endpoint(input_data: RunAgentInput, request: Request):
+    accept_header = request.headers.get("accept")
+    encoder = EventEncoder(accept=accept_header)
+
+    async def event_generator():
+        try:
+            yield encoder.encode(RunStartedEvent(
+                type=EventType.RUN_STARTED,
+                thread_id=input_data.thread_id,
+                run_id=input_data.run_id,
+            ))
+
+            stream = client.chat.completions.create(
+                model="gpt-4o",
+                stream=True,
+                tools=[
+                    {"type": "function", "function": {
+                        "name": tool.name,
+                        "description": tool.description,
+                        "parameters": tool.parameters,
+                    }} for tool in input_data.tools
+                ] if input_data.tools else None,
+                messages=[
+                    {
+                        "role": message.role,
+                        "content": message.content or "",
+                        **({"tool_calls": message.tool_calls}
+                           if message.role == "assistant" and getattr(message, "tool_calls", None) else {}),
+                        **({"tool_call_id": message.tool_call_id}
+                           if message.role == "tool" and getattr(message, "tool_call_id", None) else {}),
+                    }
+                    for message in input_data.messages
+                ],
+            )
+
+            message_id = str(uuid.uuid4())
+
+            for chunk in stream:
+                delta = chunk.choices[0].delta
+                if delta.content:
+                    yield encoder.encode(TextMessageChunkEvent(
+                        type=EventType.TEXT_MESSAGE_CHUNK,
+                        message_id=message_id,
+                        delta=delta.content,
+                    ))
+                elif delta.tool_calls:
+                    tc = delta.tool_calls[0]
+                    yield encoder.encode(ToolCallChunkEvent(
+                        type=EventType.TOOL_CALL_CHUNK,
+                        tool_call_id=tc.id,
+                        tool_call_name=tc.function.name if tc.function else None,
+                        parent_message_id=message_id,
+                        delta=tc.function.arguments if tc.function else None,
+                    ))
+
+            yield encoder.encode(RunFinishedEvent(
+                type=EventType.RUN_FINISHED,
+                thread_id=input_data.thread_id,
+                run_id=input_data.run_id,
+            ))
+
+        except Exception as error:
+            yield encoder.encode(RunErrorEvent(
+                type=EventType.RUN_ERROR,
+                message=str(error),
+            ))
+
+    return StreamingResponse(event_generator(), media_type=encoder.get_content_type())
+
+def main():
+    port = int(os.getenv("PORT", "8000"))
+    uvicorn.run("example_server:app", host="0.0.0.0", port=port, reload=True)
+
+if __name__ == "__main__":
+    main()
+```
+
+### What's happening
+
+1. **Setup** — create the OpenAI client, emit `RUN_STARTED`.
+2. **Request** — convert AG-UI tools/messages to OpenAI shapes; call
+   `chat.completions` with `stream=True`.
+3. **Streaming** — forward each chunk as `TEXT_MESSAGE_CHUNK` or
+   `TOOL_CALL_CHUNK`. Chunks auto-open/close their triads.
+4. **Finish** — emit `RUN_FINISHED` on success, `RUN_ERROR` on exception.
+
+## Smoke-test with curl
+
+```bash
+curl -X POST http://localhost:8000/ \
+  -H "Content-Type: application/json" \
+  -H "Accept: text/event-stream" \
+  -d '{
+    "threadId": "thread_123",
+    "runId": "run_456",
+    "state": {},
+    "messages": [{ "id": "msg_1", "role": "user", "content": "Hello, how are you?" }],
+    "tools": [],
+    "context": [],
+    "forwardedProps": {}
+  }'
+```
+
+You should see SSE events streamed back, terminated by `RUN_FINISHED`.
+
+## Extending the server
+
+- **Tools** — keep the `tool_calls` branch and add a `tool` role-message
+  handler in your conversion code. The client returns tool results as
+  `tool`-role messages in subsequent `RunAgentInput.messages`.
+- **State** — emit `STATE_SNAPSHOT` at the start and `STATE_DELTA` (RFC 6902
+  patches) as your agent updates internal state. See `concepts/state.md`.
+- **Interrupts** — emit `STATE_SNAPSHOT` + `MESSAGES_SNAPSHOT` then
+  `RUN_FINISHED { outcome: { type: "interrupt", interrupts: [...] } }`. See
+  `concepts/interrupts.md`.
+- **Reasoning** — wrap chain-of-thought summaries with `REASONING_*` events;
+  attach encrypted detail with `REASONING_ENCRYPTED_VALUE`. See
+  `concepts/reasoning.md`.
+
+## Tips
+
+- Use `*_CHUNK` events for the simplest streaming code — they collapse the
+  Start/Content/End triad into one event type.
+- Always wrap your generator in a `try/except` and emit `RUN_ERROR` on
+  failure; the client treats a closed stream without a terminal event as a
+  protocol violation.
+- Set the response `media_type` from `encoder.get_content_type()` so the
+  binary protocol path works too.
+- For deployment, return `StreamingResponse` (FastAPI) or your framework's
+  equivalent so the connection stays open and chunks flush as emitted.
+
+## See also
+
+- `concepts/events.md` — full event reference
+- `concepts/state.md` — snapshot/delta mechanics
+- `concepts/interrupts.md` — pausing the run for the user
+- `references/sdks/python.md` — `ag_ui.core` and `ag_ui.encoder` reference

--- a/.agents/skills/ag-ui-knowledge/references/sdks/others.md
+++ b/.agents/skills/ag-ui-knowledge/references/sdks/others.md
@@ -1,0 +1,104 @@
+# Other SDKs
+
+Source: `submodules/ag-ui/docs/sdk/**` and the upstream `sdks/community/`
+directory.
+
+Brief pointers for the community SDKs. Open this file when someone asks
+"is there an AG-UI SDK for X?" or needs an install hint. All listed SDKs
+implement the same wire protocol as the TypeScript and Python SDKs — the
+event taxonomy, message types, and run contract in `concepts/` apply
+verbatim.
+
+## Status overview
+
+| Language | Status | Where to look |
+| --- | --- | --- |
+| TypeScript / JavaScript | 1st-party (see `sdks/typescript.md`) | `submodules/ag-ui/sdks/typescript/packages/` |
+| Python | 1st-party (see `sdks/python.md`) | `submodules/ag-ui/sdks/python/` |
+| Rust | Community, supported | `submodules/ag-ui/sdks/community/rust/` |
+| Java | Community, supported | `submodules/ag-ui/docs/sdk/java/overview.mdx` |
+| Kotlin | Community, supported | `submodules/ag-ui/docs/sdk/kotlin/overview.mdx` |
+| Go | Community, supported | `submodules/ag-ui/docs/sdk/go/overview.mdx` |
+| Dart | Community, supported | `submodules/ag-ui/sdks/community/dart/` |
+| Ruby | Community, supported | `submodules/ag-ui/sdks/community/ruby/` |
+| .NET | In progress | upstream PR #38 |
+| Nim | In progress | upstream PR #29 |
+| Flowise | In progress | upstream issue #367 |
+| Langflow | In progress | upstream issue #366 |
+| Cloudflare Agents | In progress | upstream PR #655 |
+
+## Rust
+
+Upstream: `submodules/ag-ui/sdks/community/rust/crates/ag-ui-client/`
+
+```bash
+cargo add ag-ui-client
+```
+
+Provides:
+
+- `Agent` trait — equivalent of `AbstractAgent`.
+- `HttpAgent` implementation for connecting to AG-UI endpoints.
+- Subscriber/observer patterns over the event stream.
+- Core types (events, messages, RunAgentInput) generated to match the
+  TypeScript schema.
+
+For the latest docs, read the source `README.md` in the crate directory —
+the docs site references the GitHub source rather than maintaining separate
+prose.
+
+## Java
+
+Upstream docs: `submodules/ag-ui/docs/sdk/java/`
+
+Provides client (`HttpAgent`, `AbstractAgent`, `Subscriber`), core types,
+and a Spring-integration server module. The package layout mirrors the
+TypeScript SDK closely — same conceptual API surface, idiomatic Java.
+
+## Kotlin
+
+Upstream docs: `submodules/ag-ui/docs/sdk/kotlin/`
+
+Provides multiple agent types, core types, and a tools package with an
+executor and registry pattern. Suitable for JVM and Android targets.
+
+## Go
+
+Upstream docs: `submodules/ag-ui/docs/sdk/go/`
+
+Provides an SSE client, core types, encoding, and error types. The client is
+written idiomatic Go (channels over RxJS).
+
+## Dart
+
+Upstream: `submodules/ag-ui/sdks/community/dart/`
+
+Provides client, core types, and an encoder. Useful for Flutter mobile apps.
+
+## Ruby
+
+Upstream: `submodules/ag-ui/sdks/community/ruby/`
+
+Provides core types and an encoder. Useful for Rails/Sinatra backends.
+
+## When using a community SDK
+
+- The **wire protocol is the same** as TypeScript/Python — events,
+  RunAgentInput, message types, interrupt outcomes all match.
+- API ergonomics differ per language (RxJS in TS/JS, async generators in
+  Python, channels in Go, Coroutines in Kotlin/Rust). The mapping is
+  mechanical once you know the events.
+- Community SDKs may lag behind the spec by a release or two. Cross-reference
+  the event types you need against `concepts/events.md`; if something is
+  missing, file or check an upstream issue.
+- Some community SDKs only ship the client. For server-side implementations
+  in those languages, you can still emit AG-UI events manually using the
+  HTTP+SSE contract from `quickstart/server.md` (the format is just JSON
+  over SSE).
+
+## See also
+
+- `sdks/typescript.md` — the reference 1st-party SDK
+- `sdks/python.md` — the reference 1st-party SDK
+- `integrations.md` — framework-level integrations (LangGraph, Mastra,
+  CopilotKit, etc.), which often bundle client/server pieces

--- a/.agents/skills/ag-ui-knowledge/references/sdks/python.md
+++ b/.agents/skills/ag-ui-knowledge/references/sdks/python.md
@@ -1,0 +1,222 @@
+# Python SDK
+
+Source: `submodules/ag-ui/docs/sdk/python/**`
+
+The first-party Python package `ag-ui-protocol`. Open this file for
+`ag_ui.core` (types and events), `ag_ui.encoder.EventEncoder`, and
+FastAPI/SSE server patterns.
+
+## Install
+
+```bash
+pip install ag-ui-protocol
+```
+
+Or with Poetry:
+
+```bash
+poetry add ag-ui-protocol
+```
+
+## `ag_ui.core`
+
+Strongly-typed Pydantic models for the protocol.
+
+```python
+from ag_ui.core import (
+    RunAgentInput,
+    EventType,
+    BaseEvent,
+    RunStartedEvent, RunFinishedEvent, RunErrorEvent,
+    StepStartedEvent, StepFinishedEvent,
+    TextMessageStartEvent, TextMessageContentEvent, TextMessageEndEvent, TextMessageChunkEvent,
+    ToolCallStartEvent, ToolCallArgsEvent, ToolCallEndEvent, ToolCallResultEvent, ToolCallChunkEvent,
+    StateSnapshotEvent, StateDeltaEvent, MessagesSnapshotEvent,
+    ActivitySnapshotEvent, ActivityDeltaEvent,
+    ReasoningStartEvent, ReasoningMessageStartEvent, ReasoningMessageContentEvent,
+    ReasoningMessageEndEvent, ReasoningMessageChunkEvent, ReasoningEndEvent,
+    ReasoningEncryptedValueEvent,
+    RawEvent, CustomEvent,
+)
+```
+
+### Core data structures
+
+| Type | Purpose |
+| --- | --- |
+| `RunAgentInput` | The POST body: `thread_id`, `run_id`, `messages`, `tools`, `state`, `context`, `forwarded_props`, optional `resume` for interrupts |
+| `Message` (union: User/Assistant/System/Tool/Activity/Developer/Reasoning) | Conversation history |
+| `Context` | Contextual information attached to a run |
+| `Tool` | Frontend-defined tool with name, description, JSON-Schema parameters |
+| `State` | Arbitrary JSON state object |
+
+All events inherit from `BaseEvent { type: EventType, timestamp?, raw_event? }`.
+
+### Field name convention
+
+Python uses `snake_case` (`thread_id`, `run_id`, `message_id`, `tool_call_id`,
+`parent_message_id`), serialized to `camelCase` on the wire (`threadId`,
+`runId`, `messageId`, `toolCallId`, `parentMessageId`) via Pydantic's alias
+generators. The wire format matches the TypeScript SDK exactly.
+
+## `ag_ui.encoder.EventEncoder`
+
+Encodes events as Server-Sent Events (SSE) by default.
+
+```python
+from ag_ui.core import TextMessageContentEvent, EventType
+from ag_ui.encoder import EventEncoder
+
+encoder = EventEncoder()  # or EventEncoder(accept="application/x-ag-ui-binary") for binary
+
+event = TextMessageContentEvent(
+    type=EventType.TEXT_MESSAGE_CONTENT,
+    message_id="msg_123",
+    delta="Hello, world!",
+)
+
+encoded = encoder.encode(event)
+print(encoded)
+# data: {"type":"TEXT_MESSAGE_CONTENT","messageId":"msg_123","delta":"Hello, world!"}\n\n
+```
+
+### Methods
+
+| Method | Purpose |
+| --- | --- |
+| `__init__(accept: Optional[str] = None)` | Construct with the client's `Accept` header |
+| `encode(event: BaseEvent) -> str` | Format an event for transmission |
+| `get_content_type() -> str` | Use when setting `media_type` on a `StreamingResponse` |
+
+SSE wire format: `data: {json}\n\n` per event. Clients consume via the
+`EventSource` API or any SSE library.
+
+## FastAPI server pattern
+
+```python
+from fastapi import FastAPI, Request
+from fastapi.responses import StreamingResponse
+from ag_ui.core import RunAgentInput, EventType, RunStartedEvent, RunFinishedEvent
+from ag_ui.encoder import EventEncoder
+
+app = FastAPI(title="AG-UI Endpoint")
+
+@app.post("/")
+async def endpoint(input_data: RunAgentInput, request: Request):
+    encoder = EventEncoder(accept=request.headers.get("accept"))
+
+    async def event_generator():
+        yield encoder.encode(RunStartedEvent(
+            type=EventType.RUN_STARTED,
+            thread_id=input_data.thread_id,
+            run_id=input_data.run_id,
+        ))
+        # ... stream content events ...
+        yield encoder.encode(RunFinishedEvent(
+            type=EventType.RUN_FINISHED,
+            thread_id=input_data.thread_id,
+            run_id=input_data.run_id,
+        ))
+
+    return StreamingResponse(event_generator(), media_type=encoder.get_content_type())
+```
+
+Always:
+
+- Set `media_type=encoder.get_content_type()` so the binary path works.
+- Wrap your generator in `try/except` and emit `RunErrorEvent` on failure.
+- Use `*_CHUNK` events when possible — they're the shortest correct way to
+  stream text/tool calls.
+
+See `quickstart/server.md` for a full OpenAI integration.
+
+## Multimodal input (Python)
+
+`UserMessage.content` can be a plain string or a list of `InputContent`
+items:
+
+```python
+from ag_ui.core import UserMessage, TextInputContent, ImageInputContent, InputContentUrlSource
+
+msg = UserMessage(
+    id="msg_1",
+    role="user",
+    content=[
+        TextInputContent(type="text", text="What's in this image?"),
+        ImageInputContent(
+            type="image",
+            source=InputContentUrlSource(type="url", value="https://example.com/cat.jpg"),
+        ),
+    ],
+)
+```
+
+Supported types: `text`, `image`, `audio`, `video`, `document`. Each non-text
+type has a `source` that's either `{type: "data", value, mimeType}` (inline)
+or `{type: "url", value, mimeType?}`. The older `BinaryInputContent` is
+deprecated but kept temporarily for compatibility.
+
+## State events
+
+```python
+from ag_ui.core import StateSnapshotEvent, StateDeltaEvent, EventType
+
+# Replace entire state
+yield encoder.encode(StateSnapshotEvent(
+    type=EventType.STATE_SNAPSHOT,
+    snapshot={"counter": 0, "items": []},
+))
+
+# Apply RFC 6902 JSON Patch
+yield encoder.encode(StateDeltaEvent(
+    type=EventType.STATE_DELTA,
+    delta=[
+        {"op": "replace", "path": "/counter", "value": 1},
+        {"op": "add",     "path": "/items/-", "value": "new item"},
+    ],
+))
+```
+
+See `concepts/state.md` for snapshot/delta semantics.
+
+## Interrupts
+
+Emit state and messages snapshots, then `RunFinishedEvent` with an interrupt
+outcome:
+
+```python
+from ag_ui.core import RunFinishedEvent, EventType
+
+yield encoder.encode(StateSnapshotEvent(type=EventType.STATE_SNAPSHOT, snapshot=...))
+yield encoder.encode(MessagesSnapshotEvent(type=EventType.MESSAGES_SNAPSHOT, messages=...))
+
+yield encoder.encode(RunFinishedEvent(
+    type=EventType.RUN_FINISHED,
+    thread_id=input_data.thread_id,
+    run_id=input_data.run_id,
+    outcome={
+        "type": "interrupt",
+        "interrupts": [{
+            "id": "int-1",
+            "reason": "tool_call",
+            "message": "Approve sending email?",
+            "toolCallId": "tc-1",
+            "responseSchema": {
+                "type": "object",
+                "properties": {"approved": {"type": "boolean"}},
+                "required": ["approved"],
+            },
+        }],
+    },
+))
+```
+
+The next `RunAgentInput.resume` array brings you back. See
+`concepts/interrupts.md`.
+
+## See also
+
+- `quickstart/server.md` — full FastAPI + OpenAI example
+- `concepts/events.md` — every event type and its fields
+- `concepts/state.md` — snapshot/delta mechanics
+- `concepts/interrupts.md` — interrupt outcomes and resume contracts

--- a/.agents/skills/ag-ui-knowledge/references/sdks/typescript.md
+++ b/.agents/skills/ag-ui-knowledge/references/sdks/typescript.md
@@ -1,0 +1,293 @@
+# TypeScript / JavaScript SDK
+
+Source: `submodules/ag-ui/docs/sdk/js/**`
+
+The first-party TypeScript packages: `@ag-ui/core`, `@ag-ui/client`,
+`@ag-ui/encoder`, `@ag-ui/proto`. Open this file for `AbstractAgent`,
+`HttpAgent`, middleware, and `AgentSubscriber` APIs.
+
+## Packages
+
+| Package | Purpose | Install |
+| --- | --- | --- |
+| `@ag-ui/core` | Types and event definitions, `BaseEvent`, `EventType`, `RunAgentInput`, `Message`, `Tool`, `Context`, `State` | `npm install @ag-ui/core` |
+| `@ag-ui/client` | Client runtime: `AbstractAgent`, `HttpAgent`, middleware, `AgentSubscriber`, RxJS event streams | `npm install @ag-ui/client` |
+| `@ag-ui/encoder` | Event encoding (SSE and binary) | `npm install @ag-ui/encoder` |
+| `@ag-ui/proto` | Protobuf definitions for the binary transport | `npm install @ag-ui/proto` |
+
+## `@ag-ui/core`
+
+Pure type/data package. Use it on both client and server (or middleware) to
+share type definitions for events, messages, tools, context, and state.
+
+```typescript
+import { EventType, type BaseEvent, type RunAgentInput, type Message, type Tool } from "@ag-ui/core"
+```
+
+See `concepts/events.md` for the full event type reference and
+`concepts/messages.md` for message types.
+
+## `@ag-ui/client` — `AbstractAgent`
+
+The base class for any client-side agent.
+
+```typescript
+import { AbstractAgent } from "@ag-ui/client"
+```
+
+### Configuration
+
+```typescript
+interface AgentConfig {
+  agentId?: string         // unique agent id
+  description?: string     // human-readable; also used by the LLM
+  threadId?: string        // conversation thread id
+  initialMessages?: Message[]
+  initialState?: State
+}
+```
+
+Extend the interface in a subclass to add custom options:
+
+```typescript
+interface MyAgentConfig extends AgentConfig { myOption: string }
+
+class MyAgent extends AbstractAgent {
+  private myOption: string
+  constructor(config: MyAgentConfig) {
+    super(config)
+    this.myOption = config.myOption
+  }
+}
+```
+
+### Core methods
+
+#### `runAgent(parameters?, subscriber?): Promise<RunAgentResult>`
+
+```typescript
+interface RunAgentParameters {
+  runId?: string
+  tools?: Tool[]
+  context?: Context[]
+  forwardedProps?: Record<string, any>
+}
+
+interface RunAgentResult {
+  result: any
+  newMessages: Message[]
+}
+```
+
+The optional `subscriber` receives events for this specific run.
+
+#### `subscribe(subscriber: AgentSubscriber): { unsubscribe(): void }`
+
+Adds a subscriber that handles events across multiple runs. Returns an
+unsubscribe function.
+
+#### `use(...middlewares): this`
+
+Adds middleware to the agent's event-processing pipeline. Accepts both
+function- and class-based middleware.
+
+```typescript
+agent.use((input, next) => { /* function middleware */ return next.run(input) })
+agent.use(new FilterToolCallsMiddleware({ allowedToolCalls: ["search"] }))
+agent.use(loggingMiddleware, authMiddleware, filterMiddleware)
+```
+
+Middleware executes in the order added; each wraps the next. Applied in
+`runAgent()`; **not** in `connectAgent()` (which calls `connect()` directly).
+See `concepts/middleware.md`.
+
+#### `getCapabilities?(): Promise<AgentCapabilities>`
+
+Optional. Returns `undefined` when not implemented. See
+`concepts/capabilities.md`.
+
+#### `abortRun(): void`
+
+Cancels the current execution.
+
+#### `clone(): AbstractAgent`
+
+Deep-copies the agent instance.
+
+#### `connectAgent(parameters?, subscriber?): Promise<RunAgentResult>`
+
+Long-lived connection variant. Requires `connect()` to be implemented in the
+subclass. Default implementation throws `ConnectNotImplementedError`.
+
+### Observable properties
+
+```typescript
+events$: Observable<BaseEvent>
+```
+
+RxJS `ReplaySubject` of all events emitted during execution — late subscribers
+replay history. Switch on `event.type` for the typed event stream:
+
+```typescript
+agent.events$.subscribe((event) => {
+  if (event.type === EventType.TEXT_MESSAGE_CONTENT) appendToUi(event.delta)
+})
+```
+
+### Properties
+
+| Property | Type |
+| --- | --- |
+| `agentId` | `string` |
+| `description` | `string` |
+| `threadId` | `string` |
+| `messages` | `Message[]` |
+| `state` | `any` |
+| `events$` | `Observable<BaseEvent>` |
+
+### Protected hooks (override in subclasses)
+
+| Method | Purpose |
+| --- | --- |
+| `run(input)` | **Abstract** — emit events for the run |
+| `connect(input)` | Override for persistent connections |
+| `apply(input)` | Process events and update state |
+| `prepareRunAgentInput(parameters?)` | Build `RunAgentInput` |
+| `onError(error)` | Error hook |
+| `onFinalize()` | Cleanup hook |
+
+## `@ag-ui/client` — `HttpAgent`
+
+Concrete subclass that talks to an AG-UI HTTP endpoint.
+
+```typescript
+import { HttpAgent } from "@ag-ui/client"
+
+interface HttpAgentConfig extends AgentConfig {
+  url: string
+  headers?: Record<string, string>
+}
+
+const agent = new HttpAgent({
+  url: "https://api.example.com/v1/agent",
+  headers: { Authorization: "Bearer token" },
+})
+```
+
+### Default request shape
+
+```typescript
+{
+  method: "POST",
+  headers: {
+    ...this.headers,
+    "Content-Type": "application/json",
+    Accept: "text/event-stream",
+  },
+  body: JSON.stringify(input),
+  signal: this.abortController.signal,
+}
+```
+
+Override `requestInit(input)` to customize.
+
+### Properties
+
+| Property | Notes |
+| --- | --- |
+| `url` | Endpoint |
+| `headers` | Default headers |
+| `abortController` | `AbortController` used by `abortRun()` |
+
+## Middleware
+
+See `concepts/middleware.md` for the full picture. Two flavors:
+
+```typescript
+import { MiddlewareFunction, Middleware } from "@ag-ui/client"
+
+// Function
+const logger: MiddlewareFunction = (input, next) => next.run(input).pipe(tap(console.log))
+
+// Class
+class MetricsMiddleware extends Middleware {
+  run(input: RunAgentInput, next: AbstractAgent): Observable<BaseEvent> {
+    return this.runNext(input, next).pipe(/* ... */)
+  }
+}
+
+agent.use(logger, new MetricsMiddleware())
+```
+
+Inside class middleware:
+
+- `runNext(input, next)` — normalizes chunk events into the canonical
+  Start/Content/End triads.
+- `runNextWithState(input, next)` — also gives you accumulated messages and
+  state after each event.
+
+### Built-in: `FilterToolCallsMiddleware`
+
+```typescript
+import { FilterToolCallsMiddleware } from "@ag-ui/client"
+
+agent.use(new FilterToolCallsMiddleware({ allowedToolCalls: ["search", "calculate"] }))
+// or
+agent.use(new FilterToolCallsMiddleware({ disallowedToolCalls: ["delete", "modify"] }))
+```
+
+Filters emitted `TOOL_CALL_*` events. Does not block tool execution upstream —
+those still happen on the backend.
+
+## `AgentSubscriber`
+
+Event-driven subscriber for handling lifecycle events and state mutations.
+Pass to `runAgent(params, subscriber)` for per-run handlers, or use
+`agent.subscribe(subscriber)` for cross-run handlers.
+
+```typescript
+await agent.runAgent({}, {
+  onRunStartedEvent({ event })          { /* ... */ },
+  onTextMessageStartEvent({ event })    { /* ... */ },
+  onTextMessageContentEvent({ event })  { /* event.delta */ },
+  onTextMessageEndEvent({ event })      { /* ... */ },
+  onToolCallStartEvent({ event })       { /* event.toolCallName */ },
+  onToolCallArgsEvent({ event })        { /* event.delta */ },
+  onToolCallEndEvent({ event })         { /* ... */ },
+  onToolCallResultEvent({ event })      { /* event.content */ },
+  onStateSnapshotEvent({ event })       { /* event.snapshot */ },
+  onStateDeltaEvent({ event })          { /* event.delta — JSON Patch */ },
+  onReasoningStartEvent({ event })      { /* ... */ },
+  onRunFinishedEvent({ event })         { /* event.outcome */ },
+  onRunErrorEvent({ event })            { /* event.message */ },
+})
+```
+
+Subscriber methods cover the full event taxonomy with `on{EventName}Event`
+naming.
+
+## `@ag-ui/encoder` and `@ag-ui/proto`
+
+- `@ag-ui/encoder` — encodes/decodes events to SSE or binary frames.
+  Typically only needed when building a custom transport or instrumenting
+  the wire format.
+- `@ag-ui/proto` — protobuf schema for the binary transport. Used by the
+  encoder; rarely imported directly.
+
+## Quickstart commands
+
+```bash
+# Scaffold an end-to-end app
+npx create-ag-ui-app@latest
+
+# Or install packages manually
+npm install @ag-ui/client @ag-ui/core
+```
+
+## See also
+
+- `concepts/agents.md` — `AbstractAgent` conceptual overview
+- `concepts/middleware.md` — pipeline mechanics
+- `concepts/events.md` — every event type the subscriber methods cover
+- `quickstart/middleware.md` — building a real `AbstractAgent` subclass
+- `quickstart/client.md` — consuming events in an app

--- a/.agents/skills/mcp-knowledge/.sources.json
+++ b/.agents/skills/mcp-knowledge/.sources.json
@@ -1,0 +1,15 @@
+{
+  "skill": "mcp-knowledge",
+  "sources": [
+    {
+      "repo": "submodules/modelcontextprotocol",
+      "synced": "dc105208d6c5737c010ed3b6ff50ca19746317c1",
+      "paths": ["docs", "schema"]
+    },
+    {
+      "repo": "submodules/mcp-rust-sdk",
+      "synced": "4fd4986b6204e7bf580b23592a99bc338e2899e5",
+      "paths": ["crates/rmcp", "crates/rmcp-macros", "docs"]
+    }
+  ]
+}

--- a/.agents/skills/mcp-knowledge/SKILL.md
+++ b/.agents/skills/mcp-knowledge/SKILL.md
@@ -1,0 +1,223 @@
+---
+name: mcp-knowledge
+description: >
+  Expert guidance for the Model Context Protocol (MCP), the JSON-RPC 2.0
+  protocol connecting LLM apps to external tools and data. Covers spec
+  versions 2024-11-05 through 2025-11-25 (architecture, transports,
+  Resources, Prompts, Tools, Sampling, Roots, Elicitation, Tasks,
+  lifecycle, OAuth 2.1, utilities) plus the official language SDKs: the
+  Rust SDK `rmcp` (full guide — `ServerHandler`/`ClientHandler`,
+  `#[tool_router]`/`#[tool_handler]`/`#[task_handler]` macros,
+  `StreamableHttpService`, Cargo features, SEP-1686 tasks, `tokio::io::duplex`
+  test harness) and the TypeScript SDK `@modelcontextprotocol/sdk` (incl.
+  the `pkce-challenge` Vite/bundler resolver failure). Use when building
+  MCP servers or clients in any language, working with transports or
+  OAuth, or debugging SDK-specific issues. Always invoke for questions
+  mentioning MCP, modelcontextprotocol, `rmcp`, tools/list, tools/call,
+  sampling/createMessage, elicitation/create, Streamable HTTP,
+  Mcp-Session-Id, `pkce-challenge`, or `@modelcontextprotocol/sdk`.
+license: MIT
+metadata:
+  author: "Ikuma Yamashita"
+  version: "1.1.1"
+---
+
+# MCP Skill
+
+You are an expert in the Model Context Protocol (MCP) — an open, JSON-RPC 2.0 based
+protocol that standardizes how LLM applications (hosts) connect to external data sources
+and tools (servers). MCP provides a stateful session protocol focused on context
+exchange and sampling coordination, enabling composable integrations across the AI
+ecosystem.
+
+## What MCP Is
+
+MCP follows a client-host-server architecture. A **host** (e.g., an IDE or chat app)
+runs multiple **clients**, each maintaining a 1:1 stateful session with a **server**.
+Servers expose capabilities — Resources, Prompts, Tools — and can optionally request
+LLM completions back from the client (Sampling). The protocol uses JSON-RPC 2.0 for
+all messages and supports pluggable transports.
+
+## Versions
+
+There are four public versions:
+
+| Version        | Status        | Key additions                                                                                                                                                                                                              |
+| :------------- | :------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **2024-11-05** | First release | stdio + HTTP/SSE transports; Resources, Prompts, Tools, Sampling, Roots; Pagination, Logging, Cancellation, Ping, Progress, Completion                                                                                     |
+| **2025-03-26** | Stable        | OAuth 2.1 authorization; Streamable HTTP transport; JSON-RPC batching; tool annotations; audio content type; completions capability                                                                                        |
+| **2025-06-18** | Stable        | Elicitation; structured tool output; resource links in tool results; OAuth Resource Server classification; RFC 8707 Resource Indicators; `MCP-Protocol-Version` header; removed batching; `title` field; `_meta` expansion |
+| **2025-11-25** | Latest stable | Tasks utility; OpenID Connect discovery; tool/resource/prompt icons; incremental scope consent; URL-mode elicitation; tool calling in sampling; OAuth Client ID Metadata Documents                                         |
+
+Use **2025-11-25** for new projects. Use **2024-11-05** only when targeting legacy hosts.
+
+## Core Concepts
+
+- **Host** — the LLM application; manages client lifecycle and user consent
+- **Client** — created by the host; holds one stateful session per server
+- **Server** — exposes Resources, Prompts, or Tools; may request Sampling
+- **Capability negotiation** — client and server exchange capability objects during
+  `initialize`; only negotiated capabilities may be used during the session
+- **Resources** — application-driven context: files, DB schemas, live data (URI-addressed)
+- **Prompts** — user-triggered prompt templates with optional arguments
+- **Tools** — model-controlled functions that call external systems
+- **Sampling** — server-initiated LLM completions routed through the client (human in loop)
+- **Roots** — client-declared filesystem boundaries the server should respect
+- **Elicitation** — server requests structured input from the user via the client (2025-06-18+)
+- **Tasks** — durable async state machines for long-running requests (2025-11-25+)
+
+## Reference Files
+
+Each reference file is the full specification document for that topic, converted from
+the official MDX source at `submodules/modelcontextprotocol/docs/specification/`.
+
+### 2024-11-05
+
+| File                                    | Content                                                                                   |
+| :-------------------------------------- | :---------------------------------------------------------------------------------------- |
+| `references/2024-11-05/architecture.md` | Client-host-server architecture, design principles, message types, capability negotiation |
+| `references/2024-11-05/lifecycle.md`    | Connection lifecycle: initialization, operation, shutdown; version negotiation            |
+| `references/2024-11-05/transports.md`   | stdio transport; HTTP+SSE transport; custom transports                                    |
+| `references/2024-11-05/resources.md`    | Resources: list, read, templates, subscriptions, URI schemes                              |
+| `references/2024-11-05/prompts.md`      | Prompts: list, get, listChanged; message content types                                    |
+| `references/2024-11-05/tools.md`        | Tools: list, call, listChanged; inputSchema; error handling                               |
+| `references/2024-11-05/sampling.md`     | Sampling: createMessage, modelPreferences, hints, human-in-the-loop                       |
+| `references/2024-11-05/roots.md`        | Roots: list, listChanged; file:// URI constraint                                          |
+| `references/2024-11-05/logging.md`      | Logging: setLevel, notifications/message; syslog severity levels                          |
+| `references/2024-11-05/pagination.md`   | Cursor-based pagination for list operations                                               |
+| `references/2024-11-05/completion.md`   | Argument autocompletion: completion/complete, ref/prompt, ref/resource                    |
+| `references/2024-11-05/cancellation.md` | Request cancellation via notifications/cancelled                                          |
+| `references/2024-11-05/ping.md`         | Ping/pong for connection health                                                           |
+| `references/2024-11-05/progress.md`     | Progress tracking via progressToken and notifications/progress                            |
+
+### 2025-03-26
+
+| File                                     | Content                                                                                               |
+| :--------------------------------------- | :---------------------------------------------------------------------------------------------------- |
+| `references/2025-03-26/changelog.md`     | Delta from 2024-11-05: OAuth 2.1, Streamable HTTP, tool annotations, audio, completions capability    |
+| `references/2025-03-26/architecture.md`  | Architecture (unchanged)                                                                              |
+| `references/2025-03-26/lifecycle.md`     | Lifecycle (unchanged)                                                                                 |
+| `references/2025-03-26/transports.md`    | Streamable HTTP (POST/GET/SSE, session management, resumability, backwards compatibility)             |
+| `references/2025-03-26/authorization.md` | OAuth 2.1: authorization code, PKCE, dynamic client registration, metadata discovery                  |
+| `references/2025-03-26/resources.md`     | Resources (unchanged)                                                                                 |
+| `references/2025-03-26/prompts.md`       | Prompts (unchanged)                                                                                   |
+| `references/2025-03-26/tools.md`         | Tools: adds annotations (readOnlyHint, destructiveHint, idempotentHint, openWorldHint); audio content |
+| `references/2025-03-26/sampling.md`      | Sampling: adds audio content type                                                                     |
+| `references/2025-03-26/roots.md`         | Roots (unchanged)                                                                                     |
+| `references/2025-03-26/logging.md`       | Logging (unchanged)                                                                                   |
+| `references/2025-03-26/pagination.md`    | Pagination (unchanged)                                                                                |
+| `references/2025-03-26/completion.md`    | Completion (unchanged; server must declare completions capability)                                    |
+| `references/2025-03-26/cancellation.md`  | Cancellation (unchanged)                                                                              |
+| `references/2025-03-26/ping.md`          | Ping (unchanged)                                                                                      |
+| `references/2025-03-26/progress.md`      | Progress: adds optional message field                                                                 |
+
+### 2025-06-18
+
+| File                                     | Content                                                                                                                           |
+| :--------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------- |
+| `references/2025-06-18/changelog.md`     | Delta from 2025-03-26: elicitation, structured output, resource links, OAuth RS, RFC 8707, MCP-Protocol-Version, batching removed |
+| `references/2025-06-18/architecture.md`  | Architecture (unchanged)                                                                                                          |
+| `references/2025-06-18/lifecycle.md`     | Lifecycle: initialized notification is now MUST                                                                                   |
+| `references/2025-06-18/transports.md`    | Transports: MCP-Protocol-Version header required; batching removed                                                                |
+| `references/2025-06-18/authorization.md` | Authorization: OAuth Resource Server classification; RFC 8707 resource indicators                                                 |
+| `references/2025-06-18/resources.md`     | Resources: adds title field                                                                                                       |
+| `references/2025-06-18/prompts.md`       | Prompts: adds title field                                                                                                         |
+| `references/2025-06-18/tools.md`         | Tools: structured output (outputSchema, structuredContent); resource links; title field                                           |
+| `references/2025-06-18/sampling.md`      | Sampling (unchanged)                                                                                                              |
+| `references/2025-06-18/roots.md`         | Roots (unchanged)                                                                                                                 |
+| `references/2025-06-18/elicitation.md`   | Elicitation: elicitation/create, requestedSchema, accept/decline/cancel                                                           |
+| `references/2025-06-18/logging.md`       | Logging (unchanged)                                                                                                               |
+| `references/2025-06-18/pagination.md`    | Pagination (unchanged)                                                                                                            |
+| `references/2025-06-18/completion.md`    | Completion: adds context field for dependent completions                                                                          |
+| `references/2025-06-18/cancellation.md`  | Cancellation (unchanged)                                                                                                          |
+| `references/2025-06-18/ping.md`          | Ping (unchanged)                                                                                                                  |
+| `references/2025-06-18/progress.md`      | Progress (unchanged)                                                                                                              |
+
+### 2025-11-25
+
+| File                                     | Content                                                                                                                      |
+| :--------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------- |
+| `references/2025-11-25/changelog.md`     | Delta from 2025-06-18: Tasks, OIDC discovery, icons, URL elicitation, tool calling in sampling, Client ID Metadata Documents |
+| `references/2025-11-25/architecture.md`  | Architecture (unchanged)                                                                                                     |
+| `references/2025-11-25/lifecycle.md`     | Lifecycle (unchanged)                                                                                                        |
+| `references/2025-11-25/transports.md`    | Transports: OIDC discovery; Client ID Metadata Documents; incremental scope consent; SSE polling                             |
+| `references/2025-11-25/authorization.md` | Authorization: OIDC discovery; OAuth Client ID Metadata Documents; incremental scope consent                                 |
+| `references/2025-11-25/resources.md`     | Resources: adds icon field                                                                                                   |
+| `references/2025-11-25/prompts.md`       | Prompts: adds icon field                                                                                                     |
+| `references/2025-11-25/tools.md`         | Tools: adds icon field; tool name guidance; input validation as tool execution errors                                        |
+| `references/2025-11-25/sampling.md`      | Sampling: tool calling in sampling (tools, toolChoice); sampling.tools capability                                            |
+| `references/2025-11-25/roots.md`         | Roots (unchanged)                                                                                                            |
+| `references/2025-11-25/elicitation.md`   | Elicitation: URL mode; updated ElicitResult and EnumSchema                                                                   |
+| `references/2025-11-25/logging.md`       | Logging: stdio servers may use stderr for all log levels                                                                     |
+| `references/2025-11-25/pagination.md`    | Pagination (unchanged)                                                                                                       |
+| `references/2025-11-25/completion.md`    | Completion (unchanged)                                                                                                       |
+| `references/2025-11-25/cancellation.md`  | Cancellation (unchanged)                                                                                                     |
+| `references/2025-11-25/ping.md`          | Ping (unchanged)                                                                                                             |
+| `references/2025-11-25/progress.md`      | Progress (unchanged)                                                                                                         |
+| `references/2025-11-25/tasks.md`         | Tasks (experimental): durable state machines, polling, deferred results, tasks/get, tasks/cancel                             |
+
+## When to Read Which Files
+
+| User is asking about...                    | Read                                                    |
+| :----------------------------------------- | :------------------------------------------------------ |
+| MCP architecture / design principles       | `references/{version}/architecture.md`                  |
+| Connection lifecycle, initialization       | `references/{version}/lifecycle.md`                     |
+| stdio transport                            | `references/{version}/transports.md`                    |
+| HTTP+SSE transport                         | `references/2024-11-05/transports.md`                   |
+| Streamable HTTP transport                  | `references/2025-03-26/transports.md` (or later)        |
+| OAuth 2.1 authorization                    | `references/2025-03-26/authorization.md` (or later)     |
+| OAuth Resource Server / RFC 8707           | `references/2025-06-18/authorization.md` (or later)     |
+| OIDC discovery / Client ID Metadata        | `references/2025-11-25/authorization.md`                |
+| Resources (list/read/subscribe)            | `references/{version}/resources.md`                     |
+| Prompts (list/get)                         | `references/{version}/prompts.md`                       |
+| Tools (list/call/annotations)              | `references/{version}/tools.md`                         |
+| Structured tool output                     | `references/2025-06-18/tools.md` (or later)             |
+| Resource links in tool results             | `references/2025-06-18/tools.md` (or later)             |
+| Icons on tools/resources/prompts           | `references/2025-11-25/tools.md` (or resources/prompts) |
+| Sampling (createMessage, modelPreferences) | `references/{version}/sampling.md`                      |
+| Tool calling inside sampling               | `references/2025-11-25/sampling.md`                     |
+| Roots (filesystem boundaries)              | `references/{version}/roots.md`                         |
+| Elicitation (server→user input)            | `references/2025-06-18/elicitation.md` (or later)       |
+| URL-mode elicitation                       | `references/2025-11-25/elicitation.md`                  |
+| Logging                                    | `references/{version}/logging.md`                       |
+| Pagination                                 | `references/{version}/pagination.md`                    |
+| Argument autocompletion                    | `references/{version}/completion.md`                    |
+| Cancellation                               | `references/{version}/cancellation.md`                  |
+| Ping / connection health                   | `references/{version}/ping.md`                          |
+| Progress notifications                     | `references/{version}/progress.md`                      |
+| Tasks (durable async)                      | `references/2025-11-25/tasks.md`                        |
+| Migrating between versions                 | `references/{target-version}/changelog.md`              |
+| Rust SDK (`rmcp`) — anything Rust-specific | `references/rust-sdk/overview.md` (indexes the rest)    |
+| TypeScript SDK build/bundler errors        | `references/typescript-sdk/pkce-challenge.md`           |
+
+## Language SDK Guides
+
+Beyond the spec itself, this skill ships reference material for the official
+MCP SDKs. The depth differs by language: the Rust SDK has a full user guide;
+the TypeScript SDK currently only documents one well-known build-time quirk.
+These materials are language-specific — Rust guidance does not apply to
+TypeScript and vice versa.
+
+| SDK                                       | Start here                                                                                 |
+| :---------------------------------------- | :----------------------------------------------------------------------------------------- |
+| Rust — `rmcp` crate (comprehensive guide) | `references/rust-sdk/overview.md`, then drill via `references/rust-sdk/doc-index.md`       |
+| TypeScript — `@modelcontextprotocol/sdk`  | `references/typescript-sdk/pkce-challenge.md` (Vite/bundler `pkce-challenge` resolver fix) |
+
+### Rust SDK (`rmcp`) at a glance
+
+`references/rust-sdk/overview.md` covers workspace orientation, version /
+stability notes (Tier 2 conformance — some 2025-11-25 features are still in
+motion), Cargo feature flags, and the smallest viable server and client.
+From there, `references/rust-sdk/doc-index.md` indexes every per-feature
+file: server primitives (tools, prompts, resources, tasks, sampling,
+elicitation, roots, transports), client features (handler, requests,
+sampling, elicitation, roots, transports, testing), and the shared Cargo
+`feature-flags.md`. The canonical local example is `crates/mcp-server/`;
+the pinned upstream source of truth is `submodules/mcp-rust-sdk/`.
+
+### TypeScript SDK (`@modelcontextprotocol/sdk`)
+
+Currently scoped to one entry — the Vite/Rollup/Webpack resolver error for
+`pkce-challenge` in browser/SSR builds, with a stub-alias workaround. See
+`references/typescript-sdk/pkce-challenge.md`. New TypeScript-SDK quirks
+should be added as sibling files under `references/typescript-sdk/`.

--- a/.agents/skills/mcp-knowledge/evals/evals.json
+++ b/.agents/skills/mcp-knowledge/evals/evals.json
@@ -1,0 +1,26 @@
+{
+  "skill_name": "mcp-knowledge",
+  "evals": [
+    {
+      "id": 0,
+      "name": "spec-migration-2025-11-25",
+      "prompt": "We're upgrading our MCP server from spec version 2025-03-26 to 2025-11-25. What changes do we need to handle around tools (annotations, structured output, icons, input validation)? How does the new Tasks feature work — what's the lifecycle, and when would I use it instead of regular tool calls? Should we migrate now or wait for the spec to stabilize further?",
+      "expected_output": "A migration-oriented answer that cites the per-version changelog files, walks through the tools-related deltas from 2025-03-26 → 2025-06-18 → 2025-11-25 (structured output, resource links, title, icons, input-validation-as-execution-error), explains the Tasks state machine (working/input-required/completed/failed/cancelled, polling via tasks/get, deferred results), gives a recommendation with caveats.",
+      "files": []
+    },
+    {
+      "id": 1,
+      "name": "rust-sdk-tool-with-elicitation",
+      "prompt": "I'm writing a server in Rust using rmcp 1.7. I want a tool called `transfer` that takes parameters `{amount: f64, recipient: String}` and asks the user for confirmation via elicitation before executing the transfer. Walk me through: (1) the Cargo features I need to enable, (2) the macro setup for the tool router and tool handler, (3) the Parameters<T> wrapper and how to derive JsonSchema, (4) how to call elicitation from inside the tool method (with `ctx.peer.elicit::<T>()`), and (5) which ElicitationError variants I must handle and what to return for each. Code-complete example please.",
+      "expected_output": "A code-complete Rust answer with: Cargo.toml feature list (server, macros, elicitation, transport-io at minimum), a struct with `tool_router` field, `#[tool_router]` impl block, `Parameters<TransferArgs>` with `#[derive(JsonSchema, Deserialize)]`, a `#[tool]` async method that calls `ctx.peer.elicit::<ConfirmArgs>()`, pattern-matching on ElicitationError (UserDeclined, UserCancelled, CapabilityNotSupported, others), and the `#[tool_handler] impl ServerHandler` block. Should cite `crates/mcp-server/` and `references/rust-sdk/server/elicitation.md`.",
+      "files": []
+    },
+    {
+      "id": 2,
+      "name": "typescript-sdk-pkce-challenge",
+      "prompt": "My Qwik app uses `@modelcontextprotocol/sdk` transitively through `@elmethis/qwik`'s ag-ui-client. The Vite build is failing with `Failed to resolve entry for package pkce-challenge` even though my app never calls any OAuth code path. Why is this happening, and how do I fix it without forking the SDK or removing my dependency on @elmethis/qwik? Also, would lazy-importing the SDK help?",
+      "expected_output": "An answer that: (1) explains why dynamic import doesn't help (Vite walks the full static graph behind every chunk), (2) explains the root cause (`pkce-challenge` package.json missing a `default` exports condition, MCP SDK statically imports `auth.js` which imports `pkce-challenge`), (3) gives the vite.config.ts alias + stub file workaround with the `throw new Error(...)` (not fake values) pattern, (4) mentions the upstream fix path. Should not recommend forking the SDK or removing the @elmethis/qwik dep.",
+      "files": []
+    }
+  ]
+}

--- a/.agents/skills/mcp-knowledge/references/2024-11-05/architecture.md
+++ b/.agents/skills/mcp-knowledge/references/2024-11-05/architecture.md
@@ -1,0 +1,183 @@
+<!-- markdownlint-disable -->
+# Architecture
+
+The Model Context Protocol (MCP) follows a client-host-server architecture where each
+host can run multiple client instances. This architecture enables users to integrate AI
+capabilities across applications while maintaining clear security boundaries and
+isolating concerns. Built on JSON-RPC, MCP provides a stateful session protocol focused
+on context exchange and sampling coordination between clients and servers.
+
+## Core Components
+
+```mermaid
+graph LR
+    subgraph "Application Host Process"
+        H[Host]
+        C1[Client 1]
+        C2[Client 2]
+        C3[Client 3]
+        H --> C1
+        H --> C2
+        H --> C3
+    end
+
+    subgraph "Local machine"
+        S1[Server 1<br>Files & Git]
+        S2[Server 2<br>Database]
+        R1[("Local<br>Resource A")]
+        R2[("Local<br>Resource B")]
+
+        C1 --> S1
+        C2 --> S2
+        S1 <--> R1
+        S2 <--> R2
+    end
+
+    subgraph "Internet"
+        S3[Server 3<br>External APIs]
+        R3[("Remote<br>Resource C")]
+
+        C3 --> S3
+        S3 <--> R3
+    end
+```
+
+### Host
+
+The host process acts as the container and coordinator:
+
+- Creates and manages multiple client instances
+- Controls client connection permissions and lifecycle
+- Enforces security policies and consent requirements
+- Handles user authorization decisions
+- Coordinates AI/LLM integration and sampling
+- Manages context aggregation across clients
+
+### Clients
+
+Each client is created by the host and maintains an isolated server connection:
+
+- Establishes one stateful session per server
+- Handles protocol negotiation and capability exchange
+- Routes protocol messages bidirectionally
+- Manages subscriptions and notifications
+- Maintains security boundaries between servers
+
+A host application creates and manages multiple clients, with each client having a 1:1
+relationship with a particular server.
+
+### Servers
+
+Servers provide specialized context and capabilities:
+
+- Expose resources, tools and prompts via MCP primitives
+- Operate independently with focused responsibilities
+- Request sampling through client interfaces
+- Must respect security constraints
+- Can be local processes or remote services
+
+## Design Principles
+
+MCP is built on several key design principles that inform its architecture and
+implementation:
+
+1. **Servers should be extremely easy to build**
+   - Host applications handle complex orchestration responsibilities
+   - Servers focus on specific, well-defined capabilities
+   - Simple interfaces minimize implementation overhead
+   - Clear separation enables maintainable code
+
+2. **Servers should be highly composable**
+   - Each server provides focused functionality in isolation
+   - Multiple servers can be combined seamlessly
+   - Shared protocol enables interoperability
+   - Modular design supports extensibility
+
+3. **Servers should not be able to read the whole conversation, nor "see into" other
+   servers**
+   - Servers receive only necessary contextual information
+   - Full conversation history stays with the host
+   - Each server connection maintains isolation
+   - Cross-server interactions are controlled by the host
+   - Host process enforces security boundaries
+
+4. **Features can be added to servers and clients progressively**
+   - Core protocol provides minimal required functionality
+   - Additional capabilities can be negotiated as needed
+   - Servers and clients evolve independently
+   - Protocol designed for future extensibility
+   - Backwards compatibility is maintained
+
+## Message Types
+
+MCP defines three core message types based on
+[JSON-RPC 2.0](https://www.jsonrpc.org/specification):
+
+- **Requests**: Bidirectional messages with method and parameters expecting a response
+- **Responses**: Successful results or errors matching specific request IDs
+- **Notifications**: One-way messages requiring no response
+
+Each message type follows the JSON-RPC 2.0 specification for structure and delivery
+semantics.
+
+## Capability Negotiation
+
+The Model Context Protocol uses a capability-based negotiation system where clients and
+servers explicitly declare their supported features during initialization. Capabilities
+determine which protocol features and primitives are available during a session.
+
+- Servers declare capabilities like resource subscriptions, tool support, and prompt
+  templates
+- Clients declare capabilities like sampling support and notification handling
+- Both parties must respect declared capabilities throughout the session
+- Additional capabilities can be negotiated through extensions to the protocol
+
+```mermaid
+sequenceDiagram
+    participant Host
+    participant Client
+    participant Server
+
+    Host->>+Client: Initialize client
+    Client->>+Server: Initialize session with capabilities
+    Server-->>Client: Respond with supported capabilities
+
+    Note over Host,Server: Active Session with Negotiated Features
+
+    loop Client Requests
+        Host->>Client: User- or model-initiated action
+        Client->>Server: Request (tools/resources)
+        Server-->>Client: Response
+        Client-->>Host: Update UI or respond to model
+    end
+
+    loop Server Requests
+        Server->>Client: Request (sampling)
+        Client->>Host: Forward to AI
+        Host-->>Client: AI response
+        Client-->>Server: Response
+    end
+
+    loop Notifications
+        Server--)Client: Resource updates
+        Client--)Server: Status changes
+    end
+
+    Host->>Client: Terminate
+    Client->>-Server: End session
+    deactivate Server
+```
+
+Each capability unlocks specific protocol features for use during the session. For
+example:
+
+- Implemented [server features](/specification/2024-11-05/server) must be
+  advertised in the server's capabilities
+- Emitting resource subscription notifications requires the server to declare
+  subscription support
+- Tool invocation requires the server to declare tool capabilities
+- [Sampling](/specification/2024-11-05/client) requires the client to
+  declare support in its capabilities
+
+This capability negotiation ensures clients and servers have a clear understanding of
+supported functionality while maintaining protocol extensibility.

--- a/.agents/skills/mcp-knowledge/references/2024-11-05/cancellation.md
+++ b/.agents/skills/mcp-knowledge/references/2024-11-05/cancellation.md
@@ -1,0 +1,80 @@
+<!-- markdownlint-disable -->
+# Cancellation
+
+The Model Context Protocol (MCP) supports optional cancellation of in-progress requests
+through notification messages. Either side can send a cancellation notification to
+indicate that a previously-issued request should be terminated.
+
+## Cancellation Flow
+
+When a party wants to cancel an in-progress request, it sends a `notifications/cancelled`
+notification containing:
+
+- The ID of the request to cancel
+- An optional reason string that can be logged or displayed
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/cancelled",
+  "params": {
+    "requestId": "123",
+    "reason": "User requested cancellation"
+  }
+}
+```
+
+## Behavior Requirements
+
+1. Cancellation notifications **MUST** only reference requests that:
+   - Were previously issued in the same direction
+   - Are believed to still be in-progress
+2. The `initialize` request **MUST NOT** be cancelled by clients
+3. Receivers of cancellation notifications **SHOULD**:
+   - Stop processing the cancelled request
+   - Free associated resources
+   - Not send a response for the cancelled request
+4. Receivers **MAY** ignore cancellation notifications if:
+   - The referenced request is unknown
+   - Processing has already completed
+   - The request cannot be cancelled
+5. The sender of the cancellation notification **SHOULD** ignore any response to the
+   request that arrives afterward
+
+## Timing Considerations
+
+Due to network latency, cancellation notifications may arrive after request processing
+has completed, and potentially after a response has already been sent.
+
+Both parties **MUST** handle these race conditions gracefully:
+
+```mermaid
+sequenceDiagram
+   participant Client
+   participant Server
+
+   Client->>Server: Request (ID: 123)
+   Note over Server: Processing starts
+   Client--)Server: notifications/cancelled (ID: 123)
+   alt
+      Note over Server: Processing may have<br/>completed before<br/>cancellation arrives
+   else If not completed
+      Note over Server: Stop processing
+   end
+```
+
+## Implementation Notes
+
+- Both parties **SHOULD** log cancellation reasons for debugging
+- Application UIs **SHOULD** indicate when cancellation is requested
+
+## Error Handling
+
+Invalid cancellation notifications **SHOULD** be ignored:
+
+- Unknown request IDs
+- Already completed requests
+- Malformed notifications
+
+This maintains the "fire and forget" nature of notifications while allowing for race
+conditions in asynchronous communication.

--- a/.agents/skills/mcp-knowledge/references/2024-11-05/completion.md
+++ b/.agents/skills/mcp-knowledge/references/2024-11-05/completion.md
@@ -1,0 +1,133 @@
+<!-- markdownlint-disable -->
+# Completion
+
+The Model Context Protocol (MCP) provides a standardized way for servers to offer
+argument autocompletion suggestions for prompts and resource URIs. This enables rich,
+IDE-like experiences where users receive contextual suggestions while entering argument
+values.
+
+## User Interaction Model
+
+Completion in MCP is designed to support interactive user experiences similar to IDE code
+completion.
+
+For example, applications may show completion suggestions in a dropdown or popup menu as
+users type, with the ability to filter and select from available options.
+
+However, implementations are free to expose completion through any interface pattern that
+suits their needs&mdash;the protocol itself does not mandate any specific user
+interaction model.
+
+## Protocol Messages
+
+### Requesting Completions
+
+To get completion suggestions, clients send a `completion/complete` request specifying
+what is being completed through a reference type:
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "completion/complete",
+  "params": {
+    "ref": {
+      "type": "ref/prompt",
+      "name": "code_review"
+    },
+    "argument": {
+      "name": "language",
+      "value": "py"
+    }
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "completion": {
+      "values": ["python", "pytorch", "pyside"],
+      "total": 10,
+      "hasMore": true
+    }
+  }
+}
+```
+
+### Reference Types
+
+The protocol supports two types of completion references:
+
+| Type           | Description                 | Example                                             |
+| -------------- | --------------------------- | --------------------------------------------------- |
+| `ref/prompt`   | References a prompt by name | `{"type": "ref/prompt", "name": "code_review"}`     |
+| `ref/resource` | References a resource URI   | `{"type": "ref/resource", "uri": "file:///{path}"}` |
+
+### Completion Results
+
+Servers return an array of completion values ranked by relevance, with:
+
+- Maximum 100 items per response
+- Optional total number of available matches
+- Boolean indicating if additional results exist
+
+## Message Flow
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Server
+
+    Note over Client: User types argument
+    Client->>Server: completion/complete
+    Server-->>Client: Completion suggestions
+
+    Note over Client: User continues typing
+    Client->>Server: completion/complete
+    Server-->>Client: Refined suggestions
+```
+
+## Data Types
+
+### CompleteRequest
+
+- `ref`: A `PromptReference` or `ResourceReference`
+- `argument`: Object containing:
+  - `name`: Argument name
+  - `value`: Current value
+
+### CompleteResult
+
+- `completion`: Object containing:
+  - `values`: Array of suggestions (max 100)
+  - `total`: Optional total matches
+  - `hasMore`: Additional results flag
+
+## Implementation Considerations
+
+1. Servers **SHOULD**:
+   - Return suggestions sorted by relevance
+   - Implement fuzzy matching where appropriate
+   - Rate limit completion requests
+   - Validate all inputs
+
+2. Clients **SHOULD**:
+   - Debounce rapid completion requests
+   - Cache completion results where appropriate
+   - Handle missing or partial results gracefully
+
+## Security
+
+Implementations **MUST**:
+
+- Validate all completion inputs
+- Implement appropriate rate limiting
+- Control access to sensitive suggestions
+- Prevent completion-based information disclosure

--- a/.agents/skills/mcp-knowledge/references/2024-11-05/lifecycle.md
+++ b/.agents/skills/mcp-knowledge/references/2024-11-05/lifecycle.md
@@ -1,0 +1,215 @@
+<!-- markdownlint-disable -->
+# Lifecycle
+
+The Model Context Protocol (MCP) defines a rigorous lifecycle for client-server
+connections that ensures proper capability negotiation and state management.
+
+1. **Initialization**: Capability negotiation and protocol version agreement
+2. **Operation**: Normal protocol communication
+3. **Shutdown**: Graceful termination of the connection
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Server
+
+    Note over Client,Server: Initialization Phase
+    activate Client
+    Client->>+Server: initialize request
+    Server-->>Client: initialize response
+    Client--)Server: initialized notification
+
+    Note over Client,Server: Operation Phase
+    rect rgb(200, 220, 250)
+        note over Client,Server: Normal protocol operations
+    end
+
+    Note over Client,Server: Shutdown
+    Client--)-Server: Disconnect
+    deactivate Server
+    Note over Client,Server: Connection closed
+```
+
+## Lifecycle Phases
+
+### Initialization
+
+The initialization phase **MUST** be the first interaction between client and server.
+During this phase, the client and server:
+
+- Establish protocol version compatibility
+- Exchange and negotiate capabilities
+- Share implementation details
+
+The client **MUST** initiate this phase by sending an `initialize` request containing:
+
+- Protocol version supported
+- Client capabilities
+- Client implementation information
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "initialize",
+  "params": {
+    "protocolVersion": "2024-11-05",
+    "capabilities": {
+      "roots": {
+        "listChanged": true
+      },
+      "sampling": {}
+    },
+    "clientInfo": {
+      "name": "ExampleClient",
+      "version": "1.0.0"
+    }
+  }
+}
+```
+
+The server **MUST** respond with its own capabilities and information:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "protocolVersion": "2024-11-05",
+    "capabilities": {
+      "logging": {},
+      "prompts": {
+        "listChanged": true
+      },
+      "resources": {
+        "subscribe": true,
+        "listChanged": true
+      },
+      "tools": {
+        "listChanged": true
+      }
+    },
+    "serverInfo": {
+      "name": "ExampleServer",
+      "version": "1.0.0"
+    }
+  }
+}
+```
+
+After successful initialization, the client **MUST** send an `initialized` notification
+to indicate it is ready to begin normal operations:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/initialized"
+}
+```
+
+- The client **SHOULD NOT** send requests other than
+  [pings](/specification/2024-11-05/basic/utilities/ping) before the server
+  has responded to the `initialize` request.
+- The server **SHOULD NOT** send requests other than
+  [pings](/specification/2024-11-05/basic/utilities/ping) and
+  [logging](/specification/2024-11-05/server/utilities/logging) before
+  receiving the `initialized` notification.
+
+#### Version Negotiation
+
+In the `initialize` request, the client **MUST** send a protocol version it supports.
+This **SHOULD** be the _latest_ version supported by the client.
+
+If the server supports the requested protocol version, it **MUST** respond with the same
+version. Otherwise, the server **MUST** respond with another protocol version it
+supports. This **SHOULD** be the _latest_ version supported by the server.
+
+If the client does not support the version in the server's response, it **SHOULD**
+disconnect.
+
+#### Capability Negotiation
+
+Client and server capabilities establish which optional protocol features will be
+available during the session.
+
+Key capabilities include:
+
+| Category | Capability     | Description                                                                         |
+| -------- | -------------- | ----------------------------------------------------------------------------------- |
+| Client   | `roots`        | Ability to provide filesystem [roots](/specification/2024-11-05/client/roots)       |
+| Client   | `sampling`     | Support for LLM [sampling](/specification/2024-11-05/client/sampling) requests      |
+| Client   | `experimental` | Describes support for non-standard experimental features                            |
+| Server   | `prompts`      | Offers [prompt templates](/specification/2024-11-05/server/prompts)                 |
+| Server   | `resources`    | Provides readable [resources](/specification/2024-11-05/server/resources)           |
+| Server   | `tools`        | Exposes callable [tools](/specification/2024-11-05/server/tools)                    |
+| Server   | `logging`      | Emits structured [log messages](/specification/2024-11-05/server/utilities/logging) |
+| Server   | `experimental` | Describes support for non-standard experimental features                            |
+
+Capability objects can describe sub-capabilities like:
+
+- `listChanged`: Support for list change notifications (for prompts, resources, and
+  tools)
+- `subscribe`: Support for subscribing to individual items' changes (resources only)
+
+### Operation
+
+During the operation phase, the client and server exchange messages according to the
+negotiated capabilities.
+
+Both parties **SHOULD**:
+
+- Respect the negotiated protocol version
+- Only use capabilities that were successfully negotiated
+
+### Shutdown
+
+During the shutdown phase, one side (usually the client) cleanly terminates the protocol
+connection. No specific shutdown messages are defined—instead, the underlying transport
+mechanism should be used to signal connection termination:
+
+#### stdio
+
+For the stdio [transport](/specification/2024-11-05/basic/transports), the
+client **SHOULD** initiate shutdown by:
+
+1. First, closing the input stream to the child process (the server)
+2. Waiting for the server to exit, or sending `SIGTERM` if the server does not exit
+   within a reasonable time
+3. Sending `SIGKILL` if the server does not exit within a reasonable time after `SIGTERM`
+
+The server **MAY** initiate shutdown by closing its output stream to the client and
+exiting.
+
+#### HTTP
+
+For HTTP [transports](/specification/2024-11-05/basic/transports), shutdown
+is indicated by closing the associated HTTP connection(s).
+
+## Error Handling
+
+Implementations **SHOULD** be prepared to handle these error cases:
+
+- Protocol version mismatch
+- Failure to negotiate required capabilities
+- Initialize request timeout
+- Shutdown timeout
+
+Implementations **SHOULD** implement appropriate timeouts for all requests, to prevent
+hung connections and resource exhaustion.
+
+Example initialization error:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "error": {
+    "code": -32602,
+    "message": "Unsupported protocol version",
+    "data": {
+      "supported": ["2024-11-05"],
+      "requested": "1.0.0"
+    }
+  }
+}
+```

--- a/.agents/skills/mcp-knowledge/references/2024-11-05/logging.md
+++ b/.agents/skills/mcp-knowledge/references/2024-11-05/logging.md
@@ -1,0 +1,137 @@
+<!-- markdownlint-disable -->
+# Logging
+
+The Model Context Protocol (MCP) provides a standardized way for servers to send
+structured log messages to clients. Clients can control logging verbosity by setting
+minimum log levels, with servers sending notifications containing severity levels,
+optional logger names, and arbitrary JSON-serializable data.
+
+## User Interaction Model
+
+Implementations are free to expose logging through any interface pattern that suits their
+needs&mdash;the protocol itself does not mandate any specific user interaction model.
+
+## Capabilities
+
+Servers that emit log message notifications **MUST** declare the `logging` capability:
+
+```json
+{
+  "capabilities": {
+    "logging": {}
+  }
+}
+```
+
+## Log Levels
+
+The protocol follows the standard syslog severity levels specified in
+[RFC 5424](https://datatracker.ietf.org/doc/html/rfc5424#section-6.2.1):
+
+| Level     | Description                      | Example Use Case           |
+| --------- | -------------------------------- | -------------------------- |
+| debug     | Detailed debugging information   | Function entry/exit points |
+| info      | General informational messages   | Operation progress updates |
+| notice    | Normal but significant events    | Configuration changes      |
+| warning   | Warning conditions               | Deprecated feature usage   |
+| error     | Error conditions                 | Operation failures         |
+| critical  | Critical conditions              | System component failures  |
+| alert     | Action must be taken immediately | Data corruption detected   |
+| emergency | System is unusable               | Complete system failure    |
+
+## Protocol Messages
+
+### Setting Log Level
+
+To configure the minimum log level, clients **MAY** send a `logging/setLevel` request:
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "logging/setLevel",
+  "params": {
+    "level": "info"
+  }
+}
+```
+
+### Log Message Notifications
+
+Servers send log messages using `notifications/message` notifications:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/message",
+  "params": {
+    "level": "error",
+    "logger": "database",
+    "data": {
+      "error": "Connection failed",
+      "details": {
+        "host": "localhost",
+        "port": 5432
+      }
+    }
+  }
+}
+```
+
+## Message Flow
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Server
+
+    Note over Client,Server: Configure Logging
+    Client->>Server: logging/setLevel (info)
+    Server-->>Client: Empty Result
+
+    Note over Client,Server: Server Activity
+    Server--)Client: notifications/message (info)
+    Server--)Client: notifications/message (warning)
+    Server--)Client: notifications/message (error)
+
+    Note over Client,Server: Level Change
+    Client->>Server: logging/setLevel (error)
+    Server-->>Client: Empty Result
+    Note over Server: Only sends error level<br/>and above
+```
+
+## Error Handling
+
+Servers **SHOULD** return standard JSON-RPC errors for common failure cases:
+
+- Invalid log level: `-32602` (Invalid params)
+- Configuration errors: `-32603` (Internal error)
+
+## Implementation Considerations
+
+1. Servers **SHOULD**:
+   - Rate limit log messages
+   - Include relevant context in data field
+   - Use consistent logger names
+   - Remove sensitive information
+
+2. Clients **MAY**:
+   - Present log messages in the UI
+   - Implement log filtering/search
+   - Display severity visually
+   - Persist log messages
+
+## Security
+
+1. Log messages **MUST NOT** contain:
+   - Credentials or secrets
+   - Personal identifying information
+   - Internal system details that could aid attacks
+
+2. Implementations **SHOULD**:
+   - Rate limit messages
+   - Validate all data fields
+   - Control log access
+   - Monitor for sensitive content

--- a/.agents/skills/mcp-knowledge/references/2024-11-05/pagination.md
+++ b/.agents/skills/mcp-knowledge/references/2024-11-05/pagination.md
@@ -1,0 +1,93 @@
+<!-- markdownlint-disable -->
+# Pagination
+
+The Model Context Protocol (MCP) supports paginating list operations that may return
+large result sets. Pagination allows servers to yield results in smaller chunks rather
+than all at once.
+
+Pagination is especially important when connecting to external services over the
+internet, but also useful for local integrations to avoid performance issues with large
+data sets.
+
+## Pagination Model
+
+Pagination in MCP uses an opaque cursor-based approach, instead of numbered pages.
+
+- The **cursor** is an opaque string token, representing a position in the result set
+- **Page size** is determined by the server, and clients **MUST NOT** assume a fixed page
+  size
+
+## Response Format
+
+Pagination starts when the server sends a **response** that includes:
+
+- The current page of results
+- An optional `nextCursor` field if more results exist
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "123",
+  "result": {
+    "resources": [...],
+    "nextCursor": "eyJwYWdlIjogM30="
+  }
+}
+```
+
+## Request Format
+
+After receiving a cursor, the client can _continue_ paginating by issuing a request
+including that cursor:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "resources/list",
+  "params": {
+    "cursor": "eyJwYWdlIjogMn0="
+  }
+}
+```
+
+## Pagination Flow
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Server
+
+    Client->>Server: List Request (no cursor)
+    loop Pagination Loop
+      Server-->>Client: Page of results + nextCursor
+      Client->>Server: List Request (with cursor)
+    end
+```
+
+## Operations Supporting Pagination
+
+The following MCP operations support pagination:
+
+- `resources/list` - List available resources
+- `resources/templates/list` - List resource templates
+- `prompts/list` - List available prompts
+- `tools/list` - List available tools
+
+## Implementation Guidelines
+
+1. Servers **SHOULD**:
+   - Provide stable cursors
+   - Handle invalid cursors gracefully
+
+2. Clients **SHOULD**:
+   - Treat a missing `nextCursor` as the end of results
+   - Support both paginated and non-paginated flows
+
+3. Clients **MUST** treat cursors as opaque tokens:
+   - Don't make assumptions about cursor format
+   - Don't attempt to parse or modify cursors
+   - Don't persist cursors across sessions
+
+## Error Handling
+
+Invalid cursors **SHOULD** result in an error with code -32602 (Invalid params).

--- a/.agents/skills/mcp-knowledge/references/2024-11-05/ping.md
+++ b/.agents/skills/mcp-knowledge/references/2024-11-05/ping.md
@@ -1,0 +1,63 @@
+<!-- markdownlint-disable -->
+# Ping
+
+The Model Context Protocol includes an optional ping mechanism that allows either party
+to verify that their counterpart is still responsive and the connection is alive.
+
+## Overview
+
+The ping functionality is implemented through a simple request/response pattern. Either
+the client or server can initiate a ping by sending a `ping` request.
+
+## Message Format
+
+A ping request is a standard JSON-RPC request with no parameters:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "123",
+  "method": "ping"
+}
+```
+
+## Behavior Requirements
+
+1. The receiver **MUST** respond promptly with an empty response:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "123",
+  "result": {}
+}
+```
+
+2. If no response is received within a reasonable timeout period, the sender **MAY**:
+   - Consider the connection stale
+   - Terminate the connection
+   - Attempt reconnection procedures
+
+## Usage Patterns
+
+```mermaid
+sequenceDiagram
+    participant Sender
+    participant Receiver
+
+    Sender->>Receiver: ping request
+    Receiver->>Sender: empty response
+```
+
+## Implementation Considerations
+
+- Implementations **SHOULD** periodically issue pings to detect connection health
+- The frequency of pings **SHOULD** be configurable
+- Timeouts **SHOULD** be appropriate for the network environment
+- Excessive pinging **SHOULD** be avoided to reduce network overhead
+
+## Error Handling
+
+- Timeouts **SHOULD** be treated as connection failures
+- Multiple failed pings **MAY** trigger connection reset
+- Implementations **SHOULD** log ping failures for diagnostics

--- a/.agents/skills/mcp-knowledge/references/2024-11-05/progress.md
+++ b/.agents/skills/mcp-knowledge/references/2024-11-05/progress.md
@@ -1,0 +1,86 @@
+<!-- markdownlint-disable -->
+# Progress
+
+The Model Context Protocol (MCP) supports optional progress tracking for long-running
+operations through notification messages. Either side can send progress notifications to
+provide updates about operation status.
+
+## Progress Flow
+
+When a party wants to _receive_ progress updates for a request, it includes a
+`progressToken` in the request metadata.
+
+- Progress tokens **MUST** be a string or integer value
+- Progress tokens can be chosen by the sender using any means, but **MUST** be unique
+  across all active requests.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "some_method",
+  "params": {
+    "_meta": {
+      "progressToken": "abc123"
+    }
+  }
+}
+```
+
+The receiver **MAY** then send progress notifications containing:
+
+- The original progress token
+- The current progress value so far
+- An optional "total" value
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/progress",
+  "params": {
+    "progressToken": "abc123",
+    "progress": 50,
+    "total": 100
+  }
+}
+```
+
+- The `progress` value **MUST** increase with each notification, even if the total is
+  unknown.
+- The `progress` and the `total` values **MAY** be floating point.
+
+## Behavior Requirements
+
+1. Progress notifications **MUST** only reference tokens that:
+   - Were provided in an active request
+   - Are associated with an in-progress operation
+
+2. Receivers of progress requests **MAY**:
+   - Choose not to send any progress notifications
+   - Send notifications at whatever frequency they deem appropriate
+   - Omit the total value if unknown
+
+```mermaid
+sequenceDiagram
+    participant Sender
+    participant Receiver
+
+    Note over Sender,Receiver: Request with progress token
+    Sender->>Receiver: Method request with progressToken
+
+    Note over Sender,Receiver: Progress updates
+    loop Progress Updates
+        Receiver-->>Sender: Progress notification (0.2/1.0)
+        Receiver-->>Sender: Progress notification (0.6/1.0)
+        Receiver-->>Sender: Progress notification (1.0/1.0)
+    end
+
+    Note over Sender,Receiver: Operation complete
+    Receiver->>Sender: Method response
+```
+
+## Implementation Notes
+
+- Senders and receivers **SHOULD** track active progress tokens
+- Both parties **SHOULD** implement rate limiting to prevent flooding
+- Progress notifications **MUST** stop after completion

--- a/.agents/skills/mcp-knowledge/references/2024-11-05/prompts.md
+++ b/.agents/skills/mcp-knowledge/references/2024-11-05/prompts.md
@@ -1,0 +1,253 @@
+<!-- markdownlint-disable -->
+# Prompts
+
+The Model Context Protocol (MCP) provides a standardized way for servers to expose prompt
+templates to clients. Prompts allow servers to provide structured messages and
+instructions for interacting with language models. Clients can discover available
+prompts, retrieve their contents, and provide arguments to customize them.
+
+## User Interaction Model
+
+Prompts are designed to be **user-controlled**, meaning they are exposed from servers to
+clients with the intention of the user being able to explicitly select them for use.
+
+Typically, prompts would be triggered through user-initiated commands in the user
+interface, which allows users to naturally discover and invoke available prompts.
+
+For example, as slash commands:
+
+![Example of prompt exposed as slash command](/specification/2024-11-05/server/slash-command.png)
+
+However, implementors are free to expose prompts through any interface pattern that suits
+their needs&mdash;the protocol itself does not mandate any specific user interaction
+model.
+
+## Capabilities
+
+Servers that support prompts **MUST** declare the `prompts` capability during
+[initialization](/specification/2024-11-05/basic/lifecycle#initialization):
+
+```json
+{
+  "capabilities": {
+    "prompts": {
+      "listChanged": true
+    }
+  }
+}
+```
+
+`listChanged` indicates whether the server will emit notifications when the list of
+available prompts changes.
+
+## Protocol Messages
+
+### Listing Prompts
+
+To retrieve available prompts, clients send a `prompts/list` request. This operation
+supports
+[pagination](/specification/2024-11-05/server/utilities/pagination).
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "prompts/list",
+  "params": {
+    "cursor": "optional-cursor-value"
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "prompts": [
+      {
+        "name": "code_review",
+        "description": "Asks the LLM to analyze code quality and suggest improvements",
+        "arguments": [
+          {
+            "name": "code",
+            "description": "The code to review",
+            "required": true
+          }
+        ]
+      }
+    ],
+    "nextCursor": "next-page-cursor"
+  }
+}
+```
+
+### Getting a Prompt
+
+To retrieve a specific prompt, clients send a `prompts/get` request. Arguments may be
+auto-completed through [the completion API](/specification/2024-11-05/server/utilities/completion).
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "prompts/get",
+  "params": {
+    "name": "code_review",
+    "arguments": {
+      "code": "def hello():\n    print('world')"
+    }
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "description": "Code review prompt",
+    "messages": [
+      {
+        "role": "user",
+        "content": {
+          "type": "text",
+          "text": "Please review this Python code:\ndef hello():\n    print('world')"
+        }
+      }
+    ]
+  }
+}
+```
+
+### List Changed Notification
+
+When the list of available prompts changes, servers that declared the `listChanged`
+capability **SHOULD** send a notification:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/prompts/list_changed"
+}
+```
+
+## Message Flow
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Server
+
+    Note over Client,Server: Discovery
+    Client->>Server: prompts/list
+    Server-->>Client: List of prompts
+
+    Note over Client,Server: Usage
+    Client->>Server: prompts/get
+    Server-->>Client: Prompt content
+
+    opt listChanged
+      Note over Client,Server: Changes
+      Server--)Client: prompts/list_changed
+      Client->>Server: prompts/list
+      Server-->>Client: Updated prompts
+    end
+```
+
+## Data Types
+
+### Prompt
+
+A prompt definition includes:
+
+- `name`: Unique identifier for the prompt
+- `description`: Optional human-readable description
+- `arguments`: Optional list of arguments for customization
+
+### PromptMessage
+
+Messages in a prompt can contain:
+
+- `role`: Either "user" or "assistant" to indicate the speaker
+- `content`: One of the following content types:
+
+#### Text Content
+
+Text content represents plain text messages:
+
+```json
+{
+  "type": "text",
+  "text": "The text content of the message"
+}
+```
+
+This is the most common content type used for natural language interactions.
+
+#### Image Content
+
+Image content allows including visual information in messages:
+
+```json
+{
+  "type": "image",
+  "data": "base64-encoded-image-data",
+  "mimeType": "image/png"
+}
+```
+
+The image data **MUST** be base64-encoded and include a valid MIME type. This enables
+multi-modal interactions where visual context is important.
+
+#### Embedded Resources
+
+Embedded resources allow referencing server-side resources directly in messages:
+
+```json
+{
+  "type": "resource",
+  "resource": {
+    "uri": "resource://example",
+    "mimeType": "text/plain",
+    "text": "Resource content"
+  }
+}
+```
+
+Resources can contain either text or binary (blob) data and **MUST** include:
+
+- A valid resource URI
+- The appropriate MIME type
+- Either text content or base64-encoded blob data
+
+Embedded resources enable prompts to seamlessly incorporate server-managed content like
+documentation, code samples, or other reference materials directly into the conversation
+flow.
+
+## Error Handling
+
+Servers **SHOULD** return standard JSON-RPC errors for common failure cases:
+
+- Invalid prompt name: `-32602` (Invalid params)
+- Missing required arguments: `-32602` (Invalid params)
+- Internal errors: `-32603` (Internal error)
+
+## Implementation Considerations
+
+1. Servers **SHOULD** validate prompt arguments before processing
+2. Clients **SHOULD** handle pagination for large prompt lists
+3. Both parties **SHOULD** respect capability negotiation
+
+## Security
+
+Implementations **MUST** carefully validate all prompt inputs and outputs to prevent
+injection attacks or unauthorized access to resources.

--- a/.agents/skills/mcp-knowledge/references/2024-11-05/resources.md
+++ b/.agents/skills/mcp-knowledge/references/2024-11-05/resources.md
@@ -1,0 +1,358 @@
+<!-- markdownlint-disable -->
+# Resources
+
+The Model Context Protocol (MCP) provides a standardized way for servers to expose
+resources to clients. Resources allow servers to share data that provides context to
+language models, such as files, database schemas, or application-specific information.
+Each resource is uniquely identified by a
+[URI](https://datatracker.ietf.org/doc/html/rfc3986).
+
+## User Interaction Model
+
+Resources in MCP are designed to be **application-driven**, with host applications
+determining how to incorporate context based on their needs.
+
+For example, applications could:
+
+- Expose resources through UI elements for explicit selection, in a tree or list view
+- Allow the user to search through and filter available resources
+- Implement automatic context inclusion, based on heuristics or the AI model's selection
+
+![Example of resource context picker](/specification/2024-11-05/server/resource-picker.png)
+
+However, implementations are free to expose resources through any interface pattern that
+suits their needs&mdash;the protocol itself does not mandate any specific user
+interaction model.
+
+## Capabilities
+
+Servers that support resources **MUST** declare the `resources` capability:
+
+```json
+{
+  "capabilities": {
+    "resources": {
+      "subscribe": true,
+      "listChanged": true
+    }
+  }
+}
+```
+
+The capability supports two optional features:
+
+- `subscribe`: whether the client can subscribe to be notified of changes to individual
+  resources.
+- `listChanged`: whether the server will emit notifications when the list of available
+  resources changes.
+
+Both `subscribe` and `listChanged` are optional&mdash;servers can support neither,
+either, or both:
+
+```json
+{
+  "capabilities": {
+    "resources": {} // Neither feature supported
+  }
+}
+```
+
+```json
+{
+  "capabilities": {
+    "resources": {
+      "subscribe": true // Only subscriptions supported
+    }
+  }
+}
+```
+
+```json
+{
+  "capabilities": {
+    "resources": {
+      "listChanged": true // Only list change notifications supported
+    }
+  }
+}
+```
+
+## Protocol Messages
+
+### Listing Resources
+
+To discover available resources, clients send a `resources/list` request. This operation
+supports
+[pagination](/specification/2024-11-05/server/utilities/pagination).
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "resources/list",
+  "params": {
+    "cursor": "optional-cursor-value"
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "resources": [
+      {
+        "uri": "file:///project/src/main.rs",
+        "name": "main.rs",
+        "description": "Primary application entry point",
+        "mimeType": "text/x-rust"
+      }
+    ],
+    "nextCursor": "next-page-cursor"
+  }
+}
+```
+
+### Reading Resources
+
+To retrieve resource contents, clients send a `resources/read` request:
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "resources/read",
+  "params": {
+    "uri": "file:///project/src/main.rs"
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "contents": [
+      {
+        "uri": "file:///project/src/main.rs",
+        "mimeType": "text/x-rust",
+        "text": "fn main() {\n    println!(\"Hello world!\");\n}"
+      }
+    ]
+  }
+}
+```
+
+### Resource Templates
+
+Resource templates allow servers to expose parameterized resources using
+[URI templates](https://datatracker.ietf.org/doc/html/rfc6570). Arguments may be
+auto-completed through [the completion API](/specification/2024-11-05/server/utilities/completion).
+This operation supports
+[pagination](/specification/2024-11-05/server/utilities/pagination).
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "method": "resources/templates/list",
+  "params": {
+    "cursor": "optional-cursor-value"
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "result": {
+    "resourceTemplates": [
+      {
+        "uriTemplate": "file:///{path}",
+        "name": "Project Files",
+        "description": "Access files in the project directory",
+        "mimeType": "application/octet-stream"
+      }
+    ],
+    "nextCursor": "next-page-cursor"
+  }
+}
+```
+
+### List Changed Notification
+
+When the list of available resources changes, servers that declared the `listChanged`
+capability **SHOULD** send a notification:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/resources/list_changed"
+}
+```
+
+### Subscriptions
+
+The protocol supports optional subscriptions to resource changes. Clients can subscribe
+to specific resources and receive notifications when they change:
+
+**Subscribe Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 4,
+  "method": "resources/subscribe",
+  "params": {
+    "uri": "file:///project/src/main.rs"
+  }
+}
+```
+
+**Update Notification:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/resources/updated",
+  "params": {
+    "uri": "file:///project/src/main.rs"
+  }
+}
+```
+
+## Message Flow
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Server
+
+    Note over Client,Server: Resource Discovery
+    Client->>Server: resources/list
+    Server-->>Client: List of resources
+
+    Note over Client,Server: Resource Access
+    Client->>Server: resources/read
+    Server-->>Client: Resource contents
+
+    Note over Client,Server: Subscriptions
+    Client->>Server: resources/subscribe
+    Server-->>Client: Subscription confirmed
+
+    Note over Client,Server: Updates
+    Server--)Client: notifications/resources/updated
+    Client->>Server: resources/read
+    Server-->>Client: Updated contents
+```
+
+## Data Types
+
+### Resource
+
+A resource definition includes:
+
+- `uri`: Unique identifier for the resource
+- `name`: Human-readable name
+- `description`: Optional description
+- `mimeType`: Optional MIME type
+
+### Resource Contents
+
+Resources can contain either text or binary data:
+
+#### Text Content
+
+```json
+{
+  "uri": "file:///example.txt",
+  "mimeType": "text/plain",
+  "text": "Resource content"
+}
+```
+
+#### Binary Content
+
+```json
+{
+  "uri": "file:///example.png",
+  "mimeType": "image/png",
+  "blob": "base64-encoded-data"
+}
+```
+
+## Common URI Schemes
+
+The protocol defines several standard URI schemes. This list not
+exhaustive&mdash;implementations are always free to use additional, custom URI schemes.
+
+### https://
+
+Used to represent a resource available on the web.
+
+Servers **SHOULD** use this scheme only when the client is able to fetch and load the
+resource directly from the web on its own—that is, it doesn’t need to read the resource
+via the MCP server.
+
+For other use cases, servers **SHOULD** prefer to use another URI scheme, or define a
+custom one, even if the server will itself be downloading resource contents over the
+internet.
+
+### file://
+
+Used to identify resources that behave like a filesystem. However, the resources do not
+need to map to an actual physical filesystem.
+
+MCP servers **MAY** identify file:// resources with an
+[XDG MIME type](https://specifications.freedesktop.org/shared-mime-info-spec/0.14/ar01s02.html#id-1.3.14),
+like `inode/directory`, to represent non-regular files (such as directories) that don’t
+otherwise have a standard MIME type.
+
+### git://
+
+Git version control integration.
+
+## Error Handling
+
+Servers **SHOULD** return standard JSON-RPC errors for common failure cases:
+
+- Resource not found: `-32002`
+- Internal errors: `-32603`
+
+Example error:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 5,
+  "error": {
+    "code": -32002,
+    "message": "Resource not found",
+    "data": {
+      "uri": "file:///nonexistent.txt"
+    }
+  }
+}
+```
+
+## Security Considerations
+
+1. Servers **MUST** validate all resource URIs
+2. Access controls **SHOULD** be implemented for sensitive resources
+3. Binary data **MUST** be properly encoded
+4. Resource permissions **SHOULD** be checked before operations

--- a/.agents/skills/mcp-knowledge/references/2024-11-05/roots.md
+++ b/.agents/skills/mcp-knowledge/references/2024-11-05/roots.md
@@ -1,0 +1,185 @@
+<!-- markdownlint-disable -->
+# Roots
+
+The Model Context Protocol (MCP) provides a standardized way for clients to expose
+filesystem "roots" to servers. Roots define the boundaries of where servers can operate
+within the filesystem, allowing them to understand which directories and files they have
+access to. Servers can request the list of roots from supporting clients and receive
+notifications when that list changes.
+
+## User Interaction Model
+
+Roots in MCP are typically exposed through workspace or project configuration interfaces.
+
+For example, implementations could offer a workspace/project picker that allows users to
+select directories and files the server should have access to. This can be combined with
+automatic workspace detection from version control systems or project files.
+
+However, implementations are free to expose roots through any interface pattern that
+suits their needs&mdash;the protocol itself does not mandate any specific user
+interaction model.
+
+## Capabilities
+
+Clients that support roots **MUST** declare the `roots` capability during
+[initialization](/specification/2024-11-05/basic/lifecycle#initialization):
+
+```json
+{
+  "capabilities": {
+    "roots": {
+      "listChanged": true
+    }
+  }
+}
+```
+
+`listChanged` indicates whether the client will emit notifications when the list of roots
+changes.
+
+## Protocol Messages
+
+### Listing Roots
+
+To retrieve roots, servers send a `roots/list` request:
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "roots/list"
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "roots": [
+      {
+        "uri": "file:///home/user/projects/myproject",
+        "name": "My Project"
+      }
+    ]
+  }
+}
+```
+
+### Root List Changes
+
+When roots change, clients that support `listChanged` **MUST** send a notification:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/roots/list_changed"
+}
+```
+
+## Message Flow
+
+```mermaid
+sequenceDiagram
+    participant Server
+    participant Client
+
+    Note over Server,Client: Discovery
+    Server->>Client: roots/list
+    Client-->>Server: Available roots
+
+    Note over Server,Client: Changes
+    Client--)Server: notifications/roots/list_changed
+    Server->>Client: roots/list
+    Client-->>Server: Updated roots
+```
+
+## Data Types
+
+### Root
+
+A root definition includes:
+
+- `uri`: Unique identifier for the root. This **MUST** be a `file://` URI in the current
+  specification.
+- `name`: Optional human-readable name for display purposes.
+
+Example roots for different use cases:
+
+#### Project Directory
+
+```json
+{
+  "uri": "file:///home/user/projects/myproject",
+  "name": "My Project"
+}
+```
+
+#### Multiple Repositories
+
+```json
+[
+  {
+    "uri": "file:///home/user/repos/frontend",
+    "name": "Frontend Repository"
+  },
+  {
+    "uri": "file:///home/user/repos/backend",
+    "name": "Backend Repository"
+  }
+]
+```
+
+## Error Handling
+
+Clients **SHOULD** return standard JSON-RPC errors for common failure cases:
+
+- Client does not support roots: `-32601` (Method not found)
+- Internal errors: `-32603`
+
+Example error:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "error": {
+    "code": -32601,
+    "message": "Roots not supported",
+    "data": {
+      "reason": "Client does not have roots capability"
+    }
+  }
+}
+```
+
+## Security Considerations
+
+1. Clients **MUST**:
+   - Only expose roots with appropriate permissions
+   - Validate all root URIs to prevent path traversal
+   - Implement proper access controls
+   - Monitor root accessibility
+
+2. Servers **SHOULD**:
+   - Handle cases where roots become unavailable
+   - Respect root boundaries during operations
+   - Validate all paths against provided roots
+
+## Implementation Guidelines
+
+1. Clients **SHOULD**:
+   - Prompt users for consent before exposing roots to servers
+   - Provide clear user interfaces for root management
+   - Validate root accessibility before exposing
+   - Monitor for root changes
+
+2. Servers **SHOULD**:
+   - Check for roots capability before usage
+   - Handle root list changes gracefully
+   - Respect root boundaries in operations
+   - Cache root information appropriately

--- a/.agents/skills/mcp-knowledge/references/2024-11-05/sampling.md
+++ b/.agents/skills/mcp-knowledge/references/2024-11-05/sampling.md
@@ -1,0 +1,222 @@
+<!-- markdownlint-disable -->
+# Sampling
+
+The Model Context Protocol (MCP) provides a standardized way for servers to request LLM
+sampling ("completions" or "generations") from language models via clients. This flow
+allows clients to maintain control over model access, selection, and permissions while
+enabling servers to leverage AI capabilities&mdash;with no server API keys necessary.
+Servers can request text or image-based interactions and optionally include context from
+MCP servers in their prompts.
+
+## User Interaction Model
+
+Sampling in MCP allows servers to implement agentic behaviors, by enabling LLM calls to
+occur _nested_ inside other MCP server features.
+
+Implementations are free to expose sampling through any interface pattern that suits
+their needs&mdash;the protocol itself does not mandate any specific user interaction
+model.
+
+> **Warning:**
+> For trust & safety and security, there **SHOULD** always
+> be a human in the loop with the ability to deny sampling requests.
+>
+> Applications **SHOULD**:
+>
+> - Provide UI that makes it easy and intuitive to review sampling requests
+> - Allow users to view and edit prompts before sending
+> - Present generated responses for review before delivery
+
+## Capabilities
+
+Clients that support sampling **MUST** declare the `sampling` capability during
+[initialization](/specification/2024-11-05/basic/lifecycle#initialization):
+
+```json
+{
+  "capabilities": {
+    "sampling": {}
+  }
+}
+```
+
+## Protocol Messages
+
+### Creating Messages
+
+To request a language model generation, servers send a `sampling/createMessage` request:
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "sampling/createMessage",
+  "params": {
+    "messages": [
+      {
+        "role": "user",
+        "content": {
+          "type": "text",
+          "text": "What is the capital of France?"
+        }
+      }
+    ],
+    "modelPreferences": {
+      "hints": [
+        {
+          "name": "claude-3-sonnet"
+        }
+      ],
+      "intelligencePriority": 0.8,
+      "speedPriority": 0.5
+    },
+    "systemPrompt": "You are a helpful assistant.",
+    "maxTokens": 100
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "role": "assistant",
+    "content": {
+      "type": "text",
+      "text": "The capital of France is Paris."
+    },
+    "model": "claude-3-sonnet-20240307",
+    "stopReason": "endTurn"
+  }
+}
+```
+
+## Message Flow
+
+```mermaid
+sequenceDiagram
+    participant Server
+    participant Client
+    participant User
+    participant LLM
+
+    Note over Server,Client: Server initiates sampling
+    Server->>Client: sampling/createMessage
+
+    Note over Client,User: Human-in-the-loop review
+    Client->>User: Present request for approval
+    User-->>Client: Review and approve/modify
+
+    Note over Client,LLM: Model interaction
+    Client->>LLM: Forward approved request
+    LLM-->>Client: Return generation
+
+    Note over Client,User: Response review
+    Client->>User: Present response for approval
+    User-->>Client: Review and approve/modify
+
+    Note over Server,Client: Complete request
+    Client-->>Server: Return approved response
+```
+
+## Data Types
+
+### Messages
+
+Sampling messages can contain:
+
+#### Text Content
+
+```json
+{
+  "type": "text",
+  "text": "The message content"
+}
+```
+
+#### Image Content
+
+```json
+{
+  "type": "image",
+  "data": "base64-encoded-image-data",
+  "mimeType": "image/jpeg"
+}
+```
+
+### Model Preferences
+
+Model selection in MCP requires careful abstraction since servers and clients may use
+different AI providers with distinct model offerings. A server cannot simply request a
+specific model by name since the client may not have access to that exact model or may
+prefer to use a different provider's equivalent model.
+
+To solve this, MCP implements a preference system that combines abstract capability
+priorities with optional model hints:
+
+#### Capability Priorities
+
+Servers express their needs through three normalized priority values (0-1):
+
+- `costPriority`: How important is minimizing costs? Higher values prefer cheaper models.
+- `speedPriority`: How important is low latency? Higher values prefer faster models.
+- `intelligencePriority`: How important are advanced capabilities? Higher values prefer
+  more capable models.
+
+#### Model Hints
+
+While priorities help select models based on characteristics, `hints` allow servers to
+suggest specific models or model families:
+
+- Hints are treated as substrings that can match model names flexibly
+- Multiple hints are evaluated in order of preference
+- Clients **MAY** map hints to equivalent models from different providers
+- Hints are advisory&mdash;clients make final model selection
+
+For example:
+
+```json
+{
+  "hints": [
+    { "name": "claude-3-sonnet" }, // Prefer Sonnet-class models
+    { "name": "claude" } // Fall back to any Claude model
+  ],
+  "costPriority": 0.3, // Cost is less important
+  "speedPriority": 0.8, // Speed is very important
+  "intelligencePriority": 0.5 // Moderate capability needs
+}
+```
+
+The client processes these preferences to select an appropriate model from its available
+options. For instance, if the client doesn't have access to Claude models but has Gemini,
+it might map the sonnet hint to `gemini-1.5-pro` based on similar capabilities.
+
+## Error Handling
+
+Clients **SHOULD** return errors for common failure cases:
+
+Example error:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "error": {
+    "code": -1,
+    "message": "User rejected sampling request"
+  }
+}
+```
+
+## Security Considerations
+
+1. Clients **SHOULD** implement user approval controls
+2. Both parties **SHOULD** validate message content
+3. Clients **SHOULD** respect model preference hints
+4. Clients **SHOULD** implement rate limiting
+5. Both parties **MUST** handle sensitive data appropriately

--- a/.agents/skills/mcp-knowledge/references/2024-11-05/tools.md
+++ b/.agents/skills/mcp-knowledge/references/2024-11-05/tools.md
@@ -1,0 +1,280 @@
+<!-- markdownlint-disable -->
+# Tools
+
+The Model Context Protocol (MCP) allows servers to expose tools that can be invoked by
+language models. Tools enable models to interact with external systems, such as querying
+databases, calling APIs, or performing computations. Each tool is uniquely identified by
+a name and includes metadata describing its schema.
+
+## User Interaction Model
+
+Tools in MCP are designed to be **model-controlled**, meaning that the language model can
+discover and invoke tools automatically based on its contextual understanding and the
+user's prompts.
+
+However, implementations are free to expose tools through any interface pattern that
+suits their needs&mdash;the protocol itself does not mandate any specific user
+interaction model.
+
+> **Warning:**
+> For trust & safety and security, there **SHOULD** always
+> be a human in the loop with the ability to deny tool invocations.
+>
+> Applications **SHOULD**:
+>
+> - Provide UI that makes clear which tools are being exposed to the AI model
+> - Insert clear visual indicators when tools are invoked
+> - Present confirmation prompts to the user for operations, to ensure a human is in the
+>   loop
+
+## Capabilities
+
+Servers that support tools **MUST** declare the `tools` capability:
+
+```json
+{
+  "capabilities": {
+    "tools": {
+      "listChanged": true
+    }
+  }
+}
+```
+
+`listChanged` indicates whether the server will emit notifications when the list of
+available tools changes.
+
+## Protocol Messages
+
+### Listing Tools
+
+To discover available tools, clients send a `tools/list` request. This operation supports
+[pagination](/specification/2024-11-05/server/utilities/pagination).
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/list",
+  "params": {
+    "cursor": "optional-cursor-value"
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "tools": [
+      {
+        "name": "get_weather",
+        "description": "Get current weather information for a location",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "location": {
+              "type": "string",
+              "description": "City name or zip code"
+            }
+          },
+          "required": ["location"]
+        }
+      }
+    ],
+    "nextCursor": "next-page-cursor"
+  }
+}
+```
+
+### Calling Tools
+
+To invoke a tool, clients send a `tools/call` request:
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "tools/call",
+  "params": {
+    "name": "get_weather",
+    "arguments": {
+      "location": "New York"
+    }
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "Current weather in New York:\nTemperature: 72°F\nConditions: Partly cloudy"
+      }
+    ],
+    "isError": false
+  }
+}
+```
+
+### List Changed Notification
+
+When the list of available tools changes, servers that declared the `listChanged`
+capability **SHOULD** send a notification:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/tools/list_changed"
+}
+```
+
+## Message Flow
+
+```mermaid
+sequenceDiagram
+    participant LLM
+    participant Client
+    participant Server
+
+    Note over Client,Server: Discovery
+    Client->>Server: tools/list
+    Server-->>Client: List of tools
+
+    Note over Client,LLM: Tool Selection
+    LLM->>Client: Select tool to use
+
+    Note over Client,Server: Invocation
+    Client->>Server: tools/call
+    Server-->>Client: Tool result
+    Client->>LLM: Process result
+
+    Note over Client,Server: Updates
+    Server--)Client: tools/list_changed
+    Client->>Server: tools/list
+    Server-->>Client: Updated tools
+```
+
+## Data Types
+
+### Tool
+
+A tool definition includes:
+
+- `name`: Unique identifier for the tool
+- `description`: Human-readable description of functionality
+- `inputSchema`: JSON Schema defining expected parameters
+
+### Tool Result
+
+Tool results can contain multiple content items of different types:
+
+#### Text Content
+
+```json
+{
+  "type": "text",
+  "text": "Tool result text"
+}
+```
+
+#### Image Content
+
+```json
+{
+  "type": "image",
+  "data": "base64-encoded-data",
+  "mimeType": "image/png"
+}
+```
+
+#### Embedded Resources
+
+[Resources](/specification/2024-11-05/server/resources) **MAY** be
+embedded, to provide additional context or data, behind a URI that can be subscribed to
+or fetched again by the client later:
+
+```json
+{
+  "type": "resource",
+  "resource": {
+    "uri": "resource://example",
+    "mimeType": "text/plain",
+    "text": "Resource content"
+  }
+}
+```
+
+## Error Handling
+
+Tools use two error reporting mechanisms:
+
+1. **Protocol Errors**: Standard JSON-RPC errors for issues like:
+   - Unknown tools
+   - Invalid arguments
+   - Server errors
+
+2. **Tool Execution Errors**: Reported in tool results with `isError: true`:
+   - API failures
+   - Invalid input data
+   - Business logic errors
+
+Example protocol error:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "error": {
+    "code": -32602,
+    "message": "Unknown tool: invalid_tool_name"
+  }
+}
+```
+
+Example tool execution error:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 4,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "Failed to fetch weather data: API rate limit exceeded"
+      }
+    ],
+    "isError": true
+  }
+}
+```
+
+## Security Considerations
+
+1. Servers **MUST**:
+   - Validate all tool inputs
+   - Implement proper access controls
+   - Rate limit tool invocations
+   - Sanitize tool outputs
+
+2. Clients **SHOULD**:
+   - Prompt for user confirmation on sensitive operations
+   - Show tool inputs to the user before calling the server, to avoid malicious or
+     accidental data exfiltration
+   - Validate tool results before passing to LLM
+   - Implement timeouts for tool calls
+   - Log tool usage for audit purposes

--- a/.agents/skills/mcp-knowledge/references/2024-11-05/transports.md
+++ b/.agents/skills/mcp-knowledge/references/2024-11-05/transports.md
@@ -1,0 +1,94 @@
+<!-- markdownlint-disable -->
+# Transports
+
+MCP currently defines two standard transport mechanisms for client-server communication:
+
+1. [stdio](#stdio), communication over standard in and standard out
+2. [HTTP with Server-Sent Events](#http-with-sse) (SSE)
+
+Clients **SHOULD** support stdio whenever possible.
+
+It is also possible for clients and servers to implement
+[custom transports](#custom-transports) in a pluggable fashion.
+
+## stdio
+
+In the **stdio** transport:
+
+- The client launches the MCP server as a subprocess.
+- The server receives JSON-RPC messages on its standard input (`stdin`) and writes
+  responses to its standard output (`stdout`).
+- Messages are delimited by newlines, and **MUST NOT** contain embedded newlines.
+- The server **MAY** write UTF-8 strings to its standard error (`stderr`) for logging
+  purposes. Clients **MAY** capture, forward, or ignore this logging.
+- The server **MUST NOT** write anything to its `stdout` that is not a valid MCP message.
+- The client **MUST NOT** write anything to the server's `stdin` that is not a valid MCP
+  message.
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Server Process
+
+    Client->>+Server Process: Launch subprocess
+    loop Message Exchange
+        Client->>Server Process: Write to stdin
+        Server Process->>Client: Write to stdout
+        Server Process--)Client: Optional logs on stderr
+    end
+    Client->>Server Process: Close stdin, terminate subprocess
+    deactivate Server Process
+```
+
+## HTTP with SSE
+
+In the **SSE** transport, the server operates as an independent process that can handle
+multiple client connections.
+
+#### Security Warning
+
+When implementing HTTP with SSE transport:
+
+1. Servers **MUST** validate the `Origin` header on all incoming connections to prevent DNS rebinding attacks
+2. When running locally, servers **SHOULD** bind only to localhost (127.0.0.1) rather than all network interfaces (0.0.0.0)
+3. Servers **SHOULD** implement proper authentication for all connections
+
+Without these protections, attackers could use DNS rebinding to interact with local MCP servers from remote websites.
+
+The server **MUST** provide two endpoints:
+
+1. An SSE endpoint, for clients to establish a connection and receive messages from the
+   server
+2. A regular HTTP POST endpoint for clients to send messages to the server
+
+When a client connects, the server **MUST** send an `endpoint` event containing a URI for
+the client to use for sending messages. All subsequent client messages **MUST** be sent
+as HTTP POST requests to this endpoint.
+
+Server messages are sent as SSE `message` events, with the message content encoded as
+JSON in the event data.
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Server
+
+    Client->>Server: Open SSE connection
+    Server->>Client: endpoint event
+    loop Message Exchange
+        Client->>Server: HTTP POST messages
+        Server->>Client: SSE message events
+    end
+    Client->>Server: Close SSE connection
+```
+
+## Custom Transports
+
+Clients and servers **MAY** implement additional custom transport mechanisms to suit
+their specific needs. The protocol is transport-agnostic and can be implemented over any
+communication channel that supports bidirectional message exchange.
+
+Implementers who choose to support custom transports **MUST** ensure they preserve the
+JSON-RPC message format and lifecycle requirements defined by MCP. Custom transports
+**SHOULD** document their specific connection establishment and message exchange patterns
+to aid interoperability.

--- a/.agents/skills/mcp-knowledge/references/2025-03-26/architecture.md
+++ b/.agents/skills/mcp-knowledge/references/2025-03-26/architecture.md
@@ -1,0 +1,171 @@
+<!-- markdownlint-disable -->
+# Architecture
+
+The Model Context Protocol (MCP) follows a client-host-server architecture where each
+host can run multiple client instances. This architecture enables users to integrate AI
+capabilities across applications while maintaining clear security boundaries and
+isolating concerns. Built on JSON-RPC, MCP provides a stateful session protocol focused
+on context exchange and sampling coordination between clients and servers.
+
+## Core Components
+
+```mermaid
+graph LR
+    subgraph "Application Host Process"
+        H[Host]
+        C1[Client 1]
+        C2[Client 2]
+        C3[Client 3]
+        H --> C1
+        H --> C2
+        H --> C3
+    end
+
+    subgraph "Local machine"
+        S1[Server 1<br>Files & Git]
+        S2[Server 2<br>Database]
+        R1[("Local<br>Resource A")]
+        R2[("Local<br>Resource B")]
+
+        C1 --> S1
+        C2 --> S2
+        S1 <--> R1
+        S2 <--> R2
+    end
+
+    subgraph "Internet"
+        S3[Server 3<br>External APIs]
+        R3[("Remote<br>Resource C")]
+
+        C3 --> S3
+        S3 <--> R3
+    end
+```
+
+### Host
+
+The host process acts as the container and coordinator:
+
+- Creates and manages multiple client instances
+- Controls client connection permissions and lifecycle
+- Enforces security policies and consent requirements
+- Handles user authorization decisions
+- Coordinates AI/LLM integration and sampling
+- Manages context aggregation across clients
+
+### Clients
+
+Each client is created by the host and maintains an isolated server connection:
+
+- Establishes one stateful session per server
+- Handles protocol negotiation and capability exchange
+- Routes protocol messages bidirectionally
+- Manages subscriptions and notifications
+- Maintains security boundaries between servers
+
+A host application creates and manages multiple clients, with each client having a 1:1
+relationship with a particular server.
+
+### Servers
+
+Servers provide specialized context and capabilities:
+
+- Expose resources, tools and prompts via MCP primitives
+- Operate independently with focused responsibilities
+- Request sampling through client interfaces
+- Must respect security constraints
+- Can be local processes or remote services
+
+## Design Principles
+
+MCP is built on several key design principles that inform its architecture and
+implementation:
+
+1. **Servers should be extremely easy to build**
+   - Host applications handle complex orchestration responsibilities
+   - Servers focus on specific, well-defined capabilities
+   - Simple interfaces minimize implementation overhead
+   - Clear separation enables maintainable code
+
+2. **Servers should be highly composable**
+   - Each server provides focused functionality in isolation
+   - Multiple servers can be combined seamlessly
+   - Shared protocol enables interoperability
+   - Modular design supports extensibility
+
+3. **Servers should not be able to read the whole conversation, nor "see into" other
+   servers**
+   - Servers receive only necessary contextual information
+   - Full conversation history stays with the host
+   - Each server connection maintains isolation
+   - Cross-server interactions are controlled by the host
+   - Host process enforces security boundaries
+
+4. **Features can be added to servers and clients progressively**
+   - Core protocol provides minimal required functionality
+   - Additional capabilities can be negotiated as needed
+   - Servers and clients evolve independently
+   - Protocol designed for future extensibility
+   - Backwards compatibility is maintained
+
+## Capability Negotiation
+
+The Model Context Protocol uses a capability-based negotiation system where clients and
+servers explicitly declare their supported features during initialization. Capabilities
+determine which protocol features and primitives are available during a session.
+
+- Servers declare capabilities like resource subscriptions, tool support, and prompt
+  templates
+- Clients declare capabilities like sampling support and notification handling
+- Both parties must respect declared capabilities throughout the session
+- Additional capabilities can be negotiated through extensions to the protocol
+
+```mermaid
+sequenceDiagram
+    participant Host
+    participant Client
+    participant Server
+
+    Host->>+Client: Initialize client
+    Client->>+Server: Initialize session with capabilities
+    Server-->>Client: Respond with supported capabilities
+
+    Note over Host,Server: Active Session with Negotiated Features
+
+    loop Client Requests
+        Host->>Client: User- or model-initiated action
+        Client->>Server: Request (tools/resources)
+        Server-->>Client: Response
+        Client-->>Host: Update UI or respond to model
+    end
+
+    loop Server Requests
+        Server->>Client: Request (sampling)
+        Client->>Host: Forward to AI
+        Host-->>Client: AI response
+        Client-->>Server: Response
+    end
+
+    loop Notifications
+        Server--)Client: Resource updates
+        Client--)Server: Status changes
+    end
+
+    Host->>Client: Terminate
+    Client->>-Server: End session
+    deactivate Server
+```
+
+Each capability unlocks specific protocol features for use during the session. For
+example:
+
+- Implemented [server features](/specification/2025-03-26/server) must be advertised in the
+  server's capabilities
+- Emitting resource subscription notifications requires the server to declare
+  subscription support
+- Tool invocation requires the server to declare tool capabilities
+- [Sampling](/specification/2025-03-26/client) requires the client to declare support in its
+  capabilities
+
+This capability negotiation ensures clients and servers have a clear understanding of
+supported functionality while maintaining protocol extensibility.

--- a/.agents/skills/mcp-knowledge/references/2025-03-26/authorization.md
+++ b/.agents/skills/mcp-knowledge/references/2025-03-26/authorization.md
@@ -1,0 +1,405 @@
+<!-- markdownlint-disable -->
+# Authorization
+
+## Introduction
+
+### Purpose and Scope
+
+The Model Context Protocol provides authorization capabilities at the transport level,
+enabling MCP clients to make requests to restricted MCP servers on behalf of resource
+owners. This specification defines the authorization flow for HTTP-based transports.
+
+### Protocol Requirements
+
+Authorization is **OPTIONAL** for MCP implementations. When supported:
+
+- Implementations using an HTTP-based transport **SHOULD** conform to this specification.
+- Implementations using an STDIO transport **SHOULD NOT** follow this specification, and
+  instead retrieve credentials from the environment.
+- Implementations using alternative transports **MUST** follow established security best
+  practices for their protocol.
+
+### Standards Compliance
+
+This authorization mechanism is based on established specifications listed below, but
+implements a selected subset of their features to ensure security and interoperability
+while maintaining simplicity:
+
+- [OAuth 2.1 IETF DRAFT](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-12)
+- OAuth 2.0 Authorization Server Metadata
+  ([RFC8414](https://datatracker.ietf.org/doc/html/rfc8414))
+- OAuth 2.0 Dynamic Client Registration Protocol
+  ([RFC7591](https://datatracker.ietf.org/doc/html/rfc7591))
+
+## Authorization Flow
+
+### Overview
+
+1. MCP auth implementations **MUST** implement OAuth 2.1 with appropriate security
+   measures for both confidential and public clients.
+
+2. MCP auth implementations **SHOULD** support the OAuth 2.0 Dynamic Client Registration
+   Protocol ([RFC7591](https://datatracker.ietf.org/doc/html/rfc7591)).
+
+3. MCP servers **SHOULD** and MCP clients **MUST** implement OAuth 2.0 Authorization
+   Server Metadata ([RFC8414](https://datatracker.ietf.org/doc/html/rfc8414)). Servers
+   that do not support Authorization Server Metadata **MUST** follow the default URI
+   schema.
+
+### OAuth Grant Types
+
+OAuth specifies different flows or grant types, which are different ways of obtaining an
+access token. Each of these targets different use cases and scenarios.
+
+MCP servers **SHOULD** support the OAuth grant types that best align with the intended
+audience. For instance:
+
+1. Authorization Code: useful when the client is acting on behalf of a (human) end user.
+   - For instance, an agent calls an MCP tool implemented by a SaaS system.
+2. Client Credentials: the client is another application (not a human)
+   - For instance, an agent calls a secure MCP tool to check inventory at a specific
+     store. No need to impersonate the end user.
+
+### Example: authorization code grant
+
+This demonstrates the OAuth 2.1 flow for the authorization code grant type, used for user
+auth.
+
+**NOTE**: The following example assumes the MCP server is also functioning as the
+authorization server. However, the authorization server may be deployed as its own
+distinct service.
+
+A human user completes the OAuth flow through a web browser, obtaining an access token
+that identifies them personally and allows the client to act on their behalf.
+
+When authorization is required and not yet proven by the client, servers **MUST** respond
+with _HTTP 401 Unauthorized_.
+
+Clients initiate the
+[OAuth 2.1 IETF DRAFT](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-12#name-authorization-code-grant)
+authorization flow after receiving the _HTTP 401 Unauthorized_.
+
+The following demonstrates the basic OAuth 2.1 for public clients using PKCE.
+
+```mermaid
+sequenceDiagram
+    participant B as User-Agent (Browser)
+    participant C as Client
+    participant M as MCP Server
+
+    C->>M: MCP Request
+    M->>C: HTTP 401 Unauthorized
+    Note over C: Generate code_verifier and code_challenge
+    C->>B: Open browser with authorization URL + code_challenge
+    B->>M: GET /authorize
+    Note over M: User logs in and authorizes
+    M->>B: Redirect to callback URL with auth code
+    B->>C: Callback with authorization code
+    C->>M: Token Request with code + code_verifier
+    M->>C: Access Token (+ Refresh Token)
+    C->>M: MCP Request with Access Token
+    Note over C,M: Begin standard MCP message exchange
+```
+
+### Server Metadata Discovery
+
+For server capability discovery:
+
+- MCP clients _MUST_ follow the OAuth 2.0 Authorization Server Metadata protocol defined
+  in [RFC8414](https://datatracker.ietf.org/doc/html/rfc8414).
+- MCP server _SHOULD_ follow the OAuth 2.0 Authorization Server Metadata protocol.
+- MCP servers that do not support the OAuth 2.0 Authorization Server Metadata protocol,
+  _MUST_ support fallback URLs.
+
+The discovery flow is illustrated below:
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant S as Server
+
+    C->>S: GET /.well-known/oauth-authorization-server
+    alt Discovery Success
+        S->>C: 200 OK + Metadata Document
+        Note over C: Use endpoints from metadata
+    else Discovery Failed
+        S->>C: 404 Not Found
+        Note over C: Fall back to default endpoints
+    end
+    Note over C: Continue with authorization flow
+```
+
+#### Server Metadata Discovery Headers
+
+MCP clients _SHOULD_ include the header `MCP-Protocol-Version: <protocol-version>` during
+Server Metadata Discovery to allow the MCP server to respond based on the MCP protocol
+version.
+
+For example: `MCP-Protocol-Version: 2024-11-05`
+
+#### Authorization Base URL
+
+The authorization base URL **MUST** be determined from the MCP server URL by discarding
+any existing `path` component. For example:
+
+If the MCP server URL is `https://api.example.com/v1/mcp`, then:
+
+- The authorization base URL is `https://api.example.com`
+- The metadata endpoint **MUST** be at
+  `https://api.example.com/.well-known/oauth-authorization-server`
+
+This ensures authorization endpoints are consistently located at the root level of the
+domain hosting the MCP server, regardless of any path components in the MCP server URL.
+
+#### Fallbacks for Servers without Metadata Discovery
+
+For servers that do not implement OAuth 2.0 Authorization Server Metadata, clients
+**MUST** use the following default endpoint paths relative to the [authorization base
+URL](#authorization-base-url):
+
+| Endpoint               | Default Path | Description                          |
+| ---------------------- | ------------ | ------------------------------------ |
+| Authorization Endpoint | /authorize   | Used for authorization requests      |
+| Token Endpoint         | /token       | Used for token exchange & refresh    |
+| Registration Endpoint  | /register    | Used for dynamic client registration |
+
+For example, with an MCP server hosted at `https://api.example.com/v1/mcp`, the default
+endpoints would be:
+
+- `https://api.example.com/authorize`
+- `https://api.example.com/token`
+- `https://api.example.com/register`
+
+Clients **MUST** first attempt to discover endpoints via the metadata document before
+falling back to default paths. When using default paths, all other protocol requirements
+remain unchanged.
+
+### Dynamic Client Registration
+
+MCP clients and servers **SHOULD** support the
+[OAuth 2.0 Dynamic Client Registration Protocol](https://datatracker.ietf.org/doc/html/rfc7591)
+to allow MCP clients to obtain OAuth client IDs without user interaction. This provides a
+standardized way for clients to automatically register with new servers, which is crucial
+for MCP because:
+
+- Clients cannot know all possible servers in advance
+- Manual registration would create friction for users
+- It enables seamless connection to new servers
+- Servers can implement their own registration policies
+
+Any MCP servers that _do not_ support Dynamic Client Registration need to provide
+alternative ways to obtain a client ID (and, if applicable, client secret). For one of
+these servers, MCP clients will have to either:
+
+1. Hardcode a client ID (and, if applicable, client secret) specifically for that MCP
+   server, or
+2. Present a UI to users that allows them to enter these details, after registering an
+   OAuth client themselves (e.g., through a configuration interface hosted by the
+   server).
+
+### Authorization Flow Steps
+
+The complete Authorization flow proceeds as follows:
+
+```mermaid
+sequenceDiagram
+    participant B as User-Agent (Browser)
+    participant C as Client
+    participant M as MCP Server
+
+    C->>M: GET /.well-known/oauth-authorization-server
+    alt Server Supports Discovery
+        M->>C: Authorization Server Metadata
+    else No Discovery
+        M->>C: 404 (Use default endpoints)
+    end
+
+    alt Dynamic Client Registration
+        C->>M: POST /register
+        M->>C: Client Credentials
+    end
+
+    Note over C: Generate PKCE Parameters
+    C->>B: Open browser with authorization URL + code_challenge
+    B->>M: Authorization Request
+    Note over M: User /authorizes
+    M->>B: Redirect to callback with authorization code
+    B->>C: Authorization code callback
+    C->>M: Token Request + code_verifier
+    M->>C: Access Token (+ Refresh Token)
+    C->>M: API Requests with Access Token
+```
+
+#### Decision Flow Overview
+
+```mermaid
+flowchart TD
+    A[Start Auth Flow] --> B{Check Metadata Discovery}
+    B -->|Available| C[Use Metadata Endpoints]
+    B -->|Not Available| D[Use Default Endpoints]
+
+    C --> G{Check Registration Endpoint}
+    D --> G
+
+    G -->|Available| H[Perform Dynamic Registration]
+    G -->|Not Available| I[Alternative Registration Required]
+
+    H --> J[Start OAuth Flow]
+    I --> J
+
+    J --> K[Generate PKCE Parameters]
+    K --> L[Request Authorization]
+    L --> M[User Authorization]
+    M --> N[Exchange Code for Tokens]
+    N --> O[Use Access Token]
+```
+
+### Access Token Usage
+
+#### Token Requirements
+
+Access token handling **MUST** conform to
+[OAuth 2.1 Section 5](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-12#section-5)
+requirements for resource requests. Specifically:
+
+1. MCP client **MUST** use the Authorization request header field
+   [Section 5.1.1](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-12#section-5.1.1):
+
+```
+Authorization: Bearer <access-token>
+```
+
+Note that authorization **MUST** be included in every HTTP request from client to server,
+even if they are part of the same logical session.
+
+2. Access tokens **MUST NOT** be included in the URI query string
+
+Example request:
+
+```http
+GET /v1/contexts HTTP/1.1
+Host: mcp.example.com
+Authorization: Bearer eyJhbGciOiJIUzI1NiIs...
+```
+
+#### Token Handling
+
+Resource servers **MUST** validate access tokens as described in
+[Section 5.2](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-12#section-5.2).
+If validation fails, servers **MUST** respond according to
+[Section 5.3](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-12#section-5.3)
+error handling requirements. Invalid or expired tokens **MUST** receive a HTTP 401
+response.
+
+### Security Considerations
+
+The following security requirements **MUST** be implemented:
+
+1. Clients **MUST** securely store tokens following OAuth 2.0 best practices
+2. Servers **SHOULD** enforce token expiration and rotation
+3. All authorization endpoints **MUST** be served over HTTPS
+4. Servers **MUST** validate redirect URIs to prevent open redirect vulnerabilities
+5. Redirect URIs **MUST** be either localhost URLs or HTTPS URLs
+
+### Error Handling
+
+Servers **MUST** return appropriate HTTP status codes for authorization errors:
+
+| Status Code | Description  | Usage                                      |
+| ----------- | ------------ | ------------------------------------------ |
+| 401         | Unauthorized | Authorization required or token invalid    |
+| 403         | Forbidden    | Invalid scopes or insufficient permissions |
+| 400         | Bad Request  | Malformed authorization request            |
+
+### Implementation Requirements
+
+1. Implementations **MUST** follow OAuth 2.1 security best practices
+2. PKCE is **REQUIRED** for all clients
+3. Token rotation **SHOULD** be implemented for enhanced security
+4. Token lifetimes **SHOULD** be limited based on security requirements
+
+### Third-Party Authorization Flow
+
+#### Overview
+
+MCP servers **MAY** support delegated authorization through third-party authorization
+servers. In this flow, the MCP server acts as both an OAuth client (to the third-party
+auth server) and an OAuth authorization server (to the MCP client).
+
+#### Flow Description
+
+The third-party authorization flow comprises these steps:
+
+1. MCP client initiates standard OAuth flow with MCP server
+2. MCP server redirects user to third-party authorization server
+3. User authorizes with third-party server
+4. Third-party server redirects back to MCP server with authorization code
+5. MCP server exchanges code for third-party access token
+6. MCP server generates its own access token bound to the third-party session
+7. MCP server completes original OAuth flow with MCP client
+
+```mermaid
+sequenceDiagram
+    participant B as User-Agent (Browser)
+    participant C as MCP Client
+    participant M as MCP Server
+    participant T as Third-Party Auth Server
+
+    C->>M: Initial OAuth Request
+    M->>B: Redirect to Third-Party /authorize
+    B->>T: Authorization Request
+    Note over T: User authorizes
+    T->>B: Redirect to MCP Server callback
+    B->>M: Authorization code
+    M->>T: Exchange code for token
+    T->>M: Third-party access token
+    Note over M: Generate bound MCP token
+    M->>B: Redirect to MCP Client callback
+    B->>C: MCP authorization code
+    C->>M: Exchange code for token
+    M->>C: MCP access token
+```
+
+#### Session Binding Requirements
+
+MCP servers implementing third-party authorization **MUST**:
+
+1. Maintain secure mapping between third-party tokens and issued MCP tokens
+2. Validate third-party token status before honoring MCP tokens
+3. Implement appropriate token lifecycle management
+4. Handle third-party token expiration and renewal
+
+#### Security Considerations
+
+When implementing third-party authorization, servers **MUST**:
+
+1. Validate all redirect URIs
+2. Securely store third-party credentials
+3. Implement appropriate session timeout handling
+4. Consider security implications of token chaining
+5. Implement proper error handling for third-party auth failures
+
+## Best Practices
+
+#### Local clients as Public OAuth 2.1 Clients
+
+We strongly recommend that local clients implement OAuth 2.1 as a public client:
+
+1. Utilizing code challenges (PKCE) for authorization requests to prevent interception
+   attacks
+2. Implementing secure token storage appropriate for the local system
+3. Following token refresh best practices to maintain sessions
+4. Properly handling token expiration and renewal
+
+#### Authorization Metadata Discovery
+
+We strongly recommend that all clients implement metadata discovery. This reduces the
+need for users to provide endpoints manually or clients to fallback to the defined
+defaults.
+
+#### Dynamic Client Registration
+
+Since clients do not know the set of MCP servers in advance, we strongly recommend the
+implementation of dynamic client registration. This allows applications to automatically
+register with the MCP server, and removes the need for users to obtain client ids
+manually.

--- a/.agents/skills/mcp-knowledge/references/2025-03-26/cancellation.md
+++ b/.agents/skills/mcp-knowledge/references/2025-03-26/cancellation.md
@@ -1,0 +1,80 @@
+<!-- markdownlint-disable -->
+# Cancellation
+
+The Model Context Protocol (MCP) supports optional cancellation of in-progress requests
+through notification messages. Either side can send a cancellation notification to
+indicate that a previously-issued request should be terminated.
+
+## Cancellation Flow
+
+When a party wants to cancel an in-progress request, it sends a `notifications/cancelled`
+notification containing:
+
+- The ID of the request to cancel
+- An optional reason string that can be logged or displayed
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/cancelled",
+  "params": {
+    "requestId": "123",
+    "reason": "User requested cancellation"
+  }
+}
+```
+
+## Behavior Requirements
+
+1. Cancellation notifications **MUST** only reference requests that:
+   - Were previously issued in the same direction
+   - Are believed to still be in-progress
+2. The `initialize` request **MUST NOT** be cancelled by clients
+3. Receivers of cancellation notifications **SHOULD**:
+   - Stop processing the cancelled request
+   - Free associated resources
+   - Not send a response for the cancelled request
+4. Receivers **MAY** ignore cancellation notifications if:
+   - The referenced request is unknown
+   - Processing has already completed
+   - The request cannot be cancelled
+5. The sender of the cancellation notification **SHOULD** ignore any response to the
+   request that arrives afterward
+
+## Timing Considerations
+
+Due to network latency, cancellation notifications may arrive after request processing
+has completed, and potentially after a response has already been sent.
+
+Both parties **MUST** handle these race conditions gracefully:
+
+```mermaid
+sequenceDiagram
+   participant Client
+   participant Server
+
+   Client->>Server: Request (ID: 123)
+   Note over Server: Processing starts
+   Client--)Server: notifications/cancelled (ID: 123)
+   alt
+      Note over Server: Processing may have<br/>completed before<br/>cancellation arrives
+   else If not completed
+      Note over Server: Stop processing
+   end
+```
+
+## Implementation Notes
+
+- Both parties **SHOULD** log cancellation reasons for debugging
+- Application UIs **SHOULD** indicate when cancellation is requested
+
+## Error Handling
+
+Invalid cancellation notifications **SHOULD** be ignored:
+
+- Unknown request IDs
+- Already completed requests
+- Malformed notifications
+
+This maintains the "fire and forget" nature of notifications while allowing for race
+conditions in asynchronous communication.

--- a/.agents/skills/mcp-knowledge/references/2025-03-26/changelog.md
+++ b/.agents/skills/mcp-knowledge/references/2025-03-26/changelog.md
@@ -1,0 +1,35 @@
+<!-- markdownlint-disable -->
+# Key Changes
+
+This document lists changes made to the Model Context Protocol (MCP) specification since
+the previous revision, [2024-11-05](/specification/2024-11-05).
+
+## Major changes
+
+1. Added a comprehensive **[authorization framework](/specification/2025-03-26/basic/authorization)**
+   based on OAuth 2.1 (PR
+   [#133](https://github.com/modelcontextprotocol/specification/pull/133))
+1. Replaced the previous HTTP+SSE transport with a more flexible **[Streamable HTTP
+   transport](/specification/2025-03-26/basic/transports#streamable-http)** (PR
+   [#206](https://github.com/modelcontextprotocol/specification/pull/206))
+1. Added support for JSON-RPC **[batching](https://www.jsonrpc.org/specification#batch)**
+   (PR [#228](https://github.com/modelcontextprotocol/specification/pull/228))
+1. Added comprehensive **tool annotations** for better describing tool behavior, like
+   whether it is read-only or destructive (PR
+   [#185](https://github.com/modelcontextprotocol/specification/pull/185))
+
+## Other schema changes
+
+- Added `message` field to `ProgressNotification` to provide descriptive status updates
+- Added support for audio data, joining the existing text and image content types
+- Added `completions` capability to explicitly indicate support for argument
+  autocompletion suggestions
+
+See
+[the updated schema](http://github.com/modelcontextprotocol/specification/tree/main/schema/2025-03-26/schema.ts)
+for more details.
+
+## Full changelog
+
+For a complete list of all changes that have been made since the last protocol revision,
+[see GitHub](https://github.com/modelcontextprotocol/specification/compare/2024-11-05...2025-03-26).

--- a/.agents/skills/mcp-knowledge/references/2025-03-26/completion.md
+++ b/.agents/skills/mcp-knowledge/references/2025-03-26/completion.md
@@ -1,0 +1,154 @@
+<!-- markdownlint-disable -->
+# Completion
+
+The Model Context Protocol (MCP) provides a standardized way for servers to offer
+argument autocompletion suggestions for prompts and resource URIs. This enables rich,
+IDE-like experiences where users receive contextual suggestions while entering argument
+values.
+
+## User Interaction Model
+
+Completion in MCP is designed to support interactive user experiences similar to IDE code
+completion.
+
+For example, applications may show completion suggestions in a dropdown or popup menu as
+users type, with the ability to filter and select from available options.
+
+However, implementations are free to expose completion through any interface pattern that
+suits their needs&mdash;the protocol itself does not mandate any specific user
+interaction model.
+
+## Capabilities
+
+Servers that support completions **MUST** declare the `completions` capability:
+
+```json
+{
+  "capabilities": {
+    "completions": {}
+  }
+}
+```
+
+## Protocol Messages
+
+### Requesting Completions
+
+To get completion suggestions, clients send a `completion/complete` request specifying
+what is being completed through a reference type:
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "completion/complete",
+  "params": {
+    "ref": {
+      "type": "ref/prompt",
+      "name": "code_review"
+    },
+    "argument": {
+      "name": "language",
+      "value": "py"
+    }
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "completion": {
+      "values": ["python", "pytorch", "pyside"],
+      "total": 10,
+      "hasMore": true
+    }
+  }
+}
+```
+
+### Reference Types
+
+The protocol supports two types of completion references:
+
+| Type           | Description                 | Example                                             |
+| -------------- | --------------------------- | --------------------------------------------------- |
+| `ref/prompt`   | References a prompt by name | `{"type": "ref/prompt", "name": "code_review"}`     |
+| `ref/resource` | References a resource URI   | `{"type": "ref/resource", "uri": "file:///{path}"}` |
+
+### Completion Results
+
+Servers return an array of completion values ranked by relevance, with:
+
+- Maximum 100 items per response
+- Optional total number of available matches
+- Boolean indicating if additional results exist
+
+## Message Flow
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Server
+
+    Note over Client: User types argument
+    Client->>Server: completion/complete
+    Server-->>Client: Completion suggestions
+
+    Note over Client: User continues typing
+    Client->>Server: completion/complete
+    Server-->>Client: Refined suggestions
+```
+
+## Data Types
+
+### CompleteRequest
+
+- `ref`: A `PromptReference` or `ResourceReference`
+- `argument`: Object containing:
+  - `name`: Argument name
+  - `value`: Current value
+
+### CompleteResult
+
+- `completion`: Object containing:
+  - `values`: Array of suggestions (max 100)
+  - `total`: Optional total matches
+  - `hasMore`: Additional results flag
+
+## Error Handling
+
+Servers **SHOULD** return standard JSON-RPC errors for common failure cases:
+
+- Method not found: `-32601` (Capability not supported)
+- Invalid prompt name: `-32602` (Invalid params)
+- Missing required arguments: `-32602` (Invalid params)
+- Internal errors: `-32603` (Internal error)
+
+## Implementation Considerations
+
+1. Servers **SHOULD**:
+   - Return suggestions sorted by relevance
+   - Implement fuzzy matching where appropriate
+   - Rate limit completion requests
+   - Validate all inputs
+
+2. Clients **SHOULD**:
+   - Debounce rapid completion requests
+   - Cache completion results where appropriate
+   - Handle missing or partial results gracefully
+
+## Security
+
+Implementations **MUST**:
+
+- Validate all completion inputs
+- Implement appropriate rate limiting
+- Control access to sensitive suggestions
+- Prevent completion-based information disclosure

--- a/.agents/skills/mcp-knowledge/references/2025-03-26/lifecycle.md
+++ b/.agents/skills/mcp-knowledge/references/2025-03-26/lifecycle.md
@@ -1,0 +1,236 @@
+<!-- markdownlint-disable -->
+# Lifecycle
+
+The Model Context Protocol (MCP) defines a rigorous lifecycle for client-server
+connections that ensures proper capability negotiation and state management.
+
+1. **Initialization**: Capability negotiation and protocol version agreement
+2. **Operation**: Normal protocol communication
+3. **Shutdown**: Graceful termination of the connection
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Server
+
+    Note over Client,Server: Initialization Phase
+    activate Client
+    Client->>+Server: initialize request
+    Server-->>Client: initialize response
+    Client--)Server: initialized notification
+
+    Note over Client,Server: Operation Phase
+    rect rgb(200, 220, 250)
+        note over Client,Server: Normal protocol operations
+    end
+
+    Note over Client,Server: Shutdown
+    Client--)-Server: Disconnect
+    deactivate Server
+    Note over Client,Server: Connection closed
+```
+
+## Lifecycle Phases
+
+### Initialization
+
+The initialization phase **MUST** be the first interaction between client and server.
+During this phase, the client and server:
+
+- Establish protocol version compatibility
+- Exchange and negotiate capabilities
+- Share implementation details
+
+The client **MUST** initiate this phase by sending an `initialize` request containing:
+
+- Protocol version supported
+- Client capabilities
+- Client implementation information
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "initialize",
+  "params": {
+    "protocolVersion": "2025-03-26",
+    "capabilities": {
+      "roots": {
+        "listChanged": true
+      },
+      "sampling": {}
+    },
+    "clientInfo": {
+      "name": "ExampleClient",
+      "version": "1.0.0"
+    }
+  }
+}
+```
+
+The initialize request **MUST NOT** be part of a JSON-RPC
+[batch](https://www.jsonrpc.org/specification#batch), as other requests and notifications
+are not possible until initialization has completed. This also permits backwards
+compatibility with prior protocol versions that do not explicitly support JSON-RPC
+batches.
+
+The server **MUST** respond with its own capabilities and information:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "protocolVersion": "2025-03-26",
+    "capabilities": {
+      "logging": {},
+      "prompts": {
+        "listChanged": true
+      },
+      "resources": {
+        "subscribe": true,
+        "listChanged": true
+      },
+      "tools": {
+        "listChanged": true
+      }
+    },
+    "serverInfo": {
+      "name": "ExampleServer",
+      "version": "1.0.0"
+    },
+    "instructions": "Optional instructions for the client"
+  }
+}
+```
+
+After successful initialization, the client **MUST** send an `initialized` notification
+to indicate it is ready to begin normal operations:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/initialized"
+}
+```
+
+- The client **SHOULD NOT** send requests other than
+  [pings](/specification/2025-03-26/basic/utilities/ping) before the server has responded to the
+  `initialize` request.
+- The server **SHOULD NOT** send requests other than
+  [pings](/specification/2025-03-26/basic/utilities/ping) and
+  [logging](/specification/2025-03-26/server/utilities/logging) before receiving the `initialized`
+  notification.
+
+#### Version Negotiation
+
+In the `initialize` request, the client **MUST** send a protocol version it supports.
+This **SHOULD** be the _latest_ version supported by the client.
+
+If the server supports the requested protocol version, it **MUST** respond with the same
+version. Otherwise, the server **MUST** respond with another protocol version it
+supports. This **SHOULD** be the _latest_ version supported by the server.
+
+If the client does not support the version in the server's response, it **SHOULD**
+disconnect.
+
+#### Capability Negotiation
+
+Client and server capabilities establish which optional protocol features will be
+available during the session.
+
+Key capabilities include:
+
+| Category | Capability     | Description                                                                               |
+| -------- | -------------- | ----------------------------------------------------------------------------------------- |
+| Client   | `roots`        | Ability to provide filesystem [roots](/specification/2025-03-26/client/roots)             |
+| Client   | `sampling`     | Support for LLM [sampling](/specification/2025-03-26/client/sampling) requests            |
+| Client   | `experimental` | Describes support for non-standard experimental features                                  |
+| Server   | `prompts`      | Offers [prompt templates](/specification/2025-03-26/server/prompts)                       |
+| Server   | `resources`    | Provides readable [resources](/specification/2025-03-26/server/resources)                 |
+| Server   | `tools`        | Exposes callable [tools](/specification/2025-03-26/server/tools)                          |
+| Server   | `logging`      | Emits structured [log messages](/specification/2025-03-26/server/utilities/logging)       |
+| Server   | `completions`  | Supports argument [autocompletion](/specification/2025-03-26/server/utilities/completion) |
+| Server   | `experimental` | Describes support for non-standard experimental features                                  |
+
+Capability objects can describe sub-capabilities like:
+
+- `listChanged`: Support for list change notifications (for prompts, resources, and
+  tools)
+- `subscribe`: Support for subscribing to individual items' changes (resources only)
+
+### Operation
+
+During the operation phase, the client and server exchange messages according to the
+negotiated capabilities.
+
+Both parties **SHOULD**:
+
+- Respect the negotiated protocol version
+- Only use capabilities that were successfully negotiated
+
+### Shutdown
+
+During the shutdown phase, one side (usually the client) cleanly terminates the protocol
+connection. No specific shutdown messages are defined—instead, the underlying transport
+mechanism should be used to signal connection termination:
+
+#### stdio
+
+For the stdio [transport](/specification/2025-03-26/basic/transports), the client **SHOULD** initiate
+shutdown by:
+
+1. First, closing the input stream to the child process (the server)
+2. Waiting for the server to exit, or sending `SIGTERM` if the server does not exit
+   within a reasonable time
+3. Sending `SIGKILL` if the server does not exit within a reasonable time after `SIGTERM`
+
+The server **MAY** initiate shutdown by closing its output stream to the client and
+exiting.
+
+#### HTTP
+
+For HTTP [transports](/specification/2025-03-26/basic/transports), shutdown is indicated by closing the
+associated HTTP connection(s).
+
+## Timeouts
+
+Implementations **SHOULD** establish timeouts for all sent requests, to prevent hung
+connections and resource exhaustion. When the request has not received a success or error
+response within the timeout period, the sender **SHOULD** issue a [cancellation
+notification](/specification/2025-03-26/basic/utilities/cancellation) for that request and stop waiting for
+a response.
+
+SDKs and other middleware **SHOULD** allow these timeouts to be configured on a
+per-request basis.
+
+Implementations **MAY** choose to reset the timeout clock when receiving a [progress
+notification](/specification/2025-03-26/basic/utilities/progress) corresponding to the request, as this
+implies that work is actually happening. However, implementations **SHOULD** always
+enforce a maximum timeout, regardless of progress notifications, to limit the impact of a
+misbehaving client or server.
+
+## Error Handling
+
+Implementations **SHOULD** be prepared to handle these error cases:
+
+- Protocol version mismatch
+- Failure to negotiate required capabilities
+- Request [timeouts](#timeouts)
+
+Example initialization error:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "error": {
+    "code": -32602,
+    "message": "Unsupported protocol version",
+    "data": {
+      "supported": ["2024-11-05"],
+      "requested": "1.0.0"
+    }
+  }
+}
+```

--- a/.agents/skills/mcp-knowledge/references/2025-03-26/logging.md
+++ b/.agents/skills/mcp-knowledge/references/2025-03-26/logging.md
@@ -1,0 +1,137 @@
+<!-- markdownlint-disable -->
+# Logging
+
+The Model Context Protocol (MCP) provides a standardized way for servers to send
+structured log messages to clients. Clients can control logging verbosity by setting
+minimum log levels, with servers sending notifications containing severity levels,
+optional logger names, and arbitrary JSON-serializable data.
+
+## User Interaction Model
+
+Implementations are free to expose logging through any interface pattern that suits their
+needs&mdash;the protocol itself does not mandate any specific user interaction model.
+
+## Capabilities
+
+Servers that emit log message notifications **MUST** declare the `logging` capability:
+
+```json
+{
+  "capabilities": {
+    "logging": {}
+  }
+}
+```
+
+## Log Levels
+
+The protocol follows the standard syslog severity levels specified in
+[RFC 5424](https://datatracker.ietf.org/doc/html/rfc5424#section-6.2.1):
+
+| Level     | Description                      | Example Use Case           |
+| --------- | -------------------------------- | -------------------------- |
+| debug     | Detailed debugging information   | Function entry/exit points |
+| info      | General informational messages   | Operation progress updates |
+| notice    | Normal but significant events    | Configuration changes      |
+| warning   | Warning conditions               | Deprecated feature usage   |
+| error     | Error conditions                 | Operation failures         |
+| critical  | Critical conditions              | System component failures  |
+| alert     | Action must be taken immediately | Data corruption detected   |
+| emergency | System is unusable               | Complete system failure    |
+
+## Protocol Messages
+
+### Setting Log Level
+
+To configure the minimum log level, clients **MAY** send a `logging/setLevel` request:
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "logging/setLevel",
+  "params": {
+    "level": "info"
+  }
+}
+```
+
+### Log Message Notifications
+
+Servers send log messages using `notifications/message` notifications:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/message",
+  "params": {
+    "level": "error",
+    "logger": "database",
+    "data": {
+      "error": "Connection failed",
+      "details": {
+        "host": "localhost",
+        "port": 5432
+      }
+    }
+  }
+}
+```
+
+## Message Flow
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Server
+
+    Note over Client,Server: Configure Logging
+    Client->>Server: logging/setLevel (info)
+    Server-->>Client: Empty Result
+
+    Note over Client,Server: Server Activity
+    Server--)Client: notifications/message (info)
+    Server--)Client: notifications/message (warning)
+    Server--)Client: notifications/message (error)
+
+    Note over Client,Server: Level Change
+    Client->>Server: logging/setLevel (error)
+    Server-->>Client: Empty Result
+    Note over Server: Only sends error level<br/>and above
+```
+
+## Error Handling
+
+Servers **SHOULD** return standard JSON-RPC errors for common failure cases:
+
+- Invalid log level: `-32602` (Invalid params)
+- Configuration errors: `-32603` (Internal error)
+
+## Implementation Considerations
+
+1. Servers **SHOULD**:
+   - Rate limit log messages
+   - Include relevant context in data field
+   - Use consistent logger names
+   - Remove sensitive information
+
+2. Clients **MAY**:
+   - Present log messages in the UI
+   - Implement log filtering/search
+   - Display severity visually
+   - Persist log messages
+
+## Security
+
+1. Log messages **MUST NOT** contain:
+   - Credentials or secrets
+   - Personal identifying information
+   - Internal system details that could aid attacks
+
+2. Implementations **SHOULD**:
+   - Rate limit messages
+   - Validate all data fields
+   - Control log access
+   - Monitor for sensitive content

--- a/.agents/skills/mcp-knowledge/references/2025-03-26/pagination.md
+++ b/.agents/skills/mcp-knowledge/references/2025-03-26/pagination.md
@@ -1,0 +1,93 @@
+<!-- markdownlint-disable -->
+# Pagination
+
+The Model Context Protocol (MCP) supports paginating list operations that may return
+large result sets. Pagination allows servers to yield results in smaller chunks rather
+than all at once.
+
+Pagination is especially important when connecting to external services over the
+internet, but also useful for local integrations to avoid performance issues with large
+data sets.
+
+## Pagination Model
+
+Pagination in MCP uses an opaque cursor-based approach, instead of numbered pages.
+
+- The **cursor** is an opaque string token, representing a position in the result set
+- **Page size** is determined by the server, and clients **MUST NOT** assume a fixed page
+  size
+
+## Response Format
+
+Pagination starts when the server sends a **response** that includes:
+
+- The current page of results
+- An optional `nextCursor` field if more results exist
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "123",
+  "result": {
+    "resources": [...],
+    "nextCursor": "eyJwYWdlIjogM30="
+  }
+}
+```
+
+## Request Format
+
+After receiving a cursor, the client can _continue_ paginating by issuing a request
+including that cursor:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "resources/list",
+  "params": {
+    "cursor": "eyJwYWdlIjogMn0="
+  }
+}
+```
+
+## Pagination Flow
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Server
+
+    Client->>Server: List Request (no cursor)
+    loop Pagination Loop
+      Server-->>Client: Page of results + nextCursor
+      Client->>Server: List Request (with cursor)
+    end
+```
+
+## Operations Supporting Pagination
+
+The following MCP operations support pagination:
+
+- `resources/list` - List available resources
+- `resources/templates/list` - List resource templates
+- `prompts/list` - List available prompts
+- `tools/list` - List available tools
+
+## Implementation Guidelines
+
+1. Servers **SHOULD**:
+   - Provide stable cursors
+   - Handle invalid cursors gracefully
+
+2. Clients **SHOULD**:
+   - Treat a missing `nextCursor` as the end of results
+   - Support both paginated and non-paginated flows
+
+3. Clients **MUST** treat cursors as opaque tokens:
+   - Don't make assumptions about cursor format
+   - Don't attempt to parse or modify cursors
+   - Don't persist cursors across sessions
+
+## Error Handling
+
+Invalid cursors **SHOULD** result in an error with code -32602 (Invalid params).

--- a/.agents/skills/mcp-knowledge/references/2025-03-26/ping.md
+++ b/.agents/skills/mcp-knowledge/references/2025-03-26/ping.md
@@ -1,0 +1,63 @@
+<!-- markdownlint-disable -->
+# Ping
+
+The Model Context Protocol includes an optional ping mechanism that allows either party
+to verify that their counterpart is still responsive and the connection is alive.
+
+## Overview
+
+The ping functionality is implemented through a simple request/response pattern. Either
+the client or server can initiate a ping by sending a `ping` request.
+
+## Message Format
+
+A ping request is a standard JSON-RPC request with no parameters:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "123",
+  "method": "ping"
+}
+```
+
+## Behavior Requirements
+
+1. The receiver **MUST** respond promptly with an empty response:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "123",
+  "result": {}
+}
+```
+
+2. If no response is received within a reasonable timeout period, the sender **MAY**:
+   - Consider the connection stale
+   - Terminate the connection
+   - Attempt reconnection procedures
+
+## Usage Patterns
+
+```mermaid
+sequenceDiagram
+    participant Sender
+    participant Receiver
+
+    Sender->>Receiver: ping request
+    Receiver->>Sender: empty response
+```
+
+## Implementation Considerations
+
+- Implementations **SHOULD** periodically issue pings to detect connection health
+- The frequency of pings **SHOULD** be configurable
+- Timeouts **SHOULD** be appropriate for the network environment
+- Excessive pinging **SHOULD** be avoided to reduce network overhead
+
+## Error Handling
+
+- Timeouts **SHOULD** be treated as connection failures
+- Multiple failed pings **MAY** trigger connection reset
+- Implementations **SHOULD** log ping failures for diagnostics

--- a/.agents/skills/mcp-knowledge/references/2025-03-26/progress.md
+++ b/.agents/skills/mcp-knowledge/references/2025-03-26/progress.md
@@ -1,0 +1,89 @@
+<!-- markdownlint-disable -->
+# Progress
+
+The Model Context Protocol (MCP) supports optional progress tracking for long-running
+operations through notification messages. Either side can send progress notifications to
+provide updates about operation status.
+
+## Progress Flow
+
+When a party wants to _receive_ progress updates for a request, it includes a
+`progressToken` in the request metadata.
+
+- Progress tokens **MUST** be a string or integer value
+- Progress tokens can be chosen by the sender using any means, but **MUST** be unique
+  across all active requests.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "some_method",
+  "params": {
+    "_meta": {
+      "progressToken": "abc123"
+    }
+  }
+}
+```
+
+The receiver **MAY** then send progress notifications containing:
+
+- The original progress token
+- The current progress value so far
+- An optional "total" value
+- An optional "message" value
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/progress",
+  "params": {
+    "progressToken": "abc123",
+    "progress": 50,
+    "total": 100,
+    "message": "Reticulating splines..."
+  }
+}
+```
+
+- The `progress` value **MUST** increase with each notification, even if the total is
+  unknown.
+- The `progress` and the `total` values **MAY** be floating point.
+- The `message` field **SHOULD** provide relevant human readable progress information.
+
+## Behavior Requirements
+
+1. Progress notifications **MUST** only reference tokens that:
+   - Were provided in an active request
+   - Are associated with an in-progress operation
+
+2. Receivers of progress requests **MAY**:
+   - Choose not to send any progress notifications
+   - Send notifications at whatever frequency they deem appropriate
+   - Omit the total value if unknown
+
+```mermaid
+sequenceDiagram
+    participant Sender
+    participant Receiver
+
+    Note over Sender,Receiver: Request with progress token
+    Sender->>Receiver: Method request with progressToken
+
+    Note over Sender,Receiver: Progress updates
+    loop Progress Updates
+        Receiver-->>Sender: Progress notification (0.2/1.0)
+        Receiver-->>Sender: Progress notification (0.6/1.0)
+        Receiver-->>Sender: Progress notification (1.0/1.0)
+    end
+
+    Note over Sender,Receiver: Operation complete
+    Receiver->>Sender: Method response
+```
+
+## Implementation Notes
+
+- Senders and receivers **SHOULD** track active progress tokens
+- Both parties **SHOULD** implement rate limiting to prevent flooding
+- Progress notifications **MUST** stop after completion

--- a/.agents/skills/mcp-knowledge/references/2025-03-26/prompts.md
+++ b/.agents/skills/mcp-knowledge/references/2025-03-26/prompts.md
@@ -1,0 +1,267 @@
+<!-- markdownlint-disable -->
+# Prompts
+
+The Model Context Protocol (MCP) provides a standardized way for servers to expose prompt
+templates to clients. Prompts allow servers to provide structured messages and
+instructions for interacting with language models. Clients can discover available
+prompts, retrieve their contents, and provide arguments to customize them.
+
+## User Interaction Model
+
+Prompts are designed to be **user-controlled**, meaning they are exposed from servers to
+clients with the intention of the user being able to explicitly select them for use.
+
+Typically, prompts would be triggered through user-initiated commands in the user
+interface, which allows users to naturally discover and invoke available prompts.
+
+For example, as slash commands:
+
+![Example of prompt exposed as slash command](/specification/2025-03-26/server/slash-command.png)
+
+However, implementors are free to expose prompts through any interface pattern that suits
+their needs&mdash;the protocol itself does not mandate any specific user interaction
+model.
+
+## Capabilities
+
+Servers that support prompts **MUST** declare the `prompts` capability during
+[initialization](/specification/2025-03-26/basic/lifecycle#initialization):
+
+```json
+{
+  "capabilities": {
+    "prompts": {
+      "listChanged": true
+    }
+  }
+}
+```
+
+`listChanged` indicates whether the server will emit notifications when the list of
+available prompts changes.
+
+## Protocol Messages
+
+### Listing Prompts
+
+To retrieve available prompts, clients send a `prompts/list` request. This operation
+supports [pagination](/specification/2025-03-26/server/utilities/pagination).
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "prompts/list",
+  "params": {
+    "cursor": "optional-cursor-value"
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "prompts": [
+      {
+        "name": "code_review",
+        "description": "Asks the LLM to analyze code quality and suggest improvements",
+        "arguments": [
+          {
+            "name": "code",
+            "description": "The code to review",
+            "required": true
+          }
+        ]
+      }
+    ],
+    "nextCursor": "next-page-cursor"
+  }
+}
+```
+
+### Getting a Prompt
+
+To retrieve a specific prompt, clients send a `prompts/get` request. Arguments may be
+auto-completed through [the completion API](/specification/2025-03-26/server/utilities/completion).
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "prompts/get",
+  "params": {
+    "name": "code_review",
+    "arguments": {
+      "code": "def hello():\n    print('world')"
+    }
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "description": "Code review prompt",
+    "messages": [
+      {
+        "role": "user",
+        "content": {
+          "type": "text",
+          "text": "Please review this Python code:\ndef hello():\n    print('world')"
+        }
+      }
+    ]
+  }
+}
+```
+
+### List Changed Notification
+
+When the list of available prompts changes, servers that declared the `listChanged`
+capability **SHOULD** send a notification:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/prompts/list_changed"
+}
+```
+
+## Message Flow
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Server
+
+    Note over Client,Server: Discovery
+    Client->>Server: prompts/list
+    Server-->>Client: List of prompts
+
+    Note over Client,Server: Usage
+    Client->>Server: prompts/get
+    Server-->>Client: Prompt content
+
+    opt listChanged
+      Note over Client,Server: Changes
+      Server--)Client: prompts/list_changed
+      Client->>Server: prompts/list
+      Server-->>Client: Updated prompts
+    end
+```
+
+## Data Types
+
+### Prompt
+
+A prompt definition includes:
+
+- `name`: Unique identifier for the prompt
+- `description`: Optional human-readable description
+- `arguments`: Optional list of arguments for customization
+
+### PromptMessage
+
+Messages in a prompt can contain:
+
+- `role`: Either "user" or "assistant" to indicate the speaker
+- `content`: One of the following content types:
+
+#### Text Content
+
+Text content represents plain text messages:
+
+```json
+{
+  "type": "text",
+  "text": "The text content of the message"
+}
+```
+
+This is the most common content type used for natural language interactions.
+
+#### Image Content
+
+Image content allows including visual information in messages:
+
+```json
+{
+  "type": "image",
+  "data": "base64-encoded-image-data",
+  "mimeType": "image/png"
+}
+```
+
+The image data **MUST** be base64-encoded and include a valid MIME type. This enables
+multi-modal interactions where visual context is important.
+
+#### Audio Content
+
+Audio content allows including audio information in messages:
+
+```json
+{
+  "type": "audio",
+  "data": "base64-encoded-audio-data",
+  "mimeType": "audio/wav"
+}
+```
+
+The audio data MUST be base64-encoded and include a valid MIME type. This enables
+multi-modal interactions where audio context is important.
+
+#### Embedded Resources
+
+Embedded resources allow referencing server-side resources directly in messages:
+
+```json
+{
+  "type": "resource",
+  "resource": {
+    "uri": "resource://example",
+    "mimeType": "text/plain",
+    "text": "Resource content"
+  }
+}
+```
+
+Resources can contain either text or binary (blob) data and **MUST** include:
+
+- A valid resource URI
+- The appropriate MIME type
+- Either text content or base64-encoded blob data
+
+Embedded resources enable prompts to seamlessly incorporate server-managed content like
+documentation, code samples, or other reference materials directly into the conversation
+flow.
+
+## Error Handling
+
+Servers **SHOULD** return standard JSON-RPC errors for common failure cases:
+
+- Invalid prompt name: `-32602` (Invalid params)
+- Missing required arguments: `-32602` (Invalid params)
+- Internal errors: `-32603` (Internal error)
+
+## Implementation Considerations
+
+1. Servers **SHOULD** validate prompt arguments before processing
+2. Clients **SHOULD** handle pagination for large prompt lists
+3. Both parties **SHOULD** respect capability negotiation
+
+## Security
+
+Implementations **MUST** carefully validate all prompt inputs and outputs to prevent
+injection attacks or unauthorized access to resources.

--- a/.agents/skills/mcp-knowledge/references/2025-03-26/resources.md
+++ b/.agents/skills/mcp-knowledge/references/2025-03-26/resources.md
@@ -1,0 +1,361 @@
+<!-- markdownlint-disable -->
+# Resources
+
+The Model Context Protocol (MCP) provides a standardized way for servers to expose
+resources to clients. Resources allow servers to share data that provides context to
+language models, such as files, database schemas, or application-specific information.
+Each resource is uniquely identified by a
+[URI](https://datatracker.ietf.org/doc/html/rfc3986).
+
+## User Interaction Model
+
+Resources in MCP are designed to be **application-driven**, with host applications
+determining how to incorporate context based on their needs.
+
+For example, applications could:
+
+- Expose resources through UI elements for explicit selection, in a tree or list view
+- Allow the user to search through and filter available resources
+- Implement automatic context inclusion, based on heuristics or the AI model's selection
+
+![Example of resource context picker](/specification/2025-03-26/server/resource-picker.png)
+
+However, implementations are free to expose resources through any interface pattern that
+suits their needs&mdash;the protocol itself does not mandate any specific user
+interaction model.
+
+## Capabilities
+
+Servers that support resources **MUST** declare the `resources` capability:
+
+```json
+{
+  "capabilities": {
+    "resources": {
+      "subscribe": true,
+      "listChanged": true
+    }
+  }
+}
+```
+
+The capability supports two optional features:
+
+- `subscribe`: whether the client can subscribe to be notified of changes to individual
+  resources.
+- `listChanged`: whether the server will emit notifications when the list of available
+  resources changes.
+
+Both `subscribe` and `listChanged` are optional&mdash;servers can support neither,
+either, or both:
+
+```json
+{
+  "capabilities": {
+    "resources": {} // Neither feature supported
+  }
+}
+```
+
+```json
+{
+  "capabilities": {
+    "resources": {
+      "subscribe": true // Only subscriptions supported
+    }
+  }
+}
+```
+
+```json
+{
+  "capabilities": {
+    "resources": {
+      "listChanged": true // Only list change notifications supported
+    }
+  }
+}
+```
+
+## Protocol Messages
+
+### Listing Resources
+
+To discover available resources, clients send a `resources/list` request. This operation
+supports [pagination](/specification/2025-03-26/server/utilities/pagination).
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "resources/list",
+  "params": {
+    "cursor": "optional-cursor-value"
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "resources": [
+      {
+        "uri": "file:///project/src/main.rs",
+        "name": "main.rs",
+        "description": "Primary application entry point",
+        "mimeType": "text/x-rust"
+      }
+    ],
+    "nextCursor": "next-page-cursor"
+  }
+}
+```
+
+### Reading Resources
+
+To retrieve resource contents, clients send a `resources/read` request:
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "resources/read",
+  "params": {
+    "uri": "file:///project/src/main.rs"
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "contents": [
+      {
+        "uri": "file:///project/src/main.rs",
+        "mimeType": "text/x-rust",
+        "text": "fn main() {\n    println!(\"Hello world!\");\n}"
+      }
+    ]
+  }
+}
+```
+
+### Resource Templates
+
+Resource templates allow servers to expose parameterized resources using
+[URI templates](https://datatracker.ietf.org/doc/html/rfc6570). Arguments may be
+auto-completed through [the completion API](/specification/2025-03-26/server/utilities/completion).
+This operation supports [pagination](/specification/2025-03-26/server/utilities/pagination).
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "method": "resources/templates/list",
+  "params": {
+    "cursor": "optional-cursor-value"
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "result": {
+    "resourceTemplates": [
+      {
+        "uriTemplate": "file:///{path}",
+        "name": "Project Files",
+        "description": "Access files in the project directory",
+        "mimeType": "application/octet-stream"
+      }
+    ],
+    "nextCursor": "next-page-cursor"
+  }
+}
+```
+
+### List Changed Notification
+
+When the list of available resources changes, servers that declared the `listChanged`
+capability **SHOULD** send a notification:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/resources/list_changed"
+}
+```
+
+### Subscriptions
+
+The protocol supports optional subscriptions to resource changes. Clients can subscribe
+to specific resources and receive notifications when they change:
+
+**Subscribe Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 4,
+  "method": "resources/subscribe",
+  "params": {
+    "uri": "file:///project/src/main.rs"
+  }
+}
+```
+
+**Update Notification:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/resources/updated",
+  "params": {
+    "uri": "file:///project/src/main.rs"
+  }
+}
+```
+
+## Message Flow
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Server
+
+    Note over Client,Server: Resource Discovery
+    Client->>Server: resources/list
+    Server-->>Client: List of resources
+
+    Note over Client,Server: Resource Template Discovery
+    Client->>Server: resources/templates/list
+    Server-->>Client: List of resource templates
+
+    Note over Client,Server: Resource Access
+    Client->>Server: resources/read
+    Server-->>Client: Resource contents
+
+    Note over Client,Server: Subscriptions
+    Client->>Server: resources/subscribe
+    Server-->>Client: Subscription confirmed
+
+    Note over Client,Server: Updates
+    Server--)Client: notifications/resources/updated
+    Client->>Server: resources/read
+    Server-->>Client: Updated contents
+```
+
+## Data Types
+
+### Resource
+
+A resource definition includes:
+
+- `uri`: Unique identifier for the resource
+- `name`: Human-readable name
+- `description`: Optional description
+- `mimeType`: Optional MIME type
+- `size`: Optional size in bytes
+
+### Resource Contents
+
+Resources can contain either text or binary data:
+
+#### Text Content
+
+```json
+{
+  "uri": "file:///example.txt",
+  "mimeType": "text/plain",
+  "text": "Resource content"
+}
+```
+
+#### Binary Content
+
+```json
+{
+  "uri": "file:///example.png",
+  "mimeType": "image/png",
+  "blob": "base64-encoded-data"
+}
+```
+
+## Common URI Schemes
+
+The protocol defines several standard URI schemes. This list not
+exhaustive&mdash;implementations are always free to use additional, custom URI schemes.
+
+### https://
+
+Used to represent a resource available on the web.
+
+Servers **SHOULD** use this scheme only when the client is able to fetch and load the
+resource directly from the web on its own—that is, it doesn’t need to read the resource
+via the MCP server.
+
+For other use cases, servers **SHOULD** prefer to use another URI scheme, or define a
+custom one, even if the server will itself be downloading resource contents over the
+internet.
+
+### file://
+
+Used to identify resources that behave like a filesystem. However, the resources do not
+need to map to an actual physical filesystem.
+
+MCP servers **MAY** identify file:// resources with an
+[XDG MIME type](https://specifications.freedesktop.org/shared-mime-info-spec/0.14/ar01s02.html#id-1.3.14),
+like `inode/directory`, to represent non-regular files (such as directories) that don’t
+otherwise have a standard MIME type.
+
+### git://
+
+Git version control integration.
+
+## Error Handling
+
+Servers **SHOULD** return standard JSON-RPC errors for common failure cases:
+
+- Resource not found: `-32002`
+- Internal errors: `-32603`
+
+Example error:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 5,
+  "error": {
+    "code": -32002,
+    "message": "Resource not found",
+    "data": {
+      "uri": "file:///nonexistent.txt"
+    }
+  }
+}
+```
+
+## Security Considerations
+
+1. Servers **MUST** validate all resource URIs
+2. Access controls **SHOULD** be implemented for sensitive resources
+3. Binary data **MUST** be properly encoded
+4. Resource permissions **SHOULD** be checked before operations

--- a/.agents/skills/mcp-knowledge/references/2025-03-26/roots.md
+++ b/.agents/skills/mcp-knowledge/references/2025-03-26/roots.md
@@ -1,0 +1,185 @@
+<!-- markdownlint-disable -->
+# Roots
+
+The Model Context Protocol (MCP) provides a standardized way for clients to expose
+filesystem "roots" to servers. Roots define the boundaries of where servers can operate
+within the filesystem, allowing them to understand which directories and files they have
+access to. Servers can request the list of roots from supporting clients and receive
+notifications when that list changes.
+
+## User Interaction Model
+
+Roots in MCP are typically exposed through workspace or project configuration interfaces.
+
+For example, implementations could offer a workspace/project picker that allows users to
+select directories and files the server should have access to. This can be combined with
+automatic workspace detection from version control systems or project files.
+
+However, implementations are free to expose roots through any interface pattern that
+suits their needs&mdash;the protocol itself does not mandate any specific user
+interaction model.
+
+## Capabilities
+
+Clients that support roots **MUST** declare the `roots` capability during
+[initialization](/specification/2025-03-26/basic/lifecycle#initialization):
+
+```json
+{
+  "capabilities": {
+    "roots": {
+      "listChanged": true
+    }
+  }
+}
+```
+
+`listChanged` indicates whether the client will emit notifications when the list of roots
+changes.
+
+## Protocol Messages
+
+### Listing Roots
+
+To retrieve roots, servers send a `roots/list` request:
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "roots/list"
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "roots": [
+      {
+        "uri": "file:///home/user/projects/myproject",
+        "name": "My Project"
+      }
+    ]
+  }
+}
+```
+
+### Root List Changes
+
+When roots change, clients that support `listChanged` **MUST** send a notification:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/roots/list_changed"
+}
+```
+
+## Message Flow
+
+```mermaid
+sequenceDiagram
+    participant Server
+    participant Client
+
+    Note over Server,Client: Discovery
+    Server->>Client: roots/list
+    Client-->>Server: Available roots
+
+    Note over Server,Client: Changes
+    Client--)Server: notifications/roots/list_changed
+    Server->>Client: roots/list
+    Client-->>Server: Updated roots
+```
+
+## Data Types
+
+### Root
+
+A root definition includes:
+
+- `uri`: Unique identifier for the root. This **MUST** be a `file://` URI in the current
+  specification.
+- `name`: Optional human-readable name for display purposes.
+
+Example roots for different use cases:
+
+#### Project Directory
+
+```json
+{
+  "uri": "file:///home/user/projects/myproject",
+  "name": "My Project"
+}
+```
+
+#### Multiple Repositories
+
+```json
+[
+  {
+    "uri": "file:///home/user/repos/frontend",
+    "name": "Frontend Repository"
+  },
+  {
+    "uri": "file:///home/user/repos/backend",
+    "name": "Backend Repository"
+  }
+]
+```
+
+## Error Handling
+
+Clients **SHOULD** return standard JSON-RPC errors for common failure cases:
+
+- Client does not support roots: `-32601` (Method not found)
+- Internal errors: `-32603`
+
+Example error:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "error": {
+    "code": -32601,
+    "message": "Roots not supported",
+    "data": {
+      "reason": "Client does not have roots capability"
+    }
+  }
+}
+```
+
+## Security Considerations
+
+1. Clients **MUST**:
+   - Only expose roots with appropriate permissions
+   - Validate all root URIs to prevent path traversal
+   - Implement proper access controls
+   - Monitor root accessibility
+
+2. Servers **SHOULD**:
+   - Handle cases where roots become unavailable
+   - Respect root boundaries during operations
+   - Validate all paths against provided roots
+
+## Implementation Guidelines
+
+1. Clients **SHOULD**:
+   - Prompt users for consent before exposing roots to servers
+   - Provide clear user interfaces for root management
+   - Validate root accessibility before exposing
+   - Monitor for root changes
+
+2. Servers **SHOULD**:
+   - Check for roots capability before usage
+   - Handle root list changes gracefully
+   - Respect root boundaries in operations
+   - Cache root information appropriately

--- a/.agents/skills/mcp-knowledge/references/2025-03-26/sampling.md
+++ b/.agents/skills/mcp-knowledge/references/2025-03-26/sampling.md
@@ -1,0 +1,232 @@
+<!-- markdownlint-disable -->
+# Sampling
+
+The Model Context Protocol (MCP) provides a standardized way for servers to request LLM
+sampling ("completions" or "generations") from language models via clients. This flow
+allows clients to maintain control over model access, selection, and permissions while
+enabling servers to leverage AI capabilities&mdash;with no server API keys necessary.
+Servers can request text, audio, or image-based interactions and optionally include
+context from MCP servers in their prompts.
+
+## User Interaction Model
+
+Sampling in MCP allows servers to implement agentic behaviors, by enabling LLM calls to
+occur _nested_ inside other MCP server features.
+
+Implementations are free to expose sampling through any interface pattern that suits
+their needs&mdash;the protocol itself does not mandate any specific user interaction
+model.
+
+> **Warning:**
+> For trust & safety and security, there **SHOULD** always
+> be a human in the loop with the ability to deny sampling requests.
+>
+> Applications **SHOULD**:
+>
+> - Provide UI that makes it easy and intuitive to review sampling requests
+> - Allow users to view and edit prompts before sending
+> - Present generated responses for review before delivery
+
+## Capabilities
+
+Clients that support sampling **MUST** declare the `sampling` capability during
+[initialization](/specification/2025-03-26/basic/lifecycle#initialization):
+
+```json
+{
+  "capabilities": {
+    "sampling": {}
+  }
+}
+```
+
+## Protocol Messages
+
+### Creating Messages
+
+To request a language model generation, servers send a `sampling/createMessage` request:
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "sampling/createMessage",
+  "params": {
+    "messages": [
+      {
+        "role": "user",
+        "content": {
+          "type": "text",
+          "text": "What is the capital of France?"
+        }
+      }
+    ],
+    "modelPreferences": {
+      "hints": [
+        {
+          "name": "claude-3-sonnet"
+        }
+      ],
+      "intelligencePriority": 0.8,
+      "speedPriority": 0.5
+    },
+    "systemPrompt": "You are a helpful assistant.",
+    "maxTokens": 100
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "role": "assistant",
+    "content": {
+      "type": "text",
+      "text": "The capital of France is Paris."
+    },
+    "model": "claude-3-sonnet-20240307",
+    "stopReason": "endTurn"
+  }
+}
+```
+
+## Message Flow
+
+```mermaid
+sequenceDiagram
+    participant Server
+    participant Client
+    participant User
+    participant LLM
+
+    Note over Server,Client: Server initiates sampling
+    Server->>Client: sampling/createMessage
+
+    Note over Client,User: Human-in-the-loop review
+    Client->>User: Present request for approval
+    User-->>Client: Review and approve/modify
+
+    Note over Client,LLM: Model interaction
+    Client->>LLM: Forward approved request
+    LLM-->>Client: Return generation
+
+    Note over Client,User: Response review
+    Client->>User: Present response for approval
+    User-->>Client: Review and approve/modify
+
+    Note over Server,Client: Complete request
+    Client-->>Server: Return approved response
+```
+
+## Data Types
+
+### Messages
+
+Sampling messages can contain:
+
+#### Text Content
+
+```json
+{
+  "type": "text",
+  "text": "The message content"
+}
+```
+
+#### Image Content
+
+```json
+{
+  "type": "image",
+  "data": "base64-encoded-image-data",
+  "mimeType": "image/jpeg"
+}
+```
+
+#### Audio Content
+
+```json
+{
+  "type": "audio",
+  "data": "base64-encoded-audio-data",
+  "mimeType": "audio/wav"
+}
+```
+
+### Model Preferences
+
+Model selection in MCP requires careful abstraction since servers and clients may use
+different AI providers with distinct model offerings. A server cannot simply request a
+specific model by name since the client may not have access to that exact model or may
+prefer to use a different provider's equivalent model.
+
+To solve this, MCP implements a preference system that combines abstract capability
+priorities with optional model hints:
+
+#### Capability Priorities
+
+Servers express their needs through three normalized priority values (0-1):
+
+- `costPriority`: How important is minimizing costs? Higher values prefer cheaper models.
+- `speedPriority`: How important is low latency? Higher values prefer faster models.
+- `intelligencePriority`: How important are advanced capabilities? Higher values prefer
+  more capable models.
+
+#### Model Hints
+
+While priorities help select models based on characteristics, `hints` allow servers to
+suggest specific models or model families:
+
+- Hints are treated as substrings that can match model names flexibly
+- Multiple hints are evaluated in order of preference
+- Clients **MAY** map hints to equivalent models from different providers
+- Hints are advisory&mdash;clients make final model selection
+
+For example:
+
+```json
+{
+  "hints": [
+    { "name": "claude-3-sonnet" }, // Prefer Sonnet-class models
+    { "name": "claude" } // Fall back to any Claude model
+  ],
+  "costPriority": 0.3, // Cost is less important
+  "speedPriority": 0.8, // Speed is very important
+  "intelligencePriority": 0.5 // Moderate capability needs
+}
+```
+
+The client processes these preferences to select an appropriate model from its available
+options. For instance, if the client doesn't have access to Claude models but has Gemini,
+it might map the sonnet hint to `gemini-1.5-pro` based on similar capabilities.
+
+## Error Handling
+
+Clients **SHOULD** return errors for common failure cases:
+
+Example error:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "error": {
+    "code": -1,
+    "message": "User rejected sampling request"
+  }
+}
+```
+
+## Security Considerations
+
+1. Clients **SHOULD** implement user approval controls
+2. Both parties **SHOULD** validate message content
+3. Clients **SHOULD** respect model preference hints
+4. Clients **SHOULD** implement rate limiting
+5. Both parties **MUST** handle sensitive data appropriately

--- a/.agents/skills/mcp-knowledge/references/2025-03-26/tools.md
+++ b/.agents/skills/mcp-knowledge/references/2025-03-26/tools.md
@@ -1,0 +1,294 @@
+<!-- markdownlint-disable -->
+# Tools
+
+The Model Context Protocol (MCP) allows servers to expose tools that can be invoked by
+language models. Tools enable models to interact with external systems, such as querying
+databases, calling APIs, or performing computations. Each tool is uniquely identified by
+a name and includes metadata describing its schema.
+
+## User Interaction Model
+
+Tools in MCP are designed to be **model-controlled**, meaning that the language model can
+discover and invoke tools automatically based on its contextual understanding and the
+user's prompts.
+
+However, implementations are free to expose tools through any interface pattern that
+suits their needs&mdash;the protocol itself does not mandate any specific user
+interaction model.
+
+> **Warning:**
+> For trust & safety and security, there **SHOULD** always
+> be a human in the loop with the ability to deny tool invocations.
+>
+> Applications **SHOULD**:
+>
+> - Provide UI that makes clear which tools are being exposed to the AI model
+> - Insert clear visual indicators when tools are invoked
+> - Present confirmation prompts to the user for operations, to ensure a human is in the
+>   loop
+
+## Capabilities
+
+Servers that support tools **MUST** declare the `tools` capability:
+
+```json
+{
+  "capabilities": {
+    "tools": {
+      "listChanged": true
+    }
+  }
+}
+```
+
+`listChanged` indicates whether the server will emit notifications when the list of
+available tools changes.
+
+## Protocol Messages
+
+### Listing Tools
+
+To discover available tools, clients send a `tools/list` request. This operation supports
+[pagination](/specification/2025-03-26/server/utilities/pagination).
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/list",
+  "params": {
+    "cursor": "optional-cursor-value"
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "tools": [
+      {
+        "name": "get_weather",
+        "description": "Get current weather information for a location",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "location": {
+              "type": "string",
+              "description": "City name or zip code"
+            }
+          },
+          "required": ["location"]
+        }
+      }
+    ],
+    "nextCursor": "next-page-cursor"
+  }
+}
+```
+
+### Calling Tools
+
+To invoke a tool, clients send a `tools/call` request:
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "tools/call",
+  "params": {
+    "name": "get_weather",
+    "arguments": {
+      "location": "New York"
+    }
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "Current weather in New York:\nTemperature: 72°F\nConditions: Partly cloudy"
+      }
+    ],
+    "isError": false
+  }
+}
+```
+
+### List Changed Notification
+
+When the list of available tools changes, servers that declared the `listChanged`
+capability **SHOULD** send a notification:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/tools/list_changed"
+}
+```
+
+## Message Flow
+
+```mermaid
+sequenceDiagram
+    participant LLM
+    participant Client
+    participant Server
+
+    Note over Client,Server: Discovery
+    Client->>Server: tools/list
+    Server-->>Client: List of tools
+
+    Note over Client,LLM: Tool Selection
+    LLM->>Client: Select tool to use
+
+    Note over Client,Server: Invocation
+    Client->>Server: tools/call
+    Server-->>Client: Tool result
+    Client->>LLM: Process result
+
+    Note over Client,Server: Updates
+    Server--)Client: tools/list_changed
+    Client->>Server: tools/list
+    Server-->>Client: Updated tools
+```
+
+## Data Types
+
+### Tool
+
+A tool definition includes:
+
+- `name`: Unique identifier for the tool
+- `description`: Human-readable description of functionality
+- `inputSchema`: JSON Schema defining expected parameters
+- `annotations`: optional properties describing tool behavior
+
+> **Warning:**
+> For trust & safety and security, clients **MUST** consider
+> tool annotations to be untrusted unless they come from trusted servers.
+
+### Tool Result
+
+Tool results can contain multiple content items of different types:
+
+#### Text Content
+
+```json
+{
+  "type": "text",
+  "text": "Tool result text"
+}
+```
+
+#### Image Content
+
+```json
+{
+  "type": "image",
+  "data": "base64-encoded-data",
+  "mimeType": "image/png"
+}
+```
+
+#### Audio Content
+
+```json
+{
+  "type": "audio",
+  "data": "base64-encoded-audio-data",
+  "mimeType": "audio/wav"
+}
+```
+
+#### Embedded Resources
+
+[Resources](/specification/2025-03-26/server/resources) **MAY** be embedded, to provide additional context
+or data, behind a URI that can be subscribed to or fetched again by the client later:
+
+```json
+{
+  "type": "resource",
+  "resource": {
+    "uri": "resource://example",
+    "mimeType": "text/plain",
+    "text": "Resource content"
+  }
+}
+```
+
+## Error Handling
+
+Tools use two error reporting mechanisms:
+
+1. **Protocol Errors**: Standard JSON-RPC errors for issues like:
+   - Unknown tools
+   - Invalid arguments
+   - Server errors
+
+2. **Tool Execution Errors**: Reported in tool results with `isError: true`:
+   - API failures
+   - Invalid input data
+   - Business logic errors
+
+Example protocol error:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "error": {
+    "code": -32602,
+    "message": "Unknown tool: invalid_tool_name"
+  }
+}
+```
+
+Example tool execution error:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 4,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "Failed to fetch weather data: API rate limit exceeded"
+      }
+    ],
+    "isError": true
+  }
+}
+```
+
+## Security Considerations
+
+1. Servers **MUST**:
+   - Validate all tool inputs
+   - Implement proper access controls
+   - Rate limit tool invocations
+   - Sanitize tool outputs
+
+2. Clients **SHOULD**:
+   - Prompt for user confirmation on sensitive operations
+   - Show tool inputs to the user before calling the server, to avoid malicious or
+     accidental data exfiltration
+   - Validate tool results before passing to LLM
+   - Implement timeouts for tool calls
+   - Log tool usage for audit purposes

--- a/.agents/skills/mcp-knowledge/references/2025-03-26/transports.md
+++ b/.agents/skills/mcp-knowledge/references/2025-03-26/transports.md
@@ -1,0 +1,284 @@
+<!-- markdownlint-disable -->
+# Transports
+
+MCP uses JSON-RPC to encode messages. JSON-RPC messages **MUST** be UTF-8 encoded.
+
+The protocol currently defines two standard transport mechanisms for client-server
+communication:
+
+1. [stdio](#stdio), communication over standard in and standard out
+2. [Streamable HTTP](#streamable-http)
+
+Clients **SHOULD** support stdio whenever possible.
+
+It is also possible for clients and servers to implement
+[custom transports](#custom-transports) in a pluggable fashion.
+
+## stdio
+
+In the **stdio** transport:
+
+- The client launches the MCP server as a subprocess.
+- The server reads JSON-RPC messages from its standard input (`stdin`) and sends messages
+  to its standard output (`stdout`).
+- Messages may be JSON-RPC requests, notifications, responses—or a JSON-RPC
+  [batch](https://www.jsonrpc.org/specification#batch) containing one or more requests
+  and/or notifications.
+- Messages are delimited by newlines, and **MUST NOT** contain embedded newlines.
+- The server **MAY** write UTF-8 strings to its standard error (`stderr`) for logging
+  purposes. Clients **MAY** capture, forward, or ignore this logging.
+- The server **MUST NOT** write anything to its `stdout` that is not a valid MCP message.
+- The client **MUST NOT** write anything to the server's `stdin` that is not a valid MCP
+  message.
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Server Process
+
+    Client->>+Server Process: Launch subprocess
+    loop Message Exchange
+        Client->>Server Process: Write to stdin
+        Server Process->>Client: Write to stdout
+        Server Process--)Client: Optional logs on stderr
+    end
+    Client->>Server Process: Close stdin, terminate subprocess
+    deactivate Server Process
+```
+
+## Streamable HTTP
+
+> **Info:**
+> This replaces the [HTTP+SSE
+> transport](/specification/2024-11-05/basic/transports#http-with-sse) from
+> protocol version 2024-11-05. See the [backwards compatibility](#backwards-compatibility)
+> guide below.
+
+In the **Streamable HTTP** transport, the server operates as an independent process that
+can handle multiple client connections. This transport uses HTTP POST and GET requests.
+Server can optionally make use of
+[Server-Sent Events](https://en.wikipedia.org/wiki/Server-sent_events) (SSE) to stream
+multiple server messages. This permits basic MCP servers, as well as more feature-rich
+servers supporting streaming and server-to-client notifications and requests.
+
+The server **MUST** provide a single HTTP endpoint path (hereafter referred to as the
+**MCP endpoint**) that supports both POST and GET methods. For example, this could be a
+URL like `https://example.com/mcp`.
+
+#### Security Warning
+
+When implementing Streamable HTTP transport:
+
+1. Servers **MUST** validate the `Origin` header on all incoming connections to prevent DNS rebinding attacks
+2. When running locally, servers **SHOULD** bind only to localhost (127.0.0.1) rather than all network interfaces (0.0.0.0)
+3. Servers **SHOULD** implement proper authentication for all connections
+
+Without these protections, attackers could use DNS rebinding to interact with local MCP servers from remote websites.
+
+### Sending Messages to the Server
+
+Every JSON-RPC message sent from the client **MUST** be a new HTTP POST request to the
+MCP endpoint.
+
+1. The client **MUST** use HTTP POST to send JSON-RPC messages to the MCP endpoint.
+2. The client **MUST** include an `Accept` header, listing both `application/json` and
+   `text/event-stream` as supported content types.
+3. The body of the POST request **MUST** be one of the following:
+   - A single JSON-RPC _request_, _notification_, or _response_
+   - An array [batching](https://www.jsonrpc.org/specification#batch) one or more
+     _requests and/or notifications_
+   - An array [batching](https://www.jsonrpc.org/specification#batch) one or more
+     _responses_
+4. If the input consists solely of (any number of) JSON-RPC _responses_ or
+   _notifications_:
+   - If the server accepts the input, the server **MUST** return HTTP status code 202
+     Accepted with no body.
+   - If the server cannot accept the input, it **MUST** return an HTTP error status code
+     (e.g., 400 Bad Request). The HTTP response body **MAY** comprise a JSON-RPC _error
+     response_ that has no `id`.
+5. If the input contains any number of JSON-RPC _requests_, the server **MUST** either
+   return `Content-Type: text/event-stream`, to initiate an SSE stream, or
+   `Content-Type: application/json`, to return one JSON object. The client **MUST**
+   support both these cases.
+6. If the server initiates an SSE stream:
+   - The SSE stream **SHOULD** eventually include one JSON-RPC _response_ per each
+     JSON-RPC _request_ sent in the POST body. These _responses_ **MAY** be
+     [batched](https://www.jsonrpc.org/specification#batch).
+   - The server **MAY** send JSON-RPC _requests_ and _notifications_ before sending a
+     JSON-RPC _response_. These messages **SHOULD** relate to the originating client
+     _request_. These _requests_ and _notifications_ **MAY** be
+     [batched](https://www.jsonrpc.org/specification#batch).
+   - The server **SHOULD NOT** close the SSE stream before sending a JSON-RPC _response_
+     per each received JSON-RPC _request_, unless the [session](#session-management)
+     expires.
+   - After all JSON-RPC _responses_ have been sent, the server **SHOULD** close the SSE
+     stream.
+   - Disconnection **MAY** occur at any time (e.g., due to network conditions).
+     Therefore:
+     - Disconnection **SHOULD NOT** be interpreted as the client cancelling its request.
+     - To cancel, the client **SHOULD** explicitly send an MCP `CancelledNotification`.
+     - To avoid message loss due to disconnection, the server **MAY** make the stream
+       [resumable](#resumability-and-redelivery).
+
+### Listening for Messages from the Server
+
+1. The client **MAY** issue an HTTP GET to the MCP endpoint. This can be used to open an
+   SSE stream, allowing the server to communicate to the client, without the client first
+   sending data via HTTP POST.
+2. The client **MUST** include an `Accept` header, listing `text/event-stream` as a
+   supported content type.
+3. The server **MUST** either return `Content-Type: text/event-stream` in response to
+   this HTTP GET, or else return HTTP 405 Method Not Allowed, indicating that the server
+   does not offer an SSE stream at this endpoint.
+4. If the server initiates an SSE stream:
+   - The server **MAY** send JSON-RPC _requests_ and _notifications_ on the stream. These
+     _requests_ and _notifications_ **MAY** be
+     [batched](https://www.jsonrpc.org/specification#batch).
+   - These messages **SHOULD** be unrelated to any concurrently-running JSON-RPC
+     _request_ from the client.
+   - The server **MUST NOT** send a JSON-RPC _response_ on the stream **unless**
+     [resuming](#resumability-and-redelivery) a stream associated with a previous client
+     request.
+   - The server **MAY** close the SSE stream at any time.
+   - The client **MAY** close the SSE stream at any time.
+
+### Multiple Connections
+
+1. The client **MAY** remain connected to multiple SSE streams simultaneously.
+2. The server **MUST** send each of its JSON-RPC messages on only one of the connected
+   streams; that is, it **MUST NOT** broadcast the same message across multiple streams.
+   - The risk of message loss **MAY** be mitigated by making the stream
+     [resumable](#resumability-and-redelivery).
+
+### Resumability and Redelivery
+
+To support resuming broken connections, and redelivering messages that might otherwise be
+lost:
+
+1. Servers **MAY** attach an `id` field to their SSE events, as described in the
+   [SSE standard](https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation).
+   - If present, the ID **MUST** be globally unique across all streams within that
+     [session](#session-management)—or all streams with that specific client, if session
+     management is not in use.
+2. If the client wishes to resume after a broken connection, it **SHOULD** issue an HTTP
+   GET to the MCP endpoint, and include the
+   [`Last-Event-ID`](https://html.spec.whatwg.org/multipage/server-sent-events.html#the-last-event-id-header)
+   header to indicate the last event ID it received.
+   - The server **MAY** use this header to replay messages that would have been sent
+     after the last event ID, _on the stream that was disconnected_, and to resume the
+     stream from that point.
+   - The server **MUST NOT** replay messages that would have been delivered on a
+     different stream.
+
+In other words, these event IDs should be assigned by servers on a _per-stream_ basis, to
+act as a cursor within that particular stream.
+
+### Session Management
+
+An MCP "session" consists of logically related interactions between a client and a
+server, beginning with the [initialization phase](/specification/2025-03-26/basic/lifecycle). To support
+servers which want to establish stateful sessions:
+
+1. A server using the Streamable HTTP transport **MAY** assign a session ID at
+   initialization time, by including it in an `Mcp-Session-Id` header on the HTTP
+   response containing the `InitializeResult`.
+   - The session ID **SHOULD** be globally unique and cryptographically secure (e.g., a
+     securely generated UUID, a JWT, or a cryptographic hash).
+   - The session ID **MUST** only contain visible ASCII characters (ranging from 0x21 to
+     0x7E).
+2. If an `Mcp-Session-Id` is returned by the server during initialization, clients using
+   the Streamable HTTP transport **MUST** include it in the `Mcp-Session-Id` header on
+   all of their subsequent HTTP requests.
+   - Servers that require a session ID **SHOULD** respond to requests without an
+     `Mcp-Session-Id` header (other than initialization) with HTTP 400 Bad Request.
+3. The server **MAY** terminate the session at any time, after which it **MUST** respond
+   to requests containing that session ID with HTTP 404 Not Found.
+4. When a client receives HTTP 404 in response to a request containing an
+   `Mcp-Session-Id`, it **MUST** start a new session by sending a new `InitializeRequest`
+   without a session ID attached.
+5. Clients that no longer need a particular session (e.g., because the user is leaving
+   the client application) **SHOULD** send an HTTP DELETE to the MCP endpoint with the
+   `Mcp-Session-Id` header, to explicitly terminate the session.
+   - The server **MAY** respond to this request with HTTP 405 Method Not Allowed,
+     indicating that the server does not allow clients to terminate sessions.
+
+### Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Server
+
+    note over Client, Server: initialization
+
+    Client->>+Server: POST InitializeRequest
+    Server->>-Client: InitializeResponse<br>Mcp-Session-Id: 1868a90c...
+
+    Client->>+Server: POST InitializedNotification<br>Mcp-Session-Id: 1868a90c...
+    Server->>-Client: 202 Accepted
+
+    note over Client, Server: client requests
+    Client->>+Server: POST ... request ...<br>Mcp-Session-Id: 1868a90c...
+
+    alt single HTTP response
+      Server->>Client: ... response ...
+    else server opens SSE stream
+      loop while connection remains open
+          Server-)Client: ... SSE messages from server ...
+      end
+      Server-)Client: SSE event: ... response ...
+    end
+    deactivate Server
+
+    note over Client, Server: client notifications/responses
+    Client->>+Server: POST ... notification/response ...<br>Mcp-Session-Id: 1868a90c...
+    Server->>-Client: 202 Accepted
+
+    note over Client, Server: server requests
+    Client->>+Server: GET<br>Mcp-Session-Id: 1868a90c...
+    loop while connection remains open
+        Server-)Client: ... SSE messages from server ...
+    end
+    deactivate Server
+
+```
+
+### Backwards Compatibility
+
+Clients and servers can maintain backwards compatibility with the deprecated [HTTP+SSE
+transport](/specification/2024-11-05/basic/transports#http-with-sse) (from
+protocol version 2024-11-05) as follows:
+
+**Servers** wanting to support older clients should:
+
+- Continue to host both the SSE and POST endpoints of the old transport, alongside the
+  new "MCP endpoint" defined for the Streamable HTTP transport.
+  - It is also possible to combine the old POST endpoint and the new MCP endpoint, but
+    this may introduce unneeded complexity.
+
+**Clients** wanting to support older servers should:
+
+1. Accept an MCP server URL from the user, which may point to either a server using the
+   old transport or the new transport.
+2. Attempt to POST an `InitializeRequest` to the server URL, with an `Accept` header as
+   defined above:
+   - If it succeeds, the client can assume this is a server supporting the new Streamable
+     HTTP transport.
+   - If it fails with an HTTP 4xx status code (e.g., 405 Method Not Allowed or 404 Not
+     Found):
+     - Issue a GET request to the server URL, expecting that this will open an SSE stream
+       and return an `endpoint` event as the first event.
+     - When the `endpoint` event arrives, the client can assume this is a server running
+       the old HTTP+SSE transport, and should use that transport for all subsequent
+       communication.
+
+## Custom Transports
+
+Clients and servers **MAY** implement additional custom transport mechanisms to suit
+their specific needs. The protocol is transport-agnostic and can be implemented over any
+communication channel that supports bidirectional message exchange.
+
+Implementers who choose to support custom transports **MUST** ensure they preserve the
+JSON-RPC message format and lifecycle requirements defined by MCP. Custom transports
+**SHOULD** document their specific connection establishment and message exchange patterns
+to aid interoperability.

--- a/.agents/skills/mcp-knowledge/references/2025-06-18/architecture.md
+++ b/.agents/skills/mcp-knowledge/references/2025-06-18/architecture.md
@@ -1,0 +1,171 @@
+<!-- markdownlint-disable -->
+# Architecture
+
+The Model Context Protocol (MCP) follows a client-host-server architecture where each
+host can run multiple client instances. This architecture enables users to integrate AI
+capabilities across applications while maintaining clear security boundaries and
+isolating concerns. Built on JSON-RPC, MCP provides a stateful session protocol focused
+on context exchange and sampling coordination between clients and servers.
+
+## Core Components
+
+```mermaid
+graph LR
+    subgraph "Application Host Process"
+        H[Host]
+        C1[Client 1]
+        C2[Client 2]
+        C3[Client 3]
+        H --> C1
+        H --> C2
+        H --> C3
+    end
+
+    subgraph "Local machine"
+        S1[Server 1<br>Files & Git]
+        S2[Server 2<br>Database]
+        R1[("Local<br>Resource A")]
+        R2[("Local<br>Resource B")]
+
+        C1 --> S1
+        C2 --> S2
+        S1 <--> R1
+        S2 <--> R2
+    end
+
+    subgraph "Internet"
+        S3[Server 3<br>External APIs]
+        R3[("Remote<br>Resource C")]
+
+        C3 --> S3
+        S3 <--> R3
+    end
+```
+
+### Host
+
+The host process acts as the container and coordinator:
+
+- Creates and manages multiple client instances
+- Controls client connection permissions and lifecycle
+- Enforces security policies and consent requirements
+- Handles user authorization decisions
+- Coordinates AI/LLM integration and sampling
+- Manages context aggregation across clients
+
+### Clients
+
+Each client is created by the host and maintains an isolated server connection:
+
+- Establishes one stateful session per server
+- Handles protocol negotiation and capability exchange
+- Routes protocol messages bidirectionally
+- Manages subscriptions and notifications
+- Maintains security boundaries between servers
+
+A host application creates and manages multiple clients, with each client having a 1:1
+relationship with a particular server.
+
+### Servers
+
+Servers provide specialized context and capabilities:
+
+- Expose resources, tools and prompts via MCP primitives
+- Operate independently with focused responsibilities
+- Request sampling through client interfaces
+- Must respect security constraints
+- Can be local processes or remote services
+
+## Design Principles
+
+MCP is built on several key design principles that inform its architecture and
+implementation:
+
+1. **Servers should be extremely easy to build**
+   - Host applications handle complex orchestration responsibilities
+   - Servers focus on specific, well-defined capabilities
+   - Simple interfaces minimize implementation overhead
+   - Clear separation enables maintainable code
+
+2. **Servers should be highly composable**
+   - Each server provides focused functionality in isolation
+   - Multiple servers can be combined seamlessly
+   - Shared protocol enables interoperability
+   - Modular design supports extensibility
+
+3. **Servers should not be able to read the whole conversation, nor "see into" other
+   servers**
+   - Servers receive only necessary contextual information
+   - Full conversation history stays with the host
+   - Each server connection maintains isolation
+   - Cross-server interactions are controlled by the host
+   - Host process enforces security boundaries
+
+4. **Features can be added to servers and clients progressively**
+   - Core protocol provides minimal required functionality
+   - Additional capabilities can be negotiated as needed
+   - Servers and clients evolve independently
+   - Protocol designed for future extensibility
+   - Backwards compatibility is maintained
+
+## Capability Negotiation
+
+The Model Context Protocol uses a capability-based negotiation system where clients and
+servers explicitly declare their supported features during initialization. Capabilities
+determine which protocol features and primitives are available during a session.
+
+- Servers declare capabilities like resource subscriptions, tool support, and prompt
+  templates
+- Clients declare capabilities like sampling support and notification handling
+- Both parties must respect declared capabilities throughout the session
+- Additional capabilities can be negotiated through extensions to the protocol
+
+```mermaid
+sequenceDiagram
+    participant Host
+    participant Client
+    participant Server
+
+    Host->>+Client: Initialize client
+    Client->>+Server: Initialize session with capabilities
+    Server-->>Client: Respond with supported capabilities
+
+    Note over Host,Server: Active Session with Negotiated Features
+
+    loop Client Requests
+        Host->>Client: User- or model-initiated action
+        Client->>Server: Request (tools/resources)
+        Server-->>Client: Response
+        Client-->>Host: Update UI or respond to model
+    end
+
+    loop Server Requests
+        Server->>Client: Request (sampling)
+        Client->>Host: Forward to AI
+        Host-->>Client: AI response
+        Client-->>Server: Response
+    end
+
+    loop Notifications
+        Server--)Client: Resource updates
+        Client--)Server: Status changes
+    end
+
+    Host->>Client: Terminate
+    Client->>-Server: End session
+    deactivate Server
+```
+
+Each capability unlocks specific protocol features for use during the session. For
+example:
+
+- Implemented [server features](/specification/2025-06-18/server) must be advertised in the
+  server's capabilities
+- Emitting resource subscription notifications requires the server to declare
+  subscription support
+- Tool invocation requires the server to declare tool capabilities
+- [Sampling](/specification/2025-06-18/client) requires the client to declare support in its
+  capabilities
+
+This capability negotiation ensures clients and servers have a clear understanding of
+supported functionality while maintaining protocol extensibility.

--- a/.agents/skills/mcp-knowledge/references/2025-06-18/authorization.md
+++ b/.agents/skills/mcp-knowledge/references/2025-06-18/authorization.md
@@ -1,0 +1,370 @@
+<!-- markdownlint-disable -->
+# Authorization
+
+## Introduction
+
+### Purpose and Scope
+
+The Model Context Protocol provides authorization capabilities at the transport level,
+enabling MCP clients to make requests to restricted MCP servers on behalf of resource
+owners. This specification defines the authorization flow for HTTP-based transports.
+
+### Protocol Requirements
+
+Authorization is **OPTIONAL** for MCP implementations. When supported:
+
+- Implementations using an HTTP-based transport **SHOULD** conform to this specification.
+- Implementations using an STDIO transport **SHOULD NOT** follow this specification, and
+  instead retrieve credentials from the environment.
+- Implementations using alternative transports **MUST** follow established security best
+  practices for their protocol.
+
+### Standards Compliance
+
+This authorization mechanism is based on established specifications listed below, but
+implements a selected subset of their features to ensure security and interoperability
+while maintaining simplicity:
+
+- OAuth 2.1 IETF DRAFT ([draft-ietf-oauth-v2-1-13](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-13))
+- OAuth 2.0 Authorization Server Metadata
+  ([RFC8414](https://datatracker.ietf.org/doc/html/rfc8414))
+- OAuth 2.0 Dynamic Client Registration Protocol
+  ([RFC7591](https://datatracker.ietf.org/doc/html/rfc7591))
+- OAuth 2.0 Protected Resource Metadata ([RFC9728](https://datatracker.ietf.org/doc/html/rfc9728))
+
+## Authorization Flow
+
+### Roles
+
+A protected _MCP server_ acts as an [OAuth 2.1 resource server](https://www.ietf.org/archive/id/draft-ietf-oauth-v2-1-13.html#name-roles),
+capable of accepting and responding to protected resource requests using access tokens.
+
+An _MCP client_ acts as an [OAuth 2.1 client](https://www.ietf.org/archive/id/draft-ietf-oauth-v2-1-13.html#name-roles),
+making protected resource requests on behalf of a resource owner.
+
+The _authorization server_ is responsible for interacting with the user (if necessary) and issuing access tokens for use at the MCP server.
+The implementation details of the authorization server are beyond the scope of this specification. It may be hosted with the
+resource server or a separate entity. The [Authorization Server Discovery section](#authorization-server-discovery)
+specifies how an MCP server indicates the location of its corresponding authorization server to a client.
+
+### Overview
+
+1. Authorization servers **MUST** implement OAuth 2.1 with appropriate security
+   measures for both confidential and public clients.
+
+1. Authorization servers and MCP clients **SHOULD** support the OAuth 2.0 Dynamic Client Registration
+   Protocol ([RFC7591](https://datatracker.ietf.org/doc/html/rfc7591)).
+
+1. MCP servers **MUST** implement OAuth 2.0 Protected Resource Metadata ([RFC9728](https://datatracker.ietf.org/doc/html/rfc9728)).
+   MCP clients **MUST** use OAuth 2.0 Protected Resource Metadata for authorization server discovery.
+
+1. Authorization servers **MUST** provide OAuth 2.0 Authorization
+   Server Metadata ([RFC8414](https://datatracker.ietf.org/doc/html/rfc8414)).
+   MCP clients **MUST** use the OAuth 2.0 Authorization Server Metadata.
+
+### Authorization Server Discovery
+
+This section describes the mechanisms by which MCP servers advertise their associated
+authorization servers to MCP clients, as well as the discovery process through which MCP
+clients can determine authorization server endpoints and supported capabilities.
+
+#### Authorization Server Location
+
+MCP servers **MUST** implement the OAuth 2.0 Protected Resource Metadata ([RFC9728](https://datatracker.ietf.org/doc/html/rfc9728))
+specification to indicate the locations of authorization servers. The Protected Resource Metadata document returned by the MCP server **MUST** include
+the `authorization_servers` field containing at least one authorization server.
+
+The specific use of `authorization_servers` is beyond the scope of this specification; implementers should consult
+OAuth 2.0 Protected Resource Metadata ([RFC9728](https://datatracker.ietf.org/doc/html/rfc9728)) for
+guidance on implementation details.
+
+Implementors should note that Protected Resource Metadata documents can define multiple authorization servers. The responsibility for selecting which authorization server to use lies with the MCP client, following the guidelines specified in
+[RFC9728 Section 7.6 "Authorization Servers"](https://datatracker.ietf.org/doc/html/rfc9728#name-authorization-servers).
+
+MCP servers **MUST** use the HTTP header `WWW-Authenticate` when returning a _401 Unauthorized_ to indicate the location of the resource server metadata URL
+as described in [RFC9728 Section 5.1 "WWW-Authenticate Response"](https://datatracker.ietf.org/doc/html/rfc9728#name-www-authenticate-response).
+
+MCP clients **MUST** be able to parse `WWW-Authenticate` headers and respond appropriately to `HTTP 401 Unauthorized` responses from the MCP server.
+
+#### Server Metadata Discovery
+
+MCP clients **MUST** follow the OAuth 2.0 Authorization Server Metadata [RFC8414](https://datatracker.ietf.org/doc/html/rfc8414)
+specification to obtain the information required to interact with the authorization server.
+
+#### Sequence Diagram
+
+The following diagram outlines an example flow:
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant M as MCP Server (Resource Server)
+    participant A as Authorization Server
+
+    C->>M: MCP request without token
+    M-->>C: HTTP 401 Unauthorized with WWW-Authenticate header
+    Note over C: Extract resource_metadata<br />from WWW-Authenticate
+
+    C->>M: GET /.well-known/oauth-protected-resource
+    M-->>C: Resource metadata with authorization server URL
+    Note over C: Validate RS metadata,<br />build AS metadata URL
+
+    C->>A: GET /.well-known/oauth-authorization-server
+    A-->>C: Authorization server metadata
+
+    Note over C,A: OAuth 2.1 authorization flow happens here
+
+    C->>A: Token request
+    A-->>C: Access token
+
+    C->>M: MCP request with access token
+    M-->>C: MCP response
+    Note over C,M: MCP communication continues with valid token
+```
+
+### Dynamic Client Registration
+
+MCP clients and authorization servers **SHOULD** support the
+OAuth 2.0 Dynamic Client Registration Protocol [RFC7591](https://datatracker.ietf.org/doc/html/rfc7591)
+to allow MCP clients to obtain OAuth client IDs without user interaction. This provides a
+standardized way for clients to automatically register with new authorization servers, which is crucial
+for MCP because:
+
+- Clients may not know all possible MCP servers and their authorization servers in advance.
+- Manual registration would create friction for users.
+- It enables seamless connection to new MCP servers and their authorization servers.
+- Authorization servers can implement their own registration policies.
+
+Any authorization servers that _do not_ support Dynamic Client Registration need to provide
+alternative ways to obtain a client ID (and, if applicable, client credentials). For one of
+these authorization servers, MCP clients will have to either:
+
+1. Hardcode a client ID (and, if applicable, client credentials) specifically for the MCP client to use when
+   interacting with that authorization server, or
+2. Present a UI to users that allows them to enter these details, after registering an
+   OAuth client themselves (e.g., through a configuration interface hosted by the
+   server).
+
+### Authorization Flow Steps
+
+The complete Authorization flow proceeds as follows:
+
+```mermaid
+sequenceDiagram
+    participant B as User-Agent (Browser)
+    participant C as Client
+    participant M as MCP Server (Resource Server)
+    participant A as Authorization Server
+
+    C->>M: MCP request without token
+    M->>C: HTTP 401 Unauthorized with WWW-Authenticate header
+    Note over C: Extract resource_metadata URL from WWW-Authenticate
+
+    C->>M: Request Protected Resource Metadata
+    M->>C: Return metadata
+
+    Note over C: Parse metadata and extract authorization server(s)<br/>Client determines AS to use
+
+    C->>A: GET /.well-known/oauth-authorization-server
+    A->>C: Authorization server metadata response
+
+    alt Dynamic client registration
+        C->>A: POST /register
+        A->>C: Client Credentials
+    end
+
+    Note over C: Generate PKCE parameters<br/>Include resource parameter
+    C->>B: Open browser with authorization URL + code_challenge + resource
+    B->>A: Authorization request with resource parameter
+    Note over A: User authorizes
+    A->>B: Redirect to callback with authorization code
+    B->>C: Authorization code callback
+    C->>A: Token request + code_verifier + resource
+    A->>C: Access token (+ refresh token)
+    C->>M: MCP request with access token
+    M-->>C: MCP response
+    Note over C,M: MCP communication continues with valid token
+```
+
+#### Resource Parameter Implementation
+
+MCP clients **MUST** implement Resource Indicators for OAuth 2.0 as defined in [RFC 8707](https://www.rfc-editor.org/rfc/rfc8707.html)
+to explicitly specify the target resource for which the token is being requested. The `resource` parameter:
+
+1. **MUST** be included in both authorization requests and token requests.
+2. **MUST** identify the MCP server that the client intends to use the token with.
+3. **MUST** use the canonical URI of the MCP server as defined in [RFC 8707 Section 2](https://www.rfc-editor.org/rfc/rfc8707.html#name-access-token-request).
+
+##### Canonical Server URI
+
+For the purposes of this specification, the canonical URI of an MCP server is defined as the resource identifier as specified in
+[RFC 8707 Section 2](https://www.rfc-editor.org/rfc/rfc8707.html#section-2) and aligns with the `resource` parameter in
+[RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728).
+
+MCP clients **SHOULD** provide the most specific URI that they can for the MCP server they intend to access, following the guidance in [RFC 8707](https://www.rfc-editor.org/rfc/rfc8707). While the canonical form uses lowercase scheme and host components, implementations **SHOULD** accept uppercase scheme and host components for robustness and interoperability.
+
+Examples of valid canonical URIs:
+
+- `https://mcp.example.com/mcp`
+- `https://mcp.example.com`
+- `https://mcp.example.com:8443`
+- `https://mcp.example.com/server/mcp` (when path component is necessary to identify individual MCP server)
+
+Examples of invalid canonical URIs:
+
+- `mcp.example.com` (missing scheme)
+- `https://mcp.example.com#fragment` (contains fragment)
+
+> **Note:** While both `https://mcp.example.com/` (with trailing slash) and `https://mcp.example.com` (without trailing slash) are technically valid absolute URIs according to [RFC 3986](https://www.rfc-editor.org/rfc/rfc3986), implementations **SHOULD** consistently use the form without the trailing slash for better interoperability unless the trailing slash is semantically significant for the specific resource.
+
+For example, if accessing an MCP server at `https://mcp.example.com`, the authorization request would include:
+
+```
+&resource=https%3A%2F%2Fmcp.example.com
+```
+
+MCP clients **MUST** send this parameter regardless of whether authorization servers support it.
+
+### Access Token Usage
+
+#### Token Requirements
+
+Access token handling when making requests to MCP servers **MUST** conform to the requirements defined in
+[OAuth 2.1 Section 5 "Resource Requests"](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-13#section-5).
+Specifically:
+
+1. MCP client **MUST** use the Authorization request header field defined in
+   [OAuth 2.1 Section 5.1.1](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-13#section-5.1.1):
+
+```
+Authorization: Bearer <access-token>
+```
+
+Note that authorization **MUST** be included in every HTTP request from client to server,
+even if they are part of the same logical session.
+
+2. Access tokens **MUST NOT** be included in the URI query string
+
+Example request:
+
+```http
+GET /mcp HTTP/1.1
+Host: mcp.example.com
+Authorization: Bearer eyJhbGciOiJIUzI1NiIs...
+```
+
+#### Token Handling
+
+MCP servers, acting in their role as an OAuth 2.1 resource server, **MUST** validate access tokens as described in
+[OAuth 2.1 Section 5.2](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-13#section-5.2).
+MCP servers **MUST** validate that access tokens were issued specifically for them as the intended audience,
+according to [RFC 8707 Section 2](https://www.rfc-editor.org/rfc/rfc8707.html#section-2).
+If validation fails, servers **MUST** respond according to
+[OAuth 2.1 Section 5.3](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-13#section-5.3)
+error handling requirements. Invalid or expired tokens **MUST** receive a HTTP 401
+response.
+
+MCP clients **MUST NOT** send tokens to the MCP server other than ones issued by the MCP server's authorization server.
+
+Authorization servers **MUST** only accept tokens that are valid for use with their
+own resources.
+
+MCP servers **MUST NOT** accept or transit any other tokens.
+
+### Error Handling
+
+Servers **MUST** return appropriate HTTP status codes for authorization errors:
+
+| Status Code | Description  | Usage                                      |
+| ----------- | ------------ | ------------------------------------------ |
+| 401         | Unauthorized | Authorization required or token invalid    |
+| 403         | Forbidden    | Invalid scopes or insufficient permissions |
+| 400         | Bad Request  | Malformed authorization request            |
+
+## Security Considerations
+
+Implementations **MUST** follow OAuth 2.1 security best practices as laid out in [OAuth 2.1 Section 7. "Security Considerations"](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-13#name-security-considerations).
+
+### Token Audience Binding and Validation
+
+[RFC 8707](https://www.rfc-editor.org/rfc/rfc8707.html) Resource Indicators provide critical security benefits by binding tokens to their intended
+audiences **when the Authorization Server supports the capability**. To enable current and future adoption:
+
+- MCP clients **MUST** include the `resource` parameter in authorization and token requests as specified in the [Resource Parameter Implementation](#resource-parameter-implementation) section
+- MCP servers **MUST** validate that tokens presented to them were specifically issued for their use
+
+The [Security Best Practices document](/specification/2025-06-18/basic/security_best_practices#token-passthrough)
+outlines why token audience validation is crucial and why token passthrough is explicitly forbidden.
+
+### Token Theft
+
+Attackers who obtain tokens stored by the client, or tokens cached or logged on the server can access protected resources with
+requests that appear legitimate to resource servers.
+
+Clients and servers **MUST** implement secure token storage and follow OAuth best practices,
+as outlined in [OAuth 2.1, Section 7.1](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-13#section-7.1).
+
+Authorization servers **SHOULD** issue short-lived access tokens to reduce the impact of leaked tokens.
+For public clients, authorization servers **MUST** rotate refresh tokens as described in [OAuth 2.1 Section 4.3.1 "Token Endpoint Extension"](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-13#section-4.3.1).
+
+### Communication Security
+
+Implementations **MUST** follow [OAuth 2.1 Section 1.5 "Communication Security"](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-13#section-1.5).
+
+Specifically:
+
+1. All authorization server endpoints **MUST** be served over HTTPS.
+1. All redirect URIs **MUST** be either `localhost` or use HTTPS.
+
+### Authorization Code Protection
+
+An attacker who has gained access to an authorization code contained in an authorization response can try to redeem the authorization code for an access token or otherwise make use of the authorization code.
+(Further described in [OAuth 2.1 Section 7.5](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-13#section-7.5))
+
+To mitigate this, MCP clients **MUST** implement PKCE according to [OAuth 2.1 Section 7.5.2](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-13#section-7.5.2).
+PKCE helps prevent authorization code interception and injection attacks by requiring clients to create a secret verifier-challenge pair, ensuring that only the original requestor can exchange an authorization code for tokens.
+
+### Open Redirection
+
+An attacker may craft malicious redirect URIs to direct users to phishing sites.
+
+MCP clients **MUST** have redirect URIs registered with the authorization server.
+
+Authorization servers **MUST** validate exact redirect URIs against pre-registered values to prevent redirection attacks.
+
+MCP clients **SHOULD** use and verify state parameters in the authorization code flow
+and discard any results that do not include or have a mismatch with the original state.
+
+Authorization servers **MUST** take precautions to prevent redirecting user agents to untrusted URI's, following suggestions laid out in [OAuth 2.1 Section 7.12.2](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-13#section-7.12.2)
+
+Authorization servers **SHOULD** only automatically redirect the user agent if it trusts the redirection URI. If the URI is not trusted, the authorization server MAY inform the user and rely on the user to make the correct decision.
+
+### Confused Deputy Problem
+
+Attackers can exploit MCP servers acting as intermediaries to third-party APIs, leading to [confused deputy vulnerabilities](/specification/2025-06-18/basic/security_best_practices#confused-deputy-problem).
+By using stolen authorization codes, they can obtain access tokens without user consent.
+
+MCP proxy servers using static client IDs **MUST** obtain user consent for each dynamically
+registered client before forwarding to third-party authorization servers (which may require additional consent).
+
+### Access Token Privilege Restriction
+
+An attacker can gain unauthorized access or otherwise compromise an MCP server if the server accepts tokens issued for other resources.
+
+This vulnerability has two critical dimensions:
+
+1. **Audience validation failures.** When an MCP server doesn't verify that tokens were specifically intended for it (for example, via the audience claim, as mentioned in [RFC9068](https://www.rfc-editor.org/rfc/rfc9068.html)), it may accept tokens originally issued for other services. This breaks a fundamental OAuth security boundary, allowing attackers to reuse legitimate tokens across different services than intended.
+2. **Token passthrough.** If the MCP server not only accepts tokens with incorrect audiences but also forwards these unmodified tokens to downstream services, it can potentially cause the ["confused deputy" problem](#confused-deputy-problem), where the downstream API may incorrectly trust the token as if it came from the MCP server or assume the token was validated by the upstream API. See the [Token Passthrough section](/specification/2025-06-18/basic/security_best_practices#token-passthrough) of the Security Best Practices guide for additional details.
+
+MCP servers **MUST** validate access tokens before processing the request, ensuring the access token is issued specifically for the MCP server, and take all necessary steps to ensure no data is returned to unauthorized parties.
+
+A MCP server **MUST** follow the guidelines in [OAuth 2.1 - Section 5.2](https://www.ietf.org/archive/id/draft-ietf-oauth-v2-1-13.html#section-5.2) to validate inbound tokens.
+
+MCP servers **MUST** only accept tokens specifically intended for themselves and **MUST** reject tokens that do not include them in the audience claim or otherwise verify that they are the intended recipient of the token. See the [Security Best Practices Token Passthrough section](/specification/2025-06-18/basic/security_best_practices#token-passthrough) for details.
+
+If the MCP server makes requests to upstream APIs, it may act as an OAuth client to them. The access token used at the upstream API is a separate token, issued by the upstream authorization server. The MCP server **MUST NOT** pass through the token it received from the MCP client.
+
+MCP clients **MUST** implement and use the `resource` parameter as defined in [RFC 8707 - Resource Indicators for OAuth 2.0](https://www.rfc-editor.org/rfc/rfc8707.html)
+to explicitly specify the target resource for which the token is being requested. This requirement aligns with the recommendation in
+[RFC 9728 Section 7.4](https://datatracker.ietf.org/doc/html/rfc9728#section-7.4). This ensures that access tokens are bound to their intended resources and
+cannot be misused across different services.

--- a/.agents/skills/mcp-knowledge/references/2025-06-18/cancellation.md
+++ b/.agents/skills/mcp-knowledge/references/2025-06-18/cancellation.md
@@ -1,0 +1,80 @@
+<!-- markdownlint-disable -->
+# Cancellation
+
+The Model Context Protocol (MCP) supports optional cancellation of in-progress requests
+through notification messages. Either side can send a cancellation notification to
+indicate that a previously-issued request should be terminated.
+
+## Cancellation Flow
+
+When a party wants to cancel an in-progress request, it sends a `notifications/cancelled`
+notification containing:
+
+- The ID of the request to cancel
+- An optional reason string that can be logged or displayed
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/cancelled",
+  "params": {
+    "requestId": "123",
+    "reason": "User requested cancellation"
+  }
+}
+```
+
+## Behavior Requirements
+
+1. Cancellation notifications **MUST** only reference requests that:
+   - Were previously issued in the same direction
+   - Are believed to still be in-progress
+2. The `initialize` request **MUST NOT** be cancelled by clients
+3. Receivers of cancellation notifications **SHOULD**:
+   - Stop processing the cancelled request
+   - Free associated resources
+   - Not send a response for the cancelled request
+4. Receivers **MAY** ignore cancellation notifications if:
+   - The referenced request is unknown
+   - Processing has already completed
+   - The request cannot be cancelled
+5. The sender of the cancellation notification **SHOULD** ignore any response to the
+   request that arrives afterward
+
+## Timing Considerations
+
+Due to network latency, cancellation notifications may arrive after request processing
+has completed, and potentially after a response has already been sent.
+
+Both parties **MUST** handle these race conditions gracefully:
+
+```mermaid
+sequenceDiagram
+   participant Client
+   participant Server
+
+   Client->>Server: Request (ID: 123)
+   Note over Server: Processing starts
+   Client--)Server: notifications/cancelled (ID: 123)
+   alt
+      Note over Server: Processing may have<br/>completed before<br/>cancellation arrives
+   else If not completed
+      Note over Server: Stop processing
+   end
+```
+
+## Implementation Notes
+
+- Both parties **SHOULD** log cancellation reasons for debugging
+- Application UIs **SHOULD** indicate when cancellation is requested
+
+## Error Handling
+
+Invalid cancellation notifications **SHOULD** be ignored:
+
+- Unknown request IDs
+- Already completed requests
+- Malformed notifications
+
+This maintains the "fire and forget" nature of notifications while allowing for race
+conditions in asynchronous communication.

--- a/.agents/skills/mcp-knowledge/references/2025-06-18/changelog.md
+++ b/.agents/skills/mcp-knowledge/references/2025-06-18/changelog.md
@@ -1,0 +1,42 @@
+<!-- markdownlint-disable -->
+# Key Changes
+
+This document lists changes made to the Model Context Protocol (MCP) specification since
+the previous revision, [2025-03-26](/specification/2025-03-26).
+
+## Major changes
+
+1. Remove support for JSON-RPC **[batching](https://www.jsonrpc.org/specification#batch)**
+   (PR [#416](https://github.com/modelcontextprotocol/specification/pull/416))
+2. Add support for [structured tool output](/specification/2025-06-18/server/tools#structured-content)
+   (PR [#371](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/371))
+3. Classify MCP servers as [OAuth Resource Servers](/specification/2025-06-18/basic/authorization#authorization-server-discovery),
+   adding protected resource metadata to discover the corresponding Authorization server.
+   (PR [#338](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/338))
+4. Require MCP clients to implement Resource Indicators as described in [RFC 8707](https://www.rfc-editor.org/rfc/rfc8707.html) to prevent
+   malicious servers from obtaining access tokens.
+   (PR [#734](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/734))
+5. Clarify [security considerations](/specification/2025-06-18/basic/authorization#security-considerations) and best practices
+   in the authorization spec and in a new [security best practices page](/specification/2025-06-18/basic/security_best_practices).
+6. Add support for **[elicitation](/specification/2025-06-18/client/elicitation)**, enabling servers to request additional
+   information from users during interactions.
+   (PR [#382](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/382))
+7. Add support for **[resource links](/specification/2025-06-18/server/tools#resource-links)** in
+   tool call results. (PR [#603](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/603))
+8. Require [negotiated protocol version to be specified](/specification/2025-06-18/basic/transports#protocol-version-header)
+   via `MCP-Protocol-Version` header in subsequent requests when using HTTP (PR [#548](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/548)).
+9. Change **SHOULD** to **MUST** in [Lifecycle Operation](/specification/2025-06-18/basic/lifecycle#operation)
+
+## Other schema changes
+
+1. Add `_meta` field to additional interface types (PR [#710](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/710)),
+   and specify [proper usage](/specification/2025-06-18/basic#meta).
+2. Add `context` field to `CompletionRequest`, providing for completion requests to include
+   previously-resolved variables (PR [#598](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/598)).
+3. Add `title` field for human-friendly display names, so that `name` can be used as a programmatic
+   identifier (PR [#663](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/663))
+
+## Full changelog
+
+For a complete list of all changes that have been made since the last protocol revision,
+[see GitHub](https://github.com/modelcontextprotocol/specification/compare/2025-03-26...2025-06-18).

--- a/.agents/skills/mcp-knowledge/references/2025-06-18/completion.md
+++ b/.agents/skills/mcp-knowledge/references/2025-06-18/completion.md
@@ -1,0 +1,199 @@
+<!-- markdownlint-disable -->
+# Completion
+
+The Model Context Protocol (MCP) provides a standardized way for servers to offer
+argument autocompletion suggestions for prompts and resource URIs. This enables rich,
+IDE-like experiences where users receive contextual suggestions while entering argument
+values.
+
+## User Interaction Model
+
+Completion in MCP is designed to support interactive user experiences similar to IDE code
+completion.
+
+For example, applications may show completion suggestions in a dropdown or popup menu as
+users type, with the ability to filter and select from available options.
+
+However, implementations are free to expose completion through any interface pattern that
+suits their needs&mdash;the protocol itself does not mandate any specific user
+interaction model.
+
+## Capabilities
+
+Servers that support completions **MUST** declare the `completions` capability:
+
+```json
+{
+  "capabilities": {
+    "completions": {}
+  }
+}
+```
+
+## Protocol Messages
+
+### Requesting Completions
+
+To get completion suggestions, clients send a `completion/complete` request specifying
+what is being completed through a reference type:
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "completion/complete",
+  "params": {
+    "ref": {
+      "type": "ref/prompt",
+      "name": "code_review"
+    },
+    "argument": {
+      "name": "language",
+      "value": "py"
+    }
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "completion": {
+      "values": ["python", "pytorch", "pyside"],
+      "total": 10,
+      "hasMore": true
+    }
+  }
+}
+```
+
+For prompts or URI templates with multiple arguments, clients should include previous completions in the `context.arguments` object to provide context for subsequent requests.
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "completion/complete",
+  "params": {
+    "ref": {
+      "type": "ref/prompt",
+      "name": "code_review"
+    },
+    "argument": {
+      "name": "framework",
+      "value": "fla"
+    },
+    "context": {
+      "arguments": {
+        "language": "python"
+      }
+    }
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "completion": {
+      "values": ["flask"],
+      "total": 1,
+      "hasMore": false
+    }
+  }
+}
+```
+
+### Reference Types
+
+The protocol supports two types of completion references:
+
+| Type           | Description                 | Example                                             |
+| -------------- | --------------------------- | --------------------------------------------------- |
+| `ref/prompt`   | References a prompt by name | `{"type": "ref/prompt", "name": "code_review"}`     |
+| `ref/resource` | References a resource URI   | `{"type": "ref/resource", "uri": "file:///{path}"}` |
+
+### Completion Results
+
+Servers return an array of completion values ranked by relevance, with:
+
+- Maximum 100 items per response
+- Optional total number of available matches
+- Boolean indicating if additional results exist
+
+## Message Flow
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Server
+
+    Note over Client: User types argument
+    Client->>Server: completion/complete
+    Server-->>Client: Completion suggestions
+
+    Note over Client: User continues typing
+    Client->>Server: completion/complete
+    Server-->>Client: Refined suggestions
+```
+
+## Data Types
+
+### CompleteRequest
+
+- `ref`: A `PromptReference` or `ResourceReference`
+- `argument`: Object containing:
+  - `name`: Argument name
+  - `value`: Current value
+- `context`: Object containing:
+  - `arguments`: A mapping of already-resolved argument names to their values.
+
+### CompleteResult
+
+- `completion`: Object containing:
+  - `values`: Array of suggestions (max 100)
+  - `total`: Optional total matches
+  - `hasMore`: Additional results flag
+
+## Error Handling
+
+Servers **SHOULD** return standard JSON-RPC errors for common failure cases:
+
+- Method not found: `-32601` (Capability not supported)
+- Invalid prompt name: `-32602` (Invalid params)
+- Missing required arguments: `-32602` (Invalid params)
+- Internal errors: `-32603` (Internal error)
+
+## Implementation Considerations
+
+1. Servers **SHOULD**:
+   - Return suggestions sorted by relevance
+   - Implement fuzzy matching where appropriate
+   - Rate limit completion requests
+   - Validate all inputs
+
+2. Clients **SHOULD**:
+   - Debounce rapid completion requests
+   - Cache completion results where appropriate
+   - Handle missing or partial results gracefully
+
+## Security
+
+Implementations **MUST**:
+
+- Validate all completion inputs
+- Implement appropriate rate limiting
+- Control access to sensitive suggestions
+- Prevent completion-based information disclosure

--- a/.agents/skills/mcp-knowledge/references/2025-06-18/elicitation.md
+++ b/.agents/skills/mcp-knowledge/references/2025-06-18/elicitation.md
@@ -1,0 +1,318 @@
+<!-- markdownlint-disable -->
+# Elicitation
+
+> **Note:**
+> Elicitation is newly introduced in this version of the MCP specification and its design may evolve in future protocol versions.
+
+The Model Context Protocol (MCP) provides a standardized way for servers to request additional
+information from users through the client during interactions. This flow allows clients to
+maintain control over user interactions and data sharing while enabling servers to gather
+necessary information dynamically.
+Servers request structured data from users with JSON schemas to validate responses.
+
+## User Interaction Model
+
+Elicitation in MCP allows servers to implement interactive workflows by enabling user input
+requests to occur _nested_ inside other MCP server features.
+
+Implementations are free to expose elicitation through any interface pattern that suits
+their needs&mdash;the protocol itself does not mandate any specific user interaction
+model.
+
+> **Warning:**
+> For trust & safety and security:
+>
+> - Servers **MUST NOT** use elicitation to request sensitive information.
+>
+> Applications **SHOULD**:
+>
+> - Provide UI that makes it clear which server is requesting information
+> - Allow users to review and modify their responses before sending
+> - Respect user privacy and provide clear decline and cancel options
+
+## Capabilities
+
+Clients that support elicitation **MUST** declare the `elicitation` capability during
+[initialization](/specification/2025-06-18/basic/lifecycle#initialization):
+
+```json
+{
+  "capabilities": {
+    "elicitation": {}
+  }
+}
+```
+
+## Protocol Messages
+
+### Creating Elicitation Requests
+
+To request information from a user, servers send an `elicitation/create` request:
+
+#### Simple Text Request
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "elicitation/create",
+  "params": {
+    "message": "Please provide your GitHub username",
+    "requestedSchema": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": ["name"]
+    }
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "action": "accept",
+    "content": {
+      "name": "octocat"
+    }
+  }
+}
+```
+
+#### Structured Data Request
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "elicitation/create",
+  "params": {
+    "message": "Please provide your contact information",
+    "requestedSchema": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Your full name"
+        },
+        "email": {
+          "type": "string",
+          "format": "email",
+          "description": "Your email address"
+        },
+        "age": {
+          "type": "number",
+          "minimum": 18,
+          "description": "Your age"
+        }
+      },
+      "required": ["name", "email"]
+    }
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "action": "accept",
+    "content": {
+      "name": "Monalisa Octocat",
+      "email": "octocat@github.com",
+      "age": 30
+    }
+  }
+}
+```
+
+**Reject Response Example:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "action": "decline"
+  }
+}
+```
+
+**Cancel Response Example:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "action": "cancel"
+  }
+}
+```
+
+## Message Flow
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Client
+    participant Server
+
+    Note over Server,Client: Server initiates elicitation
+    Server->>Client: elicitation/create
+
+    Note over Client,User: Human interaction
+    Client->>User: Present elicitation UI
+    User-->>Client: Provide requested information
+
+    Note over Server,Client: Complete request
+    Client-->>Server: Return user response
+
+    Note over Server: Continue processing with new information
+```
+
+## Request Schema
+
+The `requestedSchema` field allows servers to define the structure of the expected response using a restricted subset of JSON Schema. To simplify implementation for clients, elicitation schemas are limited to flat objects with primitive properties only:
+
+```json
+"requestedSchema": {
+  "type": "object",
+  "properties": {
+    "propertyName": {
+      "type": "string",
+      "title": "Display Name",
+      "description": "Description of the property"
+    },
+    "anotherProperty": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 100
+    }
+  },
+  "required": ["propertyName"]
+}
+```
+
+### Supported Schema Types
+
+The schema is restricted to these primitive types:
+
+1. **String Schema**
+
+   ```json
+   {
+     "type": "string",
+     "title": "Display Name",
+     "description": "Description text",
+     "minLength": 3,
+     "maxLength": 50,
+     "format": "email" // Supported: "email", "uri", "date", "date-time"
+   }
+   ```
+
+   Supported formats: `email`, `uri`, `date`, `date-time`
+
+2. **Number Schema**
+
+   ```json
+   {
+     "type": "number", // or "integer"
+     "title": "Display Name",
+     "description": "Description text",
+     "minimum": 0,
+     "maximum": 100
+   }
+   ```
+
+3. **Boolean Schema**
+
+   ```json
+   {
+     "type": "boolean",
+     "title": "Display Name",
+     "description": "Description text",
+     "default": false
+   }
+   ```
+
+4. **Enum Schema**
+   ```json
+   {
+     "type": "string",
+     "title": "Display Name",
+     "description": "Description text",
+     "enum": ["option1", "option2", "option3"],
+     "enumNames": ["Option 1", "Option 2", "Option 3"]
+   }
+   ```
+
+Clients can use this schema to:
+
+1. Generate appropriate input forms
+2. Validate user input before sending
+3. Provide better guidance to users
+
+Note that complex nested structures, arrays of objects, and other advanced JSON Schema features are intentionally not supported to simplify client implementation.
+
+## Response Actions
+
+Elicitation responses use a three-action model to clearly distinguish between different user actions:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "action": "accept", // or "decline" or "cancel"
+    "content": {
+      "propertyName": "value",
+      "anotherProperty": 42
+    }
+  }
+}
+```
+
+The three response actions are:
+
+1. **Accept** (`action: "accept"`): User explicitly approved and submitted with data
+   - The `content` field contains the submitted data matching the requested schema
+   - Example: User clicked "Submit", "OK", "Confirm", etc.
+
+2. **Decline** (`action: "decline"`): User explicitly declined the request
+   - The `content` field is typically omitted
+   - Example: User clicked "Reject", "Decline", "No", etc.
+
+3. **Cancel** (`action: "cancel"`): User dismissed without making an explicit choice
+   - The `content` field is typically omitted
+   - Example: User closed the dialog, clicked outside, pressed Escape, etc.
+
+Servers should handle each state appropriately:
+
+- **Accept**: Process the submitted data
+- **Decline**: Handle explicit decline (e.g., offer alternatives)
+- **Cancel**: Handle dismissal (e.g., prompt again later)
+
+## Security Considerations
+
+1. Servers **MUST NOT** request sensitive information through elicitation
+2. Clients **SHOULD** implement user approval controls
+3. Both parties **SHOULD** validate elicitation content against the provided schema
+4. Clients **SHOULD** provide clear indication of which server is requesting information
+5. Clients **SHOULD** allow users to decline elicitation requests at any time
+6. Clients **SHOULD** implement rate limiting
+7. Clients **SHOULD** present elicitation requests in a way that makes it clear what information is being requested and why

--- a/.agents/skills/mcp-knowledge/references/2025-06-18/lifecycle.md
+++ b/.agents/skills/mcp-knowledge/references/2025-06-18/lifecycle.md
@@ -1,0 +1,240 @@
+<!-- markdownlint-disable -->
+# Lifecycle
+
+The Model Context Protocol (MCP) defines a rigorous lifecycle for client-server
+connections that ensures proper capability negotiation and state management.
+
+1. **Initialization**: Capability negotiation and protocol version agreement
+2. **Operation**: Normal protocol communication
+3. **Shutdown**: Graceful termination of the connection
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Server
+
+    Note over Client,Server: Initialization Phase
+    activate Client
+    Client->>+Server: initialize request
+    Server-->>Client: initialize response
+    Client--)Server: initialized notification
+
+    Note over Client,Server: Operation Phase
+    rect rgb(200, 220, 250)
+        note over Client,Server: Normal protocol operations
+    end
+
+    Note over Client,Server: Shutdown
+    Client--)-Server: Disconnect
+    deactivate Server
+    Note over Client,Server: Connection closed
+```
+
+## Lifecycle Phases
+
+### Initialization
+
+The initialization phase **MUST** be the first interaction between client and server.
+During this phase, the client and server:
+
+- Establish protocol version compatibility
+- Exchange and negotiate capabilities
+- Share implementation details
+
+The client **MUST** initiate this phase by sending an `initialize` request containing:
+
+- Protocol version supported
+- Client capabilities
+- Client implementation information
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "initialize",
+  "params": {
+    "protocolVersion": "2025-06-18",
+    "capabilities": {
+      "roots": {
+        "listChanged": true
+      },
+      "sampling": {},
+      "elicitation": {}
+    },
+    "clientInfo": {
+      "name": "ExampleClient",
+      "title": "Example Client Display Name",
+      "version": "1.0.0"
+    }
+  }
+}
+```
+
+The server **MUST** respond with its own capabilities and information:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "protocolVersion": "2025-06-18",
+    "capabilities": {
+      "logging": {},
+      "prompts": {
+        "listChanged": true
+      },
+      "resources": {
+        "subscribe": true,
+        "listChanged": true
+      },
+      "tools": {
+        "listChanged": true
+      }
+    },
+    "serverInfo": {
+      "name": "ExampleServer",
+      "title": "Example Server Display Name",
+      "version": "1.0.0"
+    },
+    "instructions": "Optional instructions for the client"
+  }
+}
+```
+
+After successful initialization, the client **MUST** send an `initialized` notification
+to indicate it is ready to begin normal operations:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/initialized"
+}
+```
+
+- The client **SHOULD NOT** send requests other than
+  [pings](/specification/2025-06-18/basic/utilities/ping) before the server has responded to the
+  `initialize` request.
+- The server **SHOULD NOT** send requests other than
+  [pings](/specification/2025-06-18/basic/utilities/ping) and
+  [logging](/specification/2025-06-18/server/utilities/logging) before receiving the `initialized`
+  notification.
+
+#### Version Negotiation
+
+In the `initialize` request, the client **MUST** send a protocol version it supports.
+This **SHOULD** be the _latest_ version supported by the client.
+
+If the server supports the requested protocol version, it **MUST** respond with the same
+version. Otherwise, the server **MUST** respond with another protocol version it
+supports. This **SHOULD** be the _latest_ version supported by the server.
+
+If the client does not support the version in the server's response, it **SHOULD**
+disconnect.
+
+> **Note:**
+> If using HTTP, the client **MUST** include the `MCP-Protocol-Version:
+> <protocol-version>` HTTP header on all subsequent requests to the MCP
+> server.
+> For details, see [the Protocol Version Header section in Transports](/specification/2025-06-18/basic/transports#protocol-version-header).
+
+#### Capability Negotiation
+
+Client and server capabilities establish which optional protocol features will be
+available during the session.
+
+Key capabilities include:
+
+| Category | Capability     | Description                                                                               |
+| -------- | -------------- | ----------------------------------------------------------------------------------------- |
+| Client   | `roots`        | Ability to provide filesystem [roots](/specification/2025-06-18/client/roots)             |
+| Client   | `sampling`     | Support for LLM [sampling](/specification/2025-06-18/client/sampling) requests            |
+| Client   | `elicitation`  | Support for server [elicitation](/specification/2025-06-18/client/elicitation) requests   |
+| Client   | `experimental` | Describes support for non-standard experimental features                                  |
+| Server   | `prompts`      | Offers [prompt templates](/specification/2025-06-18/server/prompts)                       |
+| Server   | `resources`    | Provides readable [resources](/specification/2025-06-18/server/resources)                 |
+| Server   | `tools`        | Exposes callable [tools](/specification/2025-06-18/server/tools)                          |
+| Server   | `logging`      | Emits structured [log messages](/specification/2025-06-18/server/utilities/logging)       |
+| Server   | `completions`  | Supports argument [autocompletion](/specification/2025-06-18/server/utilities/completion) |
+| Server   | `experimental` | Describes support for non-standard experimental features                                  |
+
+Capability objects can describe sub-capabilities like:
+
+- `listChanged`: Support for list change notifications (for prompts, resources, and
+  tools)
+- `subscribe`: Support for subscribing to individual items' changes (resources only)
+
+### Operation
+
+During the operation phase, the client and server exchange messages according to the
+negotiated capabilities.
+
+Both parties **MUST**:
+
+- Respect the negotiated protocol version
+- Only use capabilities that were successfully negotiated
+
+### Shutdown
+
+During the shutdown phase, one side (usually the client) cleanly terminates the protocol
+connection. No specific shutdown messages are defined—instead, the underlying transport
+mechanism should be used to signal connection termination:
+
+#### stdio
+
+For the stdio [transport](/specification/2025-06-18/basic/transports), the client **SHOULD** initiate
+shutdown by:
+
+1. First, closing the input stream to the child process (the server)
+2. Waiting for the server to exit, or sending `SIGTERM` if the server does not exit
+   within a reasonable time
+3. Sending `SIGKILL` if the server does not exit within a reasonable time after `SIGTERM`
+
+The server **MAY** initiate shutdown by closing its output stream to the client and
+exiting.
+
+#### HTTP
+
+For HTTP [transports](/specification/2025-06-18/basic/transports), shutdown is indicated by closing the
+associated HTTP connection(s).
+
+## Timeouts
+
+Implementations **SHOULD** establish timeouts for all sent requests, to prevent hung
+connections and resource exhaustion. When the request has not received a success or error
+response within the timeout period, the sender **SHOULD** issue a [cancellation
+notification](/specification/2025-06-18/basic/utilities/cancellation) for that request and stop waiting for
+a response.
+
+SDKs and other middleware **SHOULD** allow these timeouts to be configured on a
+per-request basis.
+
+Implementations **MAY** choose to reset the timeout clock when receiving a [progress
+notification](/specification/2025-06-18/basic/utilities/progress) corresponding to the request, as this
+implies that work is actually happening. However, implementations **SHOULD** always
+enforce a maximum timeout, regardless of progress notifications, to limit the impact of a
+misbehaving client or server.
+
+## Error Handling
+
+Implementations **SHOULD** be prepared to handle these error cases:
+
+- Protocol version mismatch
+- Failure to negotiate required capabilities
+- Request [timeouts](#timeouts)
+
+Example initialization error:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "error": {
+    "code": -32602,
+    "message": "Unsupported protocol version",
+    "data": {
+      "supported": ["2024-11-05"],
+      "requested": "1.0.0"
+    }
+  }
+}
+```

--- a/.agents/skills/mcp-knowledge/references/2025-06-18/logging.md
+++ b/.agents/skills/mcp-knowledge/references/2025-06-18/logging.md
@@ -1,0 +1,137 @@
+<!-- markdownlint-disable -->
+# Logging
+
+The Model Context Protocol (MCP) provides a standardized way for servers to send
+structured log messages to clients. Clients can control logging verbosity by setting
+minimum log levels, with servers sending notifications containing severity levels,
+optional logger names, and arbitrary JSON-serializable data.
+
+## User Interaction Model
+
+Implementations are free to expose logging through any interface pattern that suits their
+needs&mdash;the protocol itself does not mandate any specific user interaction model.
+
+## Capabilities
+
+Servers that emit log message notifications **MUST** declare the `logging` capability:
+
+```json
+{
+  "capabilities": {
+    "logging": {}
+  }
+}
+```
+
+## Log Levels
+
+The protocol follows the standard syslog severity levels specified in
+[RFC 5424](https://datatracker.ietf.org/doc/html/rfc5424#section-6.2.1):
+
+| Level     | Description                      | Example Use Case           |
+| --------- | -------------------------------- | -------------------------- |
+| debug     | Detailed debugging information   | Function entry/exit points |
+| info      | General informational messages   | Operation progress updates |
+| notice    | Normal but significant events    | Configuration changes      |
+| warning   | Warning conditions               | Deprecated feature usage   |
+| error     | Error conditions                 | Operation failures         |
+| critical  | Critical conditions              | System component failures  |
+| alert     | Action must be taken immediately | Data corruption detected   |
+| emergency | System is unusable               | Complete system failure    |
+
+## Protocol Messages
+
+### Setting Log Level
+
+To configure the minimum log level, clients **MAY** send a `logging/setLevel` request:
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "logging/setLevel",
+  "params": {
+    "level": "info"
+  }
+}
+```
+
+### Log Message Notifications
+
+Servers send log messages using `notifications/message` notifications:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/message",
+  "params": {
+    "level": "error",
+    "logger": "database",
+    "data": {
+      "error": "Connection failed",
+      "details": {
+        "host": "localhost",
+        "port": 5432
+      }
+    }
+  }
+}
+```
+
+## Message Flow
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Server
+
+    Note over Client,Server: Configure Logging
+    Client->>Server: logging/setLevel (info)
+    Server-->>Client: Empty Result
+
+    Note over Client,Server: Server Activity
+    Server--)Client: notifications/message (info)
+    Server--)Client: notifications/message (warning)
+    Server--)Client: notifications/message (error)
+
+    Note over Client,Server: Level Change
+    Client->>Server: logging/setLevel (error)
+    Server-->>Client: Empty Result
+    Note over Server: Only sends error level<br/>and above
+```
+
+## Error Handling
+
+Servers **SHOULD** return standard JSON-RPC errors for common failure cases:
+
+- Invalid log level: `-32602` (Invalid params)
+- Configuration errors: `-32603` (Internal error)
+
+## Implementation Considerations
+
+1. Servers **SHOULD**:
+   - Rate limit log messages
+   - Include relevant context in data field
+   - Use consistent logger names
+   - Remove sensitive information
+
+2. Clients **MAY**:
+   - Present log messages in the UI
+   - Implement log filtering/search
+   - Display severity visually
+   - Persist log messages
+
+## Security
+
+1. Log messages **MUST NOT** contain:
+   - Credentials or secrets
+   - Personal identifying information
+   - Internal system details that could aid attacks
+
+2. Implementations **SHOULD**:
+   - Rate limit messages
+   - Validate all data fields
+   - Control log access
+   - Monitor for sensitive content

--- a/.agents/skills/mcp-knowledge/references/2025-06-18/pagination.md
+++ b/.agents/skills/mcp-knowledge/references/2025-06-18/pagination.md
@@ -1,0 +1,94 @@
+<!-- markdownlint-disable -->
+# Pagination
+
+The Model Context Protocol (MCP) supports paginating list operations that may return
+large result sets. Pagination allows servers to yield results in smaller chunks rather
+than all at once.
+
+Pagination is especially important when connecting to external services over the
+internet, but also useful for local integrations to avoid performance issues with large
+data sets.
+
+## Pagination Model
+
+Pagination in MCP uses an opaque cursor-based approach, instead of numbered pages.
+
+- The **cursor** is an opaque string token, representing a position in the result set
+- **Page size** is determined by the server, and clients **MUST NOT** assume a fixed page
+  size
+
+## Response Format
+
+Pagination starts when the server sends a **response** that includes:
+
+- The current page of results
+- An optional `nextCursor` field if more results exist
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "123",
+  "result": {
+    "resources": [...],
+    "nextCursor": "eyJwYWdlIjogM30="
+  }
+}
+```
+
+## Request Format
+
+After receiving a cursor, the client can _continue_ paginating by issuing a request
+including that cursor:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "124",
+  "method": "resources/list",
+  "params": {
+    "cursor": "eyJwYWdlIjogMn0="
+  }
+}
+```
+
+## Pagination Flow
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Server
+
+    Client->>Server: List Request (no cursor)
+    loop Pagination Loop
+      Server-->>Client: Page of results + nextCursor
+      Client->>Server: List Request (with cursor)
+    end
+```
+
+## Operations Supporting Pagination
+
+The following MCP operations support pagination:
+
+- `resources/list` - List available resources
+- `resources/templates/list` - List resource templates
+- `prompts/list` - List available prompts
+- `tools/list` - List available tools
+
+## Implementation Guidelines
+
+1. Servers **SHOULD**:
+   - Provide stable cursors
+   - Handle invalid cursors gracefully
+
+2. Clients **SHOULD**:
+   - Treat a missing `nextCursor` as the end of results
+   - Support both paginated and non-paginated flows
+
+3. Clients **MUST** treat cursors as opaque tokens:
+   - Don't make assumptions about cursor format
+   - Don't attempt to parse or modify cursors
+   - Don't persist cursors across sessions
+
+## Error Handling
+
+Invalid cursors **SHOULD** result in an error with code -32602 (Invalid params).

--- a/.agents/skills/mcp-knowledge/references/2025-06-18/ping.md
+++ b/.agents/skills/mcp-knowledge/references/2025-06-18/ping.md
@@ -1,0 +1,63 @@
+<!-- markdownlint-disable -->
+# Ping
+
+The Model Context Protocol includes an optional ping mechanism that allows either party
+to verify that their counterpart is still responsive and the connection is alive.
+
+## Overview
+
+The ping functionality is implemented through a simple request/response pattern. Either
+the client or server can initiate a ping by sending a `ping` request.
+
+## Message Format
+
+A ping request is a standard JSON-RPC request with no parameters:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "123",
+  "method": "ping"
+}
+```
+
+## Behavior Requirements
+
+1. The receiver **MUST** respond promptly with an empty response:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "123",
+  "result": {}
+}
+```
+
+2. If no response is received within a reasonable timeout period, the sender **MAY**:
+   - Consider the connection stale
+   - Terminate the connection
+   - Attempt reconnection procedures
+
+## Usage Patterns
+
+```mermaid
+sequenceDiagram
+    participant Sender
+    participant Receiver
+
+    Sender->>Receiver: ping request
+    Receiver->>Sender: empty response
+```
+
+## Implementation Considerations
+
+- Implementations **SHOULD** periodically issue pings to detect connection health
+- The frequency of pings **SHOULD** be configurable
+- Timeouts **SHOULD** be appropriate for the network environment
+- Excessive pinging **SHOULD** be avoided to reduce network overhead
+
+## Error Handling
+
+- Timeouts **SHOULD** be treated as connection failures
+- Multiple failed pings **MAY** trigger connection reset
+- Implementations **SHOULD** log ping failures for diagnostics

--- a/.agents/skills/mcp-knowledge/references/2025-06-18/progress.md
+++ b/.agents/skills/mcp-knowledge/references/2025-06-18/progress.md
@@ -1,0 +1,87 @@
+<!-- markdownlint-disable -->
+# Progress
+
+The Model Context Protocol (MCP) supports optional progress tracking for long-running
+operations through notification messages. Either side can send progress notifications to
+provide updates about operation status.
+
+## Progress Flow
+
+When a party wants to _receive_ progress updates for a request, it includes a
+`progressToken` in the request metadata.
+
+- Progress tokens **MUST** be a string or integer value
+- Progress tokens can be chosen by the sender using any means, but **MUST** be unique
+  across all active requests.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "some_method",
+  "params": {
+    "_meta": {
+      "progressToken": "abc123"
+    }
+  }
+}
+```
+
+The receiver **MAY** then send progress notifications containing:
+
+- The original progress token
+- The current progress value so far
+- An optional "total" value
+- An optional "message" value
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/progress",
+  "params": {
+    "progressToken": "abc123",
+    "progress": 50,
+    "total": 100,
+    "message": "Reticulating splines..."
+  }
+}
+```
+
+- The `progress` value **MUST** increase with each notification, even if the total is
+  unknown.
+- The `progress` and the `total` values **MAY** be floating point.
+- The `message` field **SHOULD** provide relevant human readable progress information.
+
+## Behavior Requirements
+
+1. Progress notifications **MUST** only reference tokens that:
+   - Were provided in an active request
+   - Are associated with an in-progress operation
+
+2. Receivers of progress requests **MAY**:
+   - Choose not to send any progress notifications
+   - Send notifications at whatever frequency they deem appropriate
+   - Omit the total value if unknown
+
+```mermaid
+sequenceDiagram
+    participant Sender
+    participant Receiver
+
+    Note over Sender,Receiver: Request with progress token
+    Sender->>Receiver: Method request with progressToken
+
+    Note over Sender,Receiver: Progress updates
+    Receiver-->>Sender: Progress notification (0.2/1.0)
+    Receiver-->>Sender: Progress notification (0.6/1.0)
+    Receiver-->>Sender: Progress notification (1.0/1.0)
+
+    Note over Sender,Receiver: Operation complete
+    Receiver->>Sender: Method response
+```
+
+## Implementation Notes
+
+- Senders and receivers **SHOULD** track active progress tokens
+- Both parties **SHOULD** implement rate limiting to prevent flooding
+- Progress notifications **MUST** stop after completion

--- a/.agents/skills/mcp-knowledge/references/2025-06-18/prompts.md
+++ b/.agents/skills/mcp-knowledge/references/2025-06-18/prompts.md
@@ -1,0 +1,274 @@
+<!-- markdownlint-disable -->
+# Prompts
+
+The Model Context Protocol (MCP) provides a standardized way for servers to expose prompt
+templates to clients. Prompts allow servers to provide structured messages and
+instructions for interacting with language models. Clients can discover available
+prompts, retrieve their contents, and provide arguments to customize them.
+
+## User Interaction Model
+
+Prompts are designed to be **user-controlled**, meaning they are exposed from servers to
+clients with the intention of the user being able to explicitly select them for use.
+
+Typically, prompts would be triggered through user-initiated commands in the user
+interface, which allows users to naturally discover and invoke available prompts.
+
+For example, as slash commands:
+
+![Example of prompt exposed as slash command](/specification/2025-06-18/server/slash-command.png)
+
+However, implementors are free to expose prompts through any interface pattern that suits
+their needs&mdash;the protocol itself does not mandate any specific user interaction
+model.
+
+## Capabilities
+
+Servers that support prompts **MUST** declare the `prompts` capability during
+[initialization](/specification/2025-06-18/basic/lifecycle#initialization):
+
+```json
+{
+  "capabilities": {
+    "prompts": {
+      "listChanged": true
+    }
+  }
+}
+```
+
+`listChanged` indicates whether the server will emit notifications when the list of
+available prompts changes.
+
+## Protocol Messages
+
+### Listing Prompts
+
+To retrieve available prompts, clients send a `prompts/list` request. This operation
+supports [pagination](/specification/2025-06-18/server/utilities/pagination).
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "prompts/list",
+  "params": {
+    "cursor": "optional-cursor-value"
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "prompts": [
+      {
+        "name": "code_review",
+        "title": "Request Code Review",
+        "description": "Asks the LLM to analyze code quality and suggest improvements",
+        "arguments": [
+          {
+            "name": "code",
+            "description": "The code to review",
+            "required": true
+          }
+        ]
+      }
+    ],
+    "nextCursor": "next-page-cursor"
+  }
+}
+```
+
+### Getting a Prompt
+
+To retrieve a specific prompt, clients send a `prompts/get` request. Arguments may be
+auto-completed through [the completion API](/specification/2025-06-18/server/utilities/completion).
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "prompts/get",
+  "params": {
+    "name": "code_review",
+    "arguments": {
+      "code": "def hello():\n    print('world')"
+    }
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "description": "Code review prompt",
+    "messages": [
+      {
+        "role": "user",
+        "content": {
+          "type": "text",
+          "text": "Please review this Python code:\ndef hello():\n    print('world')"
+        }
+      }
+    ]
+  }
+}
+```
+
+### List Changed Notification
+
+When the list of available prompts changes, servers that declared the `listChanged`
+capability **SHOULD** send a notification:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/prompts/list_changed"
+}
+```
+
+## Message Flow
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Server
+
+    Note over Client,Server: Discovery
+    Client->>Server: prompts/list
+    Server-->>Client: List of prompts
+
+    Note over Client,Server: Usage
+    Client->>Server: prompts/get
+    Server-->>Client: Prompt content
+
+    opt listChanged
+      Note over Client,Server: Changes
+      Server--)Client: prompts/list_changed
+      Client->>Server: prompts/list
+      Server-->>Client: Updated prompts
+    end
+```
+
+## Data Types
+
+### Prompt
+
+A prompt definition includes:
+
+- `name`: Unique identifier for the prompt
+- `title`: Optional human-readable name of the prompt for display purposes.
+- `description`: Optional human-readable description
+- `arguments`: Optional list of arguments for customization
+
+### PromptMessage
+
+Messages in a prompt can contain:
+
+- `role`: Either "user" or "assistant" to indicate the speaker
+- `content`: One of the following content types:
+
+> **Note:**
+> All content types in prompt messages support optional
+>   [annotations](/specification/2025-06-18/server/resources#annotations) for
+>   metadata about audience, priority, and modification times.
+
+#### Text Content
+
+Text content represents plain text messages:
+
+```json
+{
+  "type": "text",
+  "text": "The text content of the message"
+}
+```
+
+This is the most common content type used for natural language interactions.
+
+#### Image Content
+
+Image content allows including visual information in messages:
+
+```json
+{
+  "type": "image",
+  "data": "base64-encoded-image-data",
+  "mimeType": "image/png"
+}
+```
+
+The image data **MUST** be base64-encoded and include a valid MIME type. This enables
+multi-modal interactions where visual context is important.
+
+#### Audio Content
+
+Audio content allows including audio information in messages:
+
+```json
+{
+  "type": "audio",
+  "data": "base64-encoded-audio-data",
+  "mimeType": "audio/wav"
+}
+```
+
+The audio data MUST be base64-encoded and include a valid MIME type. This enables
+multi-modal interactions where audio context is important.
+
+#### Embedded Resources
+
+Embedded resources allow referencing server-side resources directly in messages:
+
+```json
+{
+  "type": "resource",
+  "resource": {
+    "uri": "resource://example",
+    "mimeType": "text/plain",
+    "text": "Resource content"
+  }
+}
+```
+
+Resources can contain either text or binary (blob) data and **MUST** include:
+
+- A valid resource URI
+- The appropriate MIME type
+- Either text content or base64-encoded blob data
+
+Embedded resources enable prompts to seamlessly incorporate server-managed content like
+documentation, code samples, or other reference materials directly into the conversation
+flow.
+
+## Error Handling
+
+Servers **SHOULD** return standard JSON-RPC errors for common failure cases:
+
+- Invalid prompt name: `-32602` (Invalid params)
+- Missing required arguments: `-32602` (Invalid params)
+- Internal errors: `-32603` (Internal error)
+
+## Implementation Considerations
+
+1. Servers **SHOULD** validate prompt arguments before processing
+2. Clients **SHOULD** handle pagination for large prompt lists
+3. Both parties **SHOULD** respect capability negotiation
+
+## Security
+
+Implementations **MUST** carefully validate all prompt inputs and outputs to prevent
+injection attacks or unauthorized access to resources.

--- a/.agents/skills/mcp-knowledge/references/2025-06-18/resources.md
+++ b/.agents/skills/mcp-knowledge/references/2025-06-18/resources.md
@@ -1,0 +1,399 @@
+<!-- markdownlint-disable -->
+# Resources
+
+The Model Context Protocol (MCP) provides a standardized way for servers to expose
+resources to clients. Resources allow servers to share data that provides context to
+language models, such as files, database schemas, or application-specific information.
+Each resource is uniquely identified by a
+[URI](https://datatracker.ietf.org/doc/html/rfc3986).
+
+## User Interaction Model
+
+Resources in MCP are designed to be **application-driven**, with host applications
+determining how to incorporate context based on their needs.
+
+For example, applications could:
+
+- Expose resources through UI elements for explicit selection, in a tree or list view
+- Allow the user to search through and filter available resources
+- Implement automatic context inclusion, based on heuristics or the AI model's selection
+
+![Example of resource context picker](/specification/2025-06-18/server/resource-picker.png)
+
+However, implementations are free to expose resources through any interface pattern that
+suits their needs&mdash;the protocol itself does not mandate any specific user
+interaction model.
+
+## Capabilities
+
+Servers that support resources **MUST** declare the `resources` capability:
+
+```json
+{
+  "capabilities": {
+    "resources": {
+      "subscribe": true,
+      "listChanged": true
+    }
+  }
+}
+```
+
+The capability supports two optional features:
+
+- `subscribe`: whether the client can subscribe to be notified of changes to individual
+  resources.
+- `listChanged`: whether the server will emit notifications when the list of available
+  resources changes.
+
+Both `subscribe` and `listChanged` are optional&mdash;servers can support neither,
+either, or both:
+
+```json
+{
+  "capabilities": {
+    "resources": {} // Neither feature supported
+  }
+}
+```
+
+```json
+{
+  "capabilities": {
+    "resources": {
+      "subscribe": true // Only subscriptions supported
+    }
+  }
+}
+```
+
+```json
+{
+  "capabilities": {
+    "resources": {
+      "listChanged": true // Only list change notifications supported
+    }
+  }
+}
+```
+
+## Protocol Messages
+
+### Listing Resources
+
+To discover available resources, clients send a `resources/list` request. This operation
+supports [pagination](/specification/2025-06-18/server/utilities/pagination).
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "resources/list",
+  "params": {
+    "cursor": "optional-cursor-value"
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "resources": [
+      {
+        "uri": "file:///project/src/main.rs",
+        "name": "main.rs",
+        "title": "Rust Software Application Main File",
+        "description": "Primary application entry point",
+        "mimeType": "text/x-rust"
+      }
+    ],
+    "nextCursor": "next-page-cursor"
+  }
+}
+```
+
+### Reading Resources
+
+To retrieve resource contents, clients send a `resources/read` request:
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "resources/read",
+  "params": {
+    "uri": "file:///project/src/main.rs"
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "contents": [
+      {
+        "uri": "file:///project/src/main.rs",
+        "mimeType": "text/x-rust",
+        "text": "fn main() {\n    println!(\"Hello world!\");\n}"
+      }
+    ]
+  }
+}
+```
+
+### Resource Templates
+
+Resource templates allow servers to expose parameterized resources using
+[URI templates](https://datatracker.ietf.org/doc/html/rfc6570). Arguments may be
+auto-completed through [the completion API](/specification/2025-06-18/server/utilities/completion).
+This operation supports [pagination](/specification/2025-06-18/server/utilities/pagination).
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "method": "resources/templates/list",
+  "params": {
+    "cursor": "optional-cursor-value"
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "result": {
+    "resourceTemplates": [
+      {
+        "uriTemplate": "file:///{path}",
+        "name": "Project Files",
+        "title": "📁 Project Files",
+        "description": "Access files in the project directory",
+        "mimeType": "application/octet-stream"
+      }
+    ],
+    "nextCursor": "next-page-cursor"
+  }
+}
+```
+
+### List Changed Notification
+
+When the list of available resources changes, servers that declared the `listChanged`
+capability **SHOULD** send a notification:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/resources/list_changed"
+}
+```
+
+### Subscriptions
+
+The protocol supports optional subscriptions to resource changes. Clients can subscribe
+to specific resources and receive notifications when they change:
+
+**Subscribe Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 4,
+  "method": "resources/subscribe",
+  "params": {
+    "uri": "file:///project/src/main.rs"
+  }
+}
+```
+
+**Update Notification:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/resources/updated",
+  "params": {
+    "uri": "file:///project/src/main.rs"
+  }
+}
+```
+
+## Message Flow
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Server
+
+    Note over Client,Server: Resource Discovery
+    Client->>Server: resources/list
+    Server-->>Client: List of resources
+
+    Note over Client,Server: Resource Template Discovery
+    Client->>Server: resources/templates/list
+    Server-->>Client: List of resource templates
+
+    Note over Client,Server: Resource Access
+    Client->>Server: resources/read
+    Server-->>Client: Resource contents
+
+    Note over Client,Server: Subscriptions
+    Client->>Server: resources/subscribe
+    Server-->>Client: Subscription confirmed
+
+    Note over Client,Server: Updates
+    Server--)Client: notifications/resources/updated
+    Client->>Server: resources/read
+    Server-->>Client: Updated contents
+```
+
+## Data Types
+
+### Resource
+
+A resource definition includes:
+
+- `uri`: Unique identifier for the resource
+- `name`: The name of the resource.
+- `title`: Optional human-readable name of the resource for display purposes.
+- `description`: Optional description
+- `mimeType`: Optional MIME type
+- `size`: Optional size in bytes
+
+### Resource Contents
+
+Resources can contain either text or binary data:
+
+#### Text Content
+
+```json
+{
+  "uri": "file:///example.txt",
+  "mimeType": "text/plain",
+  "text": "Resource content"
+}
+```
+
+#### Binary Content
+
+```json
+{
+  "uri": "file:///example.png",
+  "mimeType": "image/png",
+  "blob": "base64-encoded-data"
+}
+```
+
+### Annotations
+
+Resources, resource templates and content blocks support optional annotations that provide hints to clients about how to use or display the resource:
+
+- **`audience`**: An array indicating the intended audience(s) for this resource. Valid values are `"user"` and `"assistant"`. For example, `["user", "assistant"]` indicates content useful for both.
+- **`priority`**: A number from 0.0 to 1.0 indicating the importance of this resource. A value of 1 means "most important" (effectively required), while 0 means "least important" (entirely optional).
+- **`lastModified`**: An ISO 8601 formatted timestamp indicating when the resource was last modified (e.g., `"2025-01-12T15:00:58Z"`).
+
+Example resource with annotations:
+
+```json
+{
+  "uri": "file:///project/README.md",
+  "name": "README.md",
+  "title": "Project Documentation",
+  "mimeType": "text/markdown",
+  "annotations": {
+    "audience": ["user"],
+    "priority": 0.8,
+    "lastModified": "2025-01-12T15:00:58Z"
+  }
+}
+```
+
+Clients can use these annotations to:
+
+- Filter resources based on their intended audience
+- Prioritize which resources to include in context
+- Display modification times or sort by recency
+
+## Common URI Schemes
+
+The protocol defines several standard URI schemes. This list not
+exhaustive&mdash;implementations are always free to use additional, custom URI schemes.
+
+### https://
+
+Used to represent a resource available on the web.
+
+Servers **SHOULD** use this scheme only when the client is able to fetch and load the
+resource directly from the web on its own—that is, it doesn’t need to read the resource
+via the MCP server.
+
+For other use cases, servers **SHOULD** prefer to use another URI scheme, or define a
+custom one, even if the server will itself be downloading resource contents over the
+internet.
+
+### file://
+
+Used to identify resources that behave like a filesystem. However, the resources do not
+need to map to an actual physical filesystem.
+
+MCP servers **MAY** identify file:// resources with an
+[XDG MIME type](https://specifications.freedesktop.org/shared-mime-info-spec/0.14/ar01s02.html#id-1.3.14),
+like `inode/directory`, to represent non-regular files (such as directories) that don’t
+otherwise have a standard MIME type.
+
+### git://
+
+Git version control integration.
+
+### Custom URI Schemes
+
+Custom URI schemes **MUST** be in accordance with [RFC3986](https://datatracker.ietf.org/doc/html/rfc3986),
+taking the above guidance in to account.
+
+## Error Handling
+
+Servers **SHOULD** return standard JSON-RPC errors for common failure cases:
+
+- Resource not found: `-32002`
+- Internal errors: `-32603`
+
+Example error:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 5,
+  "error": {
+    "code": -32002,
+    "message": "Resource not found",
+    "data": {
+      "uri": "file:///nonexistent.txt"
+    }
+  }
+}
+```
+
+## Security Considerations
+
+1. Servers **MUST** validate all resource URIs
+2. Access controls **SHOULD** be implemented for sensitive resources
+3. Binary data **MUST** be properly encoded
+4. Resource permissions **SHOULD** be checked before operations

--- a/.agents/skills/mcp-knowledge/references/2025-06-18/roots.md
+++ b/.agents/skills/mcp-knowledge/references/2025-06-18/roots.md
@@ -1,0 +1,185 @@
+<!-- markdownlint-disable -->
+# Roots
+
+The Model Context Protocol (MCP) provides a standardized way for clients to expose
+filesystem "roots" to servers. Roots define the boundaries of where servers can operate
+within the filesystem, allowing them to understand which directories and files they have
+access to. Servers can request the list of roots from supporting clients and receive
+notifications when that list changes.
+
+## User Interaction Model
+
+Roots in MCP are typically exposed through workspace or project configuration interfaces.
+
+For example, implementations could offer a workspace/project picker that allows users to
+select directories and files the server should have access to. This can be combined with
+automatic workspace detection from version control systems or project files.
+
+However, implementations are free to expose roots through any interface pattern that
+suits their needs&mdash;the protocol itself does not mandate any specific user
+interaction model.
+
+## Capabilities
+
+Clients that support roots **MUST** declare the `roots` capability during
+[initialization](/specification/2025-06-18/basic/lifecycle#initialization):
+
+```json
+{
+  "capabilities": {
+    "roots": {
+      "listChanged": true
+    }
+  }
+}
+```
+
+`listChanged` indicates whether the client will emit notifications when the list of roots
+changes.
+
+## Protocol Messages
+
+### Listing Roots
+
+To retrieve roots, servers send a `roots/list` request:
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "roots/list"
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "roots": [
+      {
+        "uri": "file:///home/user/projects/myproject",
+        "name": "My Project"
+      }
+    ]
+  }
+}
+```
+
+### Root List Changes
+
+When roots change, clients that support `listChanged` **MUST** send a notification:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/roots/list_changed"
+}
+```
+
+## Message Flow
+
+```mermaid
+sequenceDiagram
+    participant Server
+    participant Client
+
+    Note over Server,Client: Discovery
+    Server->>Client: roots/list
+    Client-->>Server: Available roots
+
+    Note over Server,Client: Changes
+    Client--)Server: notifications/roots/list_changed
+    Server->>Client: roots/list
+    Client-->>Server: Updated roots
+```
+
+## Data Types
+
+### Root
+
+A root definition includes:
+
+- `uri`: Unique identifier for the root. This **MUST** be a `file://` URI in the current
+  specification.
+- `name`: Optional human-readable name for display purposes.
+
+Example roots for different use cases:
+
+#### Project Directory
+
+```json
+{
+  "uri": "file:///home/user/projects/myproject",
+  "name": "My Project"
+}
+```
+
+#### Multiple Repositories
+
+```json
+[
+  {
+    "uri": "file:///home/user/repos/frontend",
+    "name": "Frontend Repository"
+  },
+  {
+    "uri": "file:///home/user/repos/backend",
+    "name": "Backend Repository"
+  }
+]
+```
+
+## Error Handling
+
+Clients **SHOULD** return standard JSON-RPC errors for common failure cases:
+
+- Client does not support roots: `-32601` (Method not found)
+- Internal errors: `-32603`
+
+Example error:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "error": {
+    "code": -32601,
+    "message": "Roots not supported",
+    "data": {
+      "reason": "Client does not have roots capability"
+    }
+  }
+}
+```
+
+## Security Considerations
+
+1. Clients **MUST**:
+   - Only expose roots with appropriate permissions
+   - Validate all root URIs to prevent path traversal
+   - Implement proper access controls
+   - Monitor root accessibility
+
+2. Servers **SHOULD**:
+   - Handle cases where roots become unavailable
+   - Respect root boundaries during operations
+   - Validate all paths against provided roots
+
+## Implementation Guidelines
+
+1. Clients **SHOULD**:
+   - Prompt users for consent before exposing roots to servers
+   - Provide clear user interfaces for root management
+   - Validate root accessibility before exposing
+   - Monitor for root changes
+
+2. Servers **SHOULD**:
+   - Check for roots capability before usage
+   - Handle root list changes gracefully
+   - Respect root boundaries in operations
+   - Cache root information appropriately

--- a/.agents/skills/mcp-knowledge/references/2025-06-18/sampling.md
+++ b/.agents/skills/mcp-knowledge/references/2025-06-18/sampling.md
@@ -1,0 +1,232 @@
+<!-- markdownlint-disable -->
+# Sampling
+
+The Model Context Protocol (MCP) provides a standardized way for servers to request LLM
+sampling ("completions" or "generations") from language models via clients. This flow
+allows clients to maintain control over model access, selection, and permissions while
+enabling servers to leverage AI capabilities&mdash;with no server API keys necessary.
+Servers can request text, audio, or image-based interactions and optionally include
+context from MCP servers in their prompts.
+
+## User Interaction Model
+
+Sampling in MCP allows servers to implement agentic behaviors, by enabling LLM calls to
+occur _nested_ inside other MCP server features.
+
+Implementations are free to expose sampling through any interface pattern that suits
+their needs&mdash;the protocol itself does not mandate any specific user interaction
+model.
+
+> **Warning:**
+> For trust & safety and security, there **SHOULD** always
+> be a human in the loop with the ability to deny sampling requests.
+>
+> Applications **SHOULD**:
+>
+> - Provide UI that makes it easy and intuitive to review sampling requests
+> - Allow users to view and edit prompts before sending
+> - Present generated responses for review before delivery
+
+## Capabilities
+
+Clients that support sampling **MUST** declare the `sampling` capability during
+[initialization](/specification/2025-06-18/basic/lifecycle#initialization):
+
+```json
+{
+  "capabilities": {
+    "sampling": {}
+  }
+}
+```
+
+## Protocol Messages
+
+### Creating Messages
+
+To request a language model generation, servers send a `sampling/createMessage` request:
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "sampling/createMessage",
+  "params": {
+    "messages": [
+      {
+        "role": "user",
+        "content": {
+          "type": "text",
+          "text": "What is the capital of France?"
+        }
+      }
+    ],
+    "modelPreferences": {
+      "hints": [
+        {
+          "name": "claude-3-sonnet"
+        }
+      ],
+      "intelligencePriority": 0.8,
+      "speedPriority": 0.5
+    },
+    "systemPrompt": "You are a helpful assistant.",
+    "maxTokens": 100
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "role": "assistant",
+    "content": {
+      "type": "text",
+      "text": "The capital of France is Paris."
+    },
+    "model": "claude-3-sonnet-20240307",
+    "stopReason": "endTurn"
+  }
+}
+```
+
+## Message Flow
+
+```mermaid
+sequenceDiagram
+    participant Server
+    participant Client
+    participant User
+    participant LLM
+
+    Note over Server,Client: Server initiates sampling
+    Server->>Client: sampling/createMessage
+
+    Note over Client,User: Human-in-the-loop review
+    Client->>User: Present request for approval
+    User-->>Client: Review and approve/modify
+
+    Note over Client,LLM: Model interaction
+    Client->>LLM: Forward approved request
+    LLM-->>Client: Return generation
+
+    Note over Client,User: Response review
+    Client->>User: Present response for approval
+    User-->>Client: Review and approve/modify
+
+    Note over Server,Client: Complete request
+    Client-->>Server: Return approved response
+```
+
+## Data Types
+
+### Messages
+
+Sampling messages can contain:
+
+#### Text Content
+
+```json
+{
+  "type": "text",
+  "text": "The message content"
+}
+```
+
+#### Image Content
+
+```json
+{
+  "type": "image",
+  "data": "base64-encoded-image-data",
+  "mimeType": "image/jpeg"
+}
+```
+
+#### Audio Content
+
+```json
+{
+  "type": "audio",
+  "data": "base64-encoded-audio-data",
+  "mimeType": "audio/wav"
+}
+```
+
+### Model Preferences
+
+Model selection in MCP requires careful abstraction since servers and clients may use
+different AI providers with distinct model offerings. A server cannot simply request a
+specific model by name since the client may not have access to that exact model or may
+prefer to use a different provider's equivalent model.
+
+To solve this, MCP implements a preference system that combines abstract capability
+priorities with optional model hints:
+
+#### Capability Priorities
+
+Servers express their needs through three normalized priority values (0-1):
+
+- `costPriority`: How important is minimizing costs? Higher values prefer cheaper models.
+- `speedPriority`: How important is low latency? Higher values prefer faster models.
+- `intelligencePriority`: How important are advanced capabilities? Higher values prefer
+  more capable models.
+
+#### Model Hints
+
+While priorities help select models based on characteristics, `hints` allow servers to
+suggest specific models or model families:
+
+- Hints are treated as substrings that can match model names flexibly
+- Multiple hints are evaluated in order of preference
+- Clients **MAY** map hints to equivalent models from different providers
+- Hints are advisory&mdash;clients make final model selection
+
+For example:
+
+```json
+{
+  "hints": [
+    { "name": "claude-3-sonnet" }, // Prefer Sonnet-class models
+    { "name": "claude" } // Fall back to any Claude model
+  ],
+  "costPriority": 0.3, // Cost is less important
+  "speedPriority": 0.8, // Speed is very important
+  "intelligencePriority": 0.5 // Moderate capability needs
+}
+```
+
+The client processes these preferences to select an appropriate model from its available
+options. For instance, if the client doesn't have access to Claude models but has Gemini,
+it might map the sonnet hint to `gemini-1.5-pro` based on similar capabilities.
+
+## Error Handling
+
+Clients **SHOULD** return errors for common failure cases:
+
+Example error:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "error": {
+    "code": -1,
+    "message": "User rejected sampling request"
+  }
+}
+```
+
+## Security Considerations
+
+1. Clients **SHOULD** implement user approval controls
+2. Both parties **SHOULD** validate message content
+3. Clients **SHOULD** respect model preference hints
+4. Clients **SHOULD** implement rate limiting
+5. Both parties **MUST** handle sensitive data appropriately

--- a/.agents/skills/mcp-knowledge/references/2025-06-18/tools.md
+++ b/.agents/skills/mcp-knowledge/references/2025-06-18/tools.md
@@ -1,0 +1,426 @@
+<!-- markdownlint-disable -->
+# Tools
+
+The Model Context Protocol (MCP) allows servers to expose tools that can be invoked by
+language models. Tools enable models to interact with external systems, such as querying
+databases, calling APIs, or performing computations. Each tool is uniquely identified by
+a name and includes metadata describing its schema.
+
+## User Interaction Model
+
+Tools in MCP are designed to be **model-controlled**, meaning that the language model can
+discover and invoke tools automatically based on its contextual understanding and the
+user's prompts.
+
+However, implementations are free to expose tools through any interface pattern that
+suits their needs&mdash;the protocol itself does not mandate any specific user
+interaction model.
+
+> **Warning:**
+> For trust & safety and security, there **SHOULD** always
+> be a human in the loop with the ability to deny tool invocations.
+>
+> Applications **SHOULD**:
+>
+> - Provide UI that makes clear which tools are being exposed to the AI model
+> - Insert clear visual indicators when tools are invoked
+> - Present confirmation prompts to the user for operations, to ensure a human is in the
+>   loop
+
+## Capabilities
+
+Servers that support tools **MUST** declare the `tools` capability:
+
+```json
+{
+  "capabilities": {
+    "tools": {
+      "listChanged": true
+    }
+  }
+}
+```
+
+`listChanged` indicates whether the server will emit notifications when the list of
+available tools changes.
+
+## Protocol Messages
+
+### Listing Tools
+
+To discover available tools, clients send a `tools/list` request. This operation supports
+[pagination](/specification/2025-06-18/server/utilities/pagination).
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/list",
+  "params": {
+    "cursor": "optional-cursor-value"
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "tools": [
+      {
+        "name": "get_weather",
+        "title": "Weather Information Provider",
+        "description": "Get current weather information for a location",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "location": {
+              "type": "string",
+              "description": "City name or zip code"
+            }
+          },
+          "required": ["location"]
+        }
+      }
+    ],
+    "nextCursor": "next-page-cursor"
+  }
+}
+```
+
+### Calling Tools
+
+To invoke a tool, clients send a `tools/call` request:
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "tools/call",
+  "params": {
+    "name": "get_weather",
+    "arguments": {
+      "location": "New York"
+    }
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "Current weather in New York:\nTemperature: 72°F\nConditions: Partly cloudy"
+      }
+    ],
+    "isError": false
+  }
+}
+```
+
+### List Changed Notification
+
+When the list of available tools changes, servers that declared the `listChanged`
+capability **SHOULD** send a notification:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/tools/list_changed"
+}
+```
+
+## Message Flow
+
+```mermaid
+sequenceDiagram
+    participant LLM
+    participant Client
+    participant Server
+
+    Note over Client,Server: Discovery
+    Client->>Server: tools/list
+    Server-->>Client: List of tools
+
+    Note over Client,LLM: Tool Selection
+    LLM->>Client: Select tool to use
+
+    Note over Client,Server: Invocation
+    Client->>Server: tools/call
+    Server-->>Client: Tool result
+    Client->>LLM: Process result
+
+    Note over Client,Server: Updates
+    Server--)Client: tools/list_changed
+    Client->>Server: tools/list
+    Server-->>Client: Updated tools
+```
+
+## Data Types
+
+### Tool
+
+A tool definition includes:
+
+- `name`: Unique identifier for the tool
+- `title`: Optional human-readable name of the tool for display purposes.
+- `description`: Human-readable description of functionality
+- `inputSchema`: JSON Schema defining expected parameters
+- `outputSchema`: Optional JSON Schema defining expected output structure
+- `annotations`: optional properties describing tool behavior
+
+> **Warning:**
+> For trust & safety and security, clients **MUST** consider
+> tool annotations to be untrusted unless they come from trusted servers.
+
+### Tool Result
+
+Tool results may contain [**structured**](#structured-content) or **unstructured** content.
+
+**Unstructured** content is returned in the `content` field of a result, and can contain multiple content items of different types:
+
+> **Note:**
+> All content types (text, image, audio, resource links, and embedded resources)
+>   support optional
+>   [annotations](/specification/2025-06-18/server/resources#annotations) that
+>   provide metadata about audience, priority, and modification times. This is the
+>   same annotation format used by resources and prompts.
+
+#### Text Content
+
+```json
+{
+  "type": "text",
+  "text": "Tool result text"
+}
+```
+
+#### Image Content
+
+```json
+{
+  "type": "image",
+  "data": "base64-encoded-data",
+  "mimeType": "image/png"
+  "annotations": {
+    "audience": ["user"],
+    "priority": 0.9
+  }
+
+}
+```
+
+This example demonstrates the use of an optional Annotation.
+
+#### Audio Content
+
+```json
+{
+  "type": "audio",
+  "data": "base64-encoded-audio-data",
+  "mimeType": "audio/wav"
+}
+```
+
+#### Resource Links
+
+A tool **MAY** return links to [Resources](/specification/2025-06-18/server/resources), to provide additional context
+or data. In this case, the tool will return a URI that can be subscribed to or fetched by the client:
+
+```json
+{
+  "type": "resource_link",
+  "uri": "file:///project/src/main.rs",
+  "name": "main.rs",
+  "description": "Primary application entry point",
+  "mimeType": "text/x-rust",
+  "annotations": {
+    "audience": ["assistant"],
+    "priority": 0.9
+  }
+}
+```
+
+Resource links support the same [Resource annotations](/specification/2025-06-18/server/resources#annotations) as regular resources to help clients understand how to use them.
+
+> **Info:**
+> Resource links returned by tools are not guaranteed to appear in the results
+>   of a `resources/list` request.
+
+#### Embedded Resources
+
+[Resources](/specification/2025-06-18/server/resources) **MAY** be embedded to provide additional context
+or data using a suitable [URI scheme](./resources#common-uri-schemes). Servers that use embedded resources **SHOULD** implement the `resources` capability:
+
+```json
+{
+  "type": "resource",
+  "resource": {
+    "uri": "file:///project/src/main.rs",
+    "mimeType": "text/x-rust",
+    "text": "fn main() {\n    println!(\"Hello world!\");\n}",
+    "annotations": {
+      "audience": ["user", "assistant"],
+      "priority": 0.7,
+      "lastModified": "2025-05-03T14:30:00Z"
+    }
+  }
+}
+```
+
+Embedded resources support the same [Resource annotations](/specification/2025-06-18/server/resources#annotations) as regular resources to help clients understand how to use them.
+
+#### Structured Content
+
+**Structured** content is returned as a JSON object in the `structuredContent` field of a result.
+
+For backwards compatibility, a tool that returns structured content SHOULD also return the serialized JSON in a TextContent block.
+
+#### Output Schema
+
+Tools may also provide an output schema for validation of structured results.
+If an output schema is provided:
+
+- Servers **MUST** provide structured results that conform to this schema.
+- Clients **SHOULD** validate structured results against this schema.
+
+Example tool with output schema:
+
+```json
+{
+  "name": "get_weather_data",
+  "title": "Weather Data Retriever",
+  "description": "Get current weather data for a location",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "location": {
+        "type": "string",
+        "description": "City name or zip code"
+      }
+    },
+    "required": ["location"]
+  },
+  "outputSchema": {
+    "type": "object",
+    "properties": {
+      "temperature": {
+        "type": "number",
+        "description": "Temperature in celsius"
+      },
+      "conditions": {
+        "type": "string",
+        "description": "Weather conditions description"
+      },
+      "humidity": {
+        "type": "number",
+        "description": "Humidity percentage"
+      }
+    },
+    "required": ["temperature", "conditions", "humidity"]
+  }
+}
+```
+
+Example valid response for this tool:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 5,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "{\"temperature\": 22.5, \"conditions\": \"Partly cloudy\", \"humidity\": 65}"
+      }
+    ],
+    "structuredContent": {
+      "temperature": 22.5,
+      "conditions": "Partly cloudy",
+      "humidity": 65
+    }
+  }
+}
+```
+
+Providing an output schema helps clients and LLMs understand and properly handle structured tool outputs by:
+
+- Enabling strict schema validation of responses
+- Providing type information for better integration with programming languages
+- Guiding clients and LLMs to properly parse and utilize the returned data
+- Supporting better documentation and developer experience
+
+## Error Handling
+
+Tools use two error reporting mechanisms:
+
+1. **Protocol Errors**: Standard JSON-RPC errors for issues like:
+   - Unknown tools
+   - Invalid arguments
+   - Server errors
+
+2. **Tool Execution Errors**: Reported in tool results with `isError: true`:
+   - API failures
+   - Invalid input data
+   - Business logic errors
+
+Example protocol error:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "error": {
+    "code": -32602,
+    "message": "Unknown tool: invalid_tool_name"
+  }
+}
+```
+
+Example tool execution error:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 4,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "Failed to fetch weather data: API rate limit exceeded"
+      }
+    ],
+    "isError": true
+  }
+}
+```
+
+## Security Considerations
+
+1. Servers **MUST**:
+   - Validate all tool inputs
+   - Implement proper access controls
+   - Rate limit tool invocations
+   - Sanitize tool outputs
+
+2. Clients **SHOULD**:
+   - Prompt for user confirmation on sensitive operations
+   - Show tool inputs to the user before calling the server, to avoid malicious or
+     accidental data exfiltration
+   - Validate tool results before passing to LLM
+   - Implement timeouts for tool calls
+   - Log tool usage for audit purposes

--- a/.agents/skills/mcp-knowledge/references/2025-06-18/transports.md
+++ b/.agents/skills/mcp-knowledge/references/2025-06-18/transports.md
@@ -1,0 +1,291 @@
+<!-- markdownlint-disable -->
+# Transports
+
+MCP uses JSON-RPC to encode messages. JSON-RPC messages **MUST** be UTF-8 encoded.
+
+The protocol currently defines two standard transport mechanisms for client-server
+communication:
+
+1. [stdio](#stdio), communication over standard in and standard out
+2. [Streamable HTTP](#streamable-http)
+
+Clients **SHOULD** support stdio whenever possible.
+
+It is also possible for clients and servers to implement
+[custom transports](#custom-transports) in a pluggable fashion.
+
+## stdio
+
+In the **stdio** transport:
+
+- The client launches the MCP server as a subprocess.
+- The server reads JSON-RPC messages from its standard input (`stdin`) and sends messages
+  to its standard output (`stdout`).
+- Messages are individual JSON-RPC requests, notifications, or responses.
+- Messages are delimited by newlines, and **MUST NOT** contain embedded newlines.
+- The server **MAY** write UTF-8 strings to its standard error (`stderr`) for logging
+  purposes. Clients **MAY** capture, forward, or ignore this logging.
+- The server **MUST NOT** write anything to its `stdout` that is not a valid MCP message.
+- The client **MUST NOT** write anything to the server's `stdin` that is not a valid MCP
+  message.
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Server Process
+
+    Client->>+Server Process: Launch subprocess
+    loop Message Exchange
+        Client->>Server Process: Write to stdin
+        Server Process->>Client: Write to stdout
+        Server Process--)Client: Optional logs on stderr
+    end
+    Client->>Server Process: Close stdin, terminate subprocess
+    deactivate Server Process
+```
+
+## Streamable HTTP
+
+> **Info:**
+> This replaces the [HTTP+SSE
+> transport](/specification/2024-11-05/basic/transports#http-with-sse) from
+> protocol version 2024-11-05. See the [backwards compatibility](#backwards-compatibility)
+> guide below.
+
+In the **Streamable HTTP** transport, the server operates as an independent process that
+can handle multiple client connections. This transport uses HTTP POST and GET requests.
+Server can optionally make use of
+[Server-Sent Events](https://en.wikipedia.org/wiki/Server-sent_events) (SSE) to stream
+multiple server messages. This permits basic MCP servers, as well as more feature-rich
+servers supporting streaming and server-to-client notifications and requests.
+
+The server **MUST** provide a single HTTP endpoint path (hereafter referred to as the
+**MCP endpoint**) that supports both POST and GET methods. For example, this could be a
+URL like `https://example.com/mcp`.
+
+#### Security Warning
+
+When implementing Streamable HTTP transport:
+
+1. Servers **MUST** validate the `Origin` header on all incoming connections to prevent DNS rebinding attacks
+2. When running locally, servers **SHOULD** bind only to localhost (127.0.0.1) rather than all network interfaces (0.0.0.0)
+3. Servers **SHOULD** implement proper authentication for all connections
+
+Without these protections, attackers could use DNS rebinding to interact with local MCP servers from remote websites.
+
+### Sending Messages to the Server
+
+Every JSON-RPC message sent from the client **MUST** be a new HTTP POST request to the
+MCP endpoint.
+
+1. The client **MUST** use HTTP POST to send JSON-RPC messages to the MCP endpoint.
+2. The client **MUST** include an `Accept` header, listing both `application/json` and
+   `text/event-stream` as supported content types.
+3. The body of the POST request **MUST** be a single JSON-RPC _request_, _notification_, or _response_.
+4. If the input is a JSON-RPC _response_ or _notification_:
+   - If the server accepts the input, the server **MUST** return HTTP status code 202
+     Accepted with no body.
+   - If the server cannot accept the input, it **MUST** return an HTTP error status code
+     (e.g., 400 Bad Request). The HTTP response body **MAY** comprise a JSON-RPC _error
+     response_ that has no `id`.
+5. If the input is a JSON-RPC _request_, the server **MUST** either
+   return `Content-Type: text/event-stream`, to initiate an SSE stream, or
+   `Content-Type: application/json`, to return one JSON object. The client **MUST**
+   support both these cases.
+6. If the server initiates an SSE stream:
+   - The SSE stream **SHOULD** eventually include JSON-RPC _response_ for the
+     JSON-RPC _request_ sent in the POST body.
+   - The server **MAY** send JSON-RPC _requests_ and _notifications_ before sending the
+     JSON-RPC _response_. These messages **SHOULD** relate to the originating client
+     _request_.
+   - The server **SHOULD NOT** close the SSE stream before sending the JSON-RPC _response_
+     for the received JSON-RPC _request_, unless the [session](#session-management)
+     expires.
+   - After the JSON-RPC _response_ has been sent, the server **SHOULD** close the SSE
+     stream.
+   - Disconnection **MAY** occur at any time (e.g., due to network conditions).
+     Therefore:
+     - Disconnection **SHOULD NOT** be interpreted as the client cancelling its request.
+     - To cancel, the client **SHOULD** explicitly send an MCP `CancelledNotification`.
+     - To avoid message loss due to disconnection, the server **MAY** make the stream
+       [resumable](#resumability-and-redelivery).
+
+### Listening for Messages from the Server
+
+1. The client **MAY** issue an HTTP GET to the MCP endpoint. This can be used to open an
+   SSE stream, allowing the server to communicate to the client, without the client first
+   sending data via HTTP POST.
+2. The client **MUST** include an `Accept` header, listing `text/event-stream` as a
+   supported content type.
+3. The server **MUST** either return `Content-Type: text/event-stream` in response to
+   this HTTP GET, or else return HTTP 405 Method Not Allowed, indicating that the server
+   does not offer an SSE stream at this endpoint.
+4. If the server initiates an SSE stream:
+   - The server **MAY** send JSON-RPC _requests_ and _notifications_ on the stream.
+   - These messages **SHOULD** be unrelated to any concurrently-running JSON-RPC
+     _request_ from the client.
+   - The server **MUST NOT** send a JSON-RPC _response_ on the stream **unless**
+     [resuming](#resumability-and-redelivery) a stream associated with a previous client
+     request.
+   - The server **MAY** close the SSE stream at any time.
+   - The client **MAY** close the SSE stream at any time.
+
+### Multiple Connections
+
+1. The client **MAY** remain connected to multiple SSE streams simultaneously.
+2. The server **MUST** send each of its JSON-RPC messages on only one of the connected
+   streams; that is, it **MUST NOT** broadcast the same message across multiple streams.
+   - The risk of message loss **MAY** be mitigated by making the stream
+     [resumable](#resumability-and-redelivery).
+
+### Resumability and Redelivery
+
+To support resuming broken connections, and redelivering messages that might otherwise be
+lost:
+
+1. Servers **MAY** attach an `id` field to their SSE events, as described in the
+   [SSE standard](https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation).
+   - If present, the ID **MUST** be globally unique across all streams within that
+     [session](#session-management)—or all streams with that specific client, if session
+     management is not in use.
+2. If the client wishes to resume after a broken connection, it **SHOULD** issue an HTTP
+   GET to the MCP endpoint, and include the
+   [`Last-Event-ID`](https://html.spec.whatwg.org/multipage/server-sent-events.html#the-last-event-id-header)
+   header to indicate the last event ID it received.
+   - The server **MAY** use this header to replay messages that would have been sent
+     after the last event ID, _on the stream that was disconnected_, and to resume the
+     stream from that point.
+   - The server **MUST NOT** replay messages that would have been delivered on a
+     different stream.
+
+In other words, these event IDs should be assigned by servers on a _per-stream_ basis, to
+act as a cursor within that particular stream.
+
+### Session Management
+
+An MCP "session" consists of logically related interactions between a client and a
+server, beginning with the [initialization phase](/specification/2025-06-18/basic/lifecycle). To support
+servers which want to establish stateful sessions:
+
+1. A server using the Streamable HTTP transport **MAY** assign a session ID at
+   initialization time, by including it in an `Mcp-Session-Id` header on the HTTP
+   response containing the `InitializeResult`.
+   - The session ID **SHOULD** be globally unique and cryptographically secure (e.g., a
+     securely generated UUID, a JWT, or a cryptographic hash).
+   - The session ID **MUST** only contain visible ASCII characters (ranging from 0x21 to
+     0x7E).
+2. If an `Mcp-Session-Id` is returned by the server during initialization, clients using
+   the Streamable HTTP transport **MUST** include it in the `Mcp-Session-Id` header on
+   all of their subsequent HTTP requests.
+   - Servers that require a session ID **SHOULD** respond to requests without an
+     `Mcp-Session-Id` header (other than initialization) with HTTP 400 Bad Request.
+3. The server **MAY** terminate the session at any time, after which it **MUST** respond
+   to requests containing that session ID with HTTP 404 Not Found.
+4. When a client receives HTTP 404 in response to a request containing an
+   `Mcp-Session-Id`, it **MUST** start a new session by sending a new `InitializeRequest`
+   without a session ID attached.
+5. Clients that no longer need a particular session (e.g., because the user is leaving
+   the client application) **SHOULD** send an HTTP DELETE to the MCP endpoint with the
+   `Mcp-Session-Id` header, to explicitly terminate the session.
+   - The server **MAY** respond to this request with HTTP 405 Method Not Allowed,
+     indicating that the server does not allow clients to terminate sessions.
+
+### Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Server
+
+    note over Client, Server: initialization
+
+    Client->>+Server: POST InitializeRequest
+    Server->>-Client: InitializeResponse<br>Mcp-Session-Id: 1868a90c...
+
+    Client->>+Server: POST InitializedNotification<br>Mcp-Session-Id: 1868a90c...
+    Server->>-Client: 202 Accepted
+
+    note over Client, Server: client requests
+    Client->>+Server: POST ... request ...<br>Mcp-Session-Id: 1868a90c...
+
+    alt single HTTP response
+      Server->>Client: ... response ...
+    else server opens SSE stream
+      loop while connection remains open
+          Server-)Client: ... SSE messages from server ...
+      end
+      Server-)Client: SSE event: ... response ...
+    end
+    deactivate Server
+
+    note over Client, Server: client notifications/responses
+    Client->>+Server: POST ... notification/response ...<br>Mcp-Session-Id: 1868a90c...
+    Server->>-Client: 202 Accepted
+
+    note over Client, Server: server requests
+    Client->>+Server: GET<br>Mcp-Session-Id: 1868a90c...
+    loop while connection remains open
+        Server-)Client: ... SSE messages from server ...
+    end
+    deactivate Server
+
+```
+
+### Protocol Version Header
+
+If using HTTP, the client **MUST** include the `MCP-Protocol-Version:
+<protocol-version>` HTTP header on all subsequent requests to the MCP
+server, allowing the MCP server to respond based on the MCP protocol version.
+
+For example: `MCP-Protocol-Version: 2025-06-18`
+
+The protocol version sent by the client **SHOULD** be the one [negotiated during
+initialization](/specification/2025-06-18/basic/lifecycle#version-negotiation).
+
+For backwards compatibility, if the server does _not_ receive an `MCP-Protocol-Version`
+header, and has no other way to identify the version - for example, by relying on the
+protocol version negotiated during initialization - the server **SHOULD** assume protocol
+version `2025-03-26`.
+
+If the server receives a request with an invalid or unsupported
+`MCP-Protocol-Version`, it **MUST** respond with `400 Bad Request`.
+
+### Backwards Compatibility
+
+Clients and servers can maintain backwards compatibility with the deprecated [HTTP+SSE
+transport](/specification/2024-11-05/basic/transports#http-with-sse) (from
+protocol version 2024-11-05) as follows:
+
+**Servers** wanting to support older clients should:
+
+- Continue to host both the SSE and POST endpoints of the old transport, alongside the
+  new "MCP endpoint" defined for the Streamable HTTP transport.
+  - It is also possible to combine the old POST endpoint and the new MCP endpoint, but
+    this may introduce unneeded complexity.
+
+**Clients** wanting to support older servers should:
+
+1. Accept an MCP server URL from the user, which may point to either a server using the
+   old transport or the new transport.
+2. Attempt to POST an `InitializeRequest` to the server URL, with an `Accept` header as
+   defined above:
+   - If it succeeds, the client can assume this is a server supporting the new Streamable
+     HTTP transport.
+   - If it fails with an HTTP 4xx status code (e.g., 405 Method Not Allowed or 404 Not
+     Found):
+     - Issue a GET request to the server URL, expecting that this will open an SSE stream
+       and return an `endpoint` event as the first event.
+     - When the `endpoint` event arrives, the client can assume this is a server running
+       the old HTTP+SSE transport, and should use that transport for all subsequent
+       communication.
+
+## Custom Transports
+
+Clients and servers **MAY** implement additional custom transport mechanisms to suit
+their specific needs. The protocol is transport-agnostic and can be implemented over any
+communication channel that supports bidirectional message exchange.
+
+Implementers who choose to support custom transports **MUST** ensure they preserve the
+JSON-RPC message format and lifecycle requirements defined by MCP. Custom transports
+**SHOULD** document their specific connection establishment and message exchange patterns
+to aid interoperability.

--- a/.agents/skills/mcp-knowledge/references/2025-11-25/architecture.md
+++ b/.agents/skills/mcp-knowledge/references/2025-11-25/architecture.md
@@ -1,0 +1,171 @@
+<!-- markdownlint-disable -->
+# Architecture
+
+The Model Context Protocol (MCP) follows a client-host-server architecture where each
+host can run multiple client instances. This architecture enables users to integrate AI
+capabilities across applications while maintaining clear security boundaries and
+isolating concerns. Built on JSON-RPC, MCP provides a stateful session protocol focused
+on context exchange and sampling coordination between clients and servers.
+
+## Core Components
+
+```mermaid
+graph LR
+    subgraph "Application Host Process"
+        H[Host]
+        C1[Client 1]
+        C2[Client 2]
+        C3[Client 3]
+        H --> C1
+        H --> C2
+        H --> C3
+    end
+
+    subgraph "Local machine"
+        S1[Server 1<br>Files & Git]
+        S2[Server 2<br>Database]
+        R1[("Local<br>Resource A")]
+        R2[("Local<br>Resource B")]
+
+        C1 --> S1
+        C2 --> S2
+        S1 <--> R1
+        S2 <--> R2
+    end
+
+    subgraph "Internet"
+        S3[Server 3<br>External APIs]
+        R3[("Remote<br>Resource C")]
+
+        C3 --> S3
+        S3 <--> R3
+    end
+```
+
+### Host
+
+The host process acts as the container and coordinator:
+
+- Creates and manages multiple client instances
+- Controls client connection permissions and lifecycle
+- Enforces security policies and consent requirements
+- Handles user authorization decisions
+- Coordinates AI/LLM integration and sampling
+- Manages context aggregation across clients
+
+### Clients
+
+Each client is created by the host and maintains an isolated server connection:
+
+- Establishes one stateful session per server
+- Handles protocol negotiation and capability exchange
+- Routes protocol messages bidirectionally
+- Manages subscriptions and notifications
+- Maintains security boundaries between servers
+
+A host application creates and manages multiple clients, with each client having a 1:1
+relationship with a particular server.
+
+### Servers
+
+Servers provide specialized context and capabilities:
+
+- Expose resources, tools and prompts via MCP primitives
+- Operate independently with focused responsibilities
+- Request sampling through client interfaces
+- Must respect security constraints
+- Can be local processes or remote services
+
+## Design Principles
+
+MCP is built on several key design principles that inform its architecture and
+implementation:
+
+1. **Servers should be extremely easy to build**
+   - Host applications handle complex orchestration responsibilities
+   - Servers focus on specific, well-defined capabilities
+   - Simple interfaces minimize implementation overhead
+   - Clear separation enables maintainable code
+
+2. **Servers should be highly composable**
+   - Each server provides focused functionality in isolation
+   - Multiple servers can be combined seamlessly
+   - Shared protocol enables interoperability
+   - Modular design supports extensibility
+
+3. **Servers should not be able to read the whole conversation, nor "see into" other
+   servers**
+   - Servers receive only necessary contextual information
+   - Full conversation history stays with the host
+   - Each server connection maintains isolation
+   - Cross-server interactions are controlled by the host
+   - Host process enforces security boundaries
+
+4. **Features can be added to servers and clients progressively**
+   - Core protocol provides minimal required functionality
+   - Additional capabilities can be negotiated as needed
+   - Servers and clients evolve independently
+   - Protocol designed for future extensibility
+   - Backwards compatibility is maintained
+
+## Capability Negotiation
+
+The Model Context Protocol uses a capability-based negotiation system where clients and
+servers explicitly declare their supported features during initialization. Capabilities
+determine which protocol features and primitives are available during a session.
+
+- Servers declare capabilities like resource subscriptions, tool support, and prompt
+  templates
+- Clients declare capabilities like sampling support and notification handling
+- Both parties must respect declared capabilities throughout the session
+- Additional capabilities can be negotiated through extensions to the protocol
+
+```mermaid
+sequenceDiagram
+    participant Host
+    participant Client
+    participant Server
+
+    Host->>+Client: Initialize client
+    Client->>+Server: Initialize session with capabilities
+    Server-->>Client: Respond with supported capabilities
+
+    Note over Host,Server: Active Session with Negotiated Features
+
+    loop Client Requests
+        Host->>Client: User- or model-initiated action
+        Client->>Server: Request (tools/resources)
+        Server-->>Client: Response
+        Client-->>Host: Update UI or respond to model
+    end
+
+    loop Server Requests
+        Server->>Client: Request (sampling)
+        Client->>Host: Forward to AI
+        Host-->>Client: AI response
+        Client-->>Server: Response
+    end
+
+    loop Notifications
+        Server--)Client: Resource updates
+        Client--)Server: Status changes
+    end
+
+    Host->>Client: Terminate
+    Client->>-Server: End session
+    deactivate Server
+```
+
+Each capability unlocks specific protocol features for use during the session. For
+example:
+
+- Implemented [server features](/specification/2025-11-25/server) must be advertised in the
+  server's capabilities
+- Emitting resource subscription notifications requires the server to declare
+  subscription support
+- Tool invocation requires the server to declare tool capabilities
+- [Sampling](/specification/2025-11-25/client) requires the client to declare support in its
+  capabilities
+
+This capability negotiation ensures clients and servers have a clear understanding of
+supported functionality while maintaining protocol extensibility.

--- a/.agents/skills/mcp-knowledge/references/2025-11-25/authorization.md
+++ b/.agents/skills/mcp-knowledge/references/2025-11-25/authorization.md
@@ -1,0 +1,705 @@
+<!-- markdownlint-disable -->
+# Authorization
+
+## Introduction
+
+### Purpose and Scope
+
+The Model Context Protocol provides authorization capabilities at the transport level,
+enabling MCP clients to make requests to restricted MCP servers on behalf of resource
+owners. This specification defines the authorization flow for HTTP-based transports.
+
+### Protocol Requirements
+
+Authorization is **OPTIONAL** for MCP implementations. When supported:
+
+- Implementations using an HTTP-based transport **SHOULD** conform to this specification.
+- Implementations using an STDIO transport **SHOULD NOT** follow this specification, and
+  instead retrieve credentials from the environment.
+- Implementations using alternative transports **MUST** follow established security best
+  practices for their protocol.
+
+### Standards Compliance
+
+This authorization mechanism is based on established specifications listed below, but
+implements a selected subset of their features to ensure security and interoperability
+while maintaining simplicity:
+
+- OAuth 2.1 IETF DRAFT ([draft-ietf-oauth-v2-1-13](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-13))
+- OAuth 2.0 Authorization Server Metadata
+  ([RFC8414](https://datatracker.ietf.org/doc/html/rfc8414))
+- OAuth 2.0 Dynamic Client Registration Protocol
+  ([RFC7591](https://datatracker.ietf.org/doc/html/rfc7591))
+- OAuth 2.0 Protected Resource Metadata ([RFC9728](https://datatracker.ietf.org/doc/html/rfc9728))
+- OAuth Client ID Metadata Documents ([draft-ietf-oauth-client-id-metadata-document-00](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-client-id-metadata-document-00))
+
+## Roles
+
+A protected _MCP server_ acts as an [OAuth 2.1 resource server](https://www.ietf.org/archive/id/draft-ietf-oauth-v2-1-13.html#name-roles),
+capable of accepting and responding to protected resource requests using access tokens.
+
+An _MCP client_ acts as an [OAuth 2.1 client](https://www.ietf.org/archive/id/draft-ietf-oauth-v2-1-13.html#name-roles),
+making protected resource requests on behalf of a resource owner.
+
+The _authorization server_ is responsible for interacting with the user (if necessary) and issuing access tokens for use at the MCP server.
+The implementation details of the authorization server are beyond the scope of this specification. It may be hosted with the
+resource server or a separate entity. The [Authorization Server Discovery section](#authorization-server-discovery)
+specifies how an MCP server indicates the location of its corresponding authorization server to a client.
+
+## Overview
+
+1. Authorization servers **MUST** implement OAuth 2.1 with appropriate security
+   measures for both confidential and public clients.
+
+2. Authorization servers and MCP clients **SHOULD** support OAuth Client ID Metadata Documents
+   ([draft-ietf-oauth-client-id-metadata-document-00](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-client-id-metadata-document-00)).
+
+3. Authorization servers and MCP clients **MAY** support the OAuth 2.0 Dynamic Client Registration
+   Protocol ([RFC7591](https://datatracker.ietf.org/doc/html/rfc7591)).
+
+4. MCP servers **MUST** implement OAuth 2.0 Protected Resource Metadata ([RFC9728](https://datatracker.ietf.org/doc/html/rfc9728)).
+   MCP clients **MUST** use OAuth 2.0 Protected Resource Metadata for authorization server discovery.
+
+5. MCP authorization servers **MUST** provide at least one of the following discovery mechanisms:
+   - OAuth 2.0 Authorization Server Metadata ([RFC8414](https://datatracker.ietf.org/doc/html/rfc8414))
+   - [OpenID Connect Discovery 1.0](https://openid.net/specs/openid-connect-discovery-1_0.html)
+
+   MCP clients **MUST** support both discovery mechanisms to obtain the information required to interact with the authorization server.
+
+## Authorization Server Discovery
+
+This section describes the mechanisms by which MCP servers advertise their associated
+authorization servers to MCP clients, as well as the discovery process through which MCP
+clients can determine authorization server endpoints and supported capabilities.
+
+### Authorization Server Location
+
+MCP servers **MUST** implement the OAuth 2.0 Protected Resource Metadata ([RFC9728](https://datatracker.ietf.org/doc/html/rfc9728))
+specification to indicate the locations of authorization servers. The Protected Resource Metadata document returned by the MCP server **MUST** include
+the `authorization_servers` field containing at least one authorization server.
+
+The specific use of `authorization_servers` is beyond the scope of this specification; implementers should consult
+OAuth 2.0 Protected Resource Metadata ([RFC9728](https://datatracker.ietf.org/doc/html/rfc9728)) for
+guidance on implementation details.
+
+Implementors should note that Protected Resource Metadata documents can define multiple authorization servers. The responsibility for selecting which authorization server to use lies with the MCP client, following the guidelines specified in
+[RFC9728 Section 7.6 "Authorization Servers"](https://datatracker.ietf.org/doc/html/rfc9728#name-authorization-servers).
+
+### Protected Resource Metadata Discovery Requirements
+
+MCP servers **MUST** implement one of the following discovery mechanisms to provide authorization server location information to MCP clients:
+
+1. **WWW-Authenticate Header**: Include the resource metadata URL in the `WWW-Authenticate` HTTP header under `resource_metadata` when returning `401 Unauthorized` responses, as described in [RFC9728 Section 5.1](https://datatracker.ietf.org/doc/html/rfc9728#name-www-authenticate-response).
+
+2. **Well-Known URI**: Serve metadata at a well-known URI as specified in [RFC9728](https://datatracker.ietf.org/doc/html/rfc9728). This can be either:
+   - At the path of the server's MCP endpoint: `https://example.com/public/mcp` could host metadata at `https://example.com/.well-known/oauth-protected-resource/public/mcp`
+   - At the root: `https://example.com/.well-known/oauth-protected-resource`
+
+MCP clients **MUST** support both discovery mechanisms and use the resource metadata URL from the parsed `WWW-Authenticate` headers when present; otherwise, they **MUST** fall back to constructing and requesting the well-known URIs in the order listed above.
+
+MCP servers **SHOULD** include a `scope` parameter in the `WWW-Authenticate` header as defined in
+[RFC 6750 Section 3](https://datatracker.ietf.org/doc/html/rfc6750#section-3)
+to indicate the scopes required for accessing the resource. This provides clients with immediate
+guidance on the appropriate scopes to request during authorization,
+following the principle of least privilege and preventing clients from requesting excessive permissions.
+
+The scopes included in the `WWW-Authenticate` challenge **MAY** match `scopes_supported`, be a subset
+or superset of it, or an alternative collection that is neither a strict subset nor
+superset. Clients **MUST NOT** assume any particular set relationship between the challenged
+scope set and `scopes_supported`. Clients **MUST** treat the scopes provided in the
+challenge as authoritative for satisfying the current request. Servers **SHOULD** strive for
+consistency in how they construct scope sets but they are not required to surface every dynamically
+issued scope through `scopes_supported`.
+
+Example 401 response with scope guidance:
+
+```http
+HTTP/1.1 401 Unauthorized
+WWW-Authenticate: Bearer resource_metadata="https://mcp.example.com/.well-known/oauth-protected-resource",
+                         scope="files:read"
+```
+
+MCP clients **MUST** be able to parse `WWW-Authenticate` headers and respond appropriately to `HTTP 401 Unauthorized` responses from the MCP server.
+
+If the `scope` parameter is absent, clients **SHOULD** apply the fallback behavior defined in the [Scope Selection Strategy](#scope-selection-strategy) section.
+
+### Authorization Server Metadata Discovery
+
+To handle different issuer URL formats and ensure interoperability with both OAuth 2.0 Authorization Server Metadata and OpenID Connect Discovery 1.0 specifications, MCP clients **MUST** attempt multiple well-known endpoints when discovering authorization server metadata.
+
+The discovery approach is based on [RFC8414 Section 3.1 "Authorization Server Metadata Request"](https://datatracker.ietf.org/doc/html/rfc8414#section-3.1) for OAuth 2.0 Authorization Server Metadata discovery and [RFC8414 Section 5 "Compatibility Notes"](https://datatracker.ietf.org/doc/html/rfc8414#section-5) for OpenID Connect Discovery 1.0 interoperability.
+
+For issuer URLs with path components (e.g., `https://auth.example.com/tenant1`), clients **MUST** try endpoints in the following priority order:
+
+1. OAuth 2.0 Authorization Server Metadata with path insertion: `https://auth.example.com/.well-known/oauth-authorization-server/tenant1`
+2. OpenID Connect Discovery 1.0 with path insertion: `https://auth.example.com/.well-known/openid-configuration/tenant1`
+3. OpenID Connect Discovery 1.0 path appending: `https://auth.example.com/tenant1/.well-known/openid-configuration`
+
+For issuer URLs without path components (e.g., `https://auth.example.com`), clients **MUST** try:
+
+1. OAuth 2.0 Authorization Server Metadata: `https://auth.example.com/.well-known/oauth-authorization-server`
+2. OpenID Connect Discovery 1.0: `https://auth.example.com/.well-known/openid-configuration`
+
+### Authorization Server Discovery Sequence Diagram
+
+The following diagram outlines an example flow:
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant M as MCP Server (Resource Server)
+    participant A as Authorization Server
+
+    Note over C: Attempt unauthenticated MCP request
+    C->>M: MCP request without token
+    M-->>C: HTTP 401 Unauthorized (may include WWW-Authenticate header)
+
+    alt Header includes resource_metadata
+        Note over C: Extract resource_metadata URL from header
+        C->>M: GET resource_metadata URI
+        M-->>C: Resource metadata with authorization server URL
+    else No resource_metadata in header
+        Note over C: Fallback to well-known URI probing
+        Note over M: _Not applicable if the MCP server is at the root_
+        C->>M: GET /.well-known/oauth-protected-resource/mcp
+        alt Sub-path metadata found
+            M-->>C: Resource metadata with authorization server URL
+        else Sub-path not found
+            C->>M: GET /.well-known/oauth-protected-resource
+            alt Root metadata found
+                M-->>C: Resource metadata with authorization server URL
+            else Root metadata not found
+                Note over C: Abort or use pre-configured values
+            end
+        end
+    end
+
+    Note over C: Validate RS metadata,<br />build AS metadata URL
+
+    C->>A: GET Authorization server metadata endpoint
+    Note over C,A: Try OAuth 2.0 and OpenID Connect<br/>discovery endpoints in priority order
+    A-->>C: Authorization server metadata
+
+    Note over C,A: OAuth 2.1 authorization flow happens here
+
+    C->>A: Token request
+    A-->>C: Access token
+
+    C->>M: MCP request with access token
+    M-->>C: MCP response
+    Note over C,M: MCP communication continues with valid token
+```
+
+## Client Registration Approaches
+
+MCP supports three client registration mechanisms. Choose based on your scenario:
+
+- **Client ID Metadata Documents**: When client and server have no prior relationship (most common)
+- **Pre-registration**: When client and server have an existing relationship
+- **Dynamic Client Registration**: For backwards compatibility or specific requirements
+
+Clients supporting all options **SHOULD** follow the following priority order:
+
+1. Use pre-registered client information for the server if the client has it available
+2. Use Client ID Metadata Documents if the Authorization Server indicates if the server supports it (via `client_id_metadata_document_supported` in OAuth Authorization Server Metadata)
+3. Use Dynamic Client Registration as a fallback if the Authorization Server supports it (via `registration_endpoint` in OAuth Authorization Server Metadata)
+4. Prompt the user to enter the client information if no other option is available
+
+### Client ID Metadata Documents
+
+MCP clients and authorization servers **SHOULD** support OAuth Client ID Metadata Documents as specified in
+[OAuth Client ID Metadata Document](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-client-id-metadata-document-00).
+This approach enables clients to use HTTPS URLs as client identifiers, where the URL points to a JSON document
+containing client metadata. This addresses the common MCP scenario where servers and clients have
+no pre-existing relationship.
+
+#### Implementation Requirements
+
+MCP implementations supporting Client ID Metadata Documents **MUST** follow the requirements specified in
+[OAuth Client ID Metadata Document](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-client-id-metadata-document-00).
+Key requirements include:
+
+**For MCP Clients:**
+
+- Clients **MUST** host their metadata document at an HTTPS URL following RFC requirements
+- The `client_id` URL **MUST** use the "https" scheme and contain a path component, e.g. `https://example.com/client.json`
+- The metadata document **MUST** include at least the following properties: `client_id`, `client_name`, `redirect_uris`
+- Clients **MUST** ensure the `client_id` value in the metadata matches the document URL exactly
+- Clients **MAY** use `private_key_jwt` for client authentication (e.g., for requests to the token endpoint) with appropriate JWKS configuration as described in [Section 6.2 of Client ID Metadata Document](https://www.ietf.org/archive/id/draft-ietf-oauth-client-id-metadata-document-00.html#section-6.2)
+
+**For Authorization Servers:**
+
+- **SHOULD** fetch metadata documents when encountering URL-formatted client_ids
+- **MUST** validate that the fetched document's `client_id` matches the URL exactly
+- **SHOULD** cache metadata respecting HTTP cache headers
+- **MUST** validate redirect URIs presented in an authorization request against those in the metadata document
+- **MUST** validate the document structure is valid JSON and contains required fields
+- **SHOULD** follow the security considerations in [Section 6 of Client ID Metadata Document](https://www.ietf.org/archive/id/draft-ietf-oauth-client-id-metadata-document-00.html#section-6)
+
+#### Example Metadata Document
+
+```json
+{
+  "client_id": "https://app.example.com/oauth/client-metadata.json",
+  "client_name": "Example MCP Client",
+  "client_uri": "https://app.example.com",
+  "logo_uri": "https://app.example.com/logo.png",
+  "redirect_uris": [
+    "http://127.0.0.1:3000/callback",
+    "http://localhost:3000/callback"
+  ],
+  "grant_types": ["authorization_code"],
+  "response_types": ["code"],
+  "token_endpoint_auth_method": "none"
+}
+```
+
+#### Client ID Metadata Documents Flow
+
+The following diagram illustrates the complete flow when using Client ID Metadata Documents:
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Client as MCP Client
+    participant Server as Authorization Server
+    participant Metadata as Metadata Endpoint<br/>(Client's HTTPS URL)
+    participant Resource as MCP Server
+
+    Note over Client,Metadata: Client hosts metadata at<br/>https://app.example.com/oauth/metadata.json
+
+    User->>Client: Initiates connection to MCP Server
+    Client->>Server: Authorization Request<br/>client_id=https://app.example.com/oauth/metadata.json<br/>redirect_uri=http://localhost:3000/callback
+
+    Server->>User: Authentication prompt
+    User->>Server: Provides credentials
+    Note over Server: Authenticates user
+
+    Note over Server: Detects URL-formatted client_id
+
+    Server->>Metadata: GET https://app.example.com/oauth/metadata.json
+    Metadata-->>Server: JSON Metadata Document<br/>{client_id, client_name, redirect_uris, ...}
+
+    Note over Server: Validates:<br/>1. client_id matches URL<br/>2. redirect_uri in allowed list<br/>3. Document structure valid<br/>4. (Optional) Domain allowed via trust policy
+
+    alt Validation Success
+        Server->>User: Display consent page with client_name
+        User->>Server: Approves access
+        Server->>Client: Authorization code via redirect_uri
+        Client->>Server: Exchange code for token<br/>client_id=https://app.example.com/oauth/metadata.json
+        Server-->>Client: Access token
+        Client->>Resource: MCP requests with access token
+        Resource-->>Client: MCP responses
+    else Validation Failure
+        Server->>User: Error response<br/>error=invalid_client or invalid_request
+    end
+
+    Note over Server: Cache metadata for future requests<br/>(respecting HTTP cache headers)
+```
+
+#### Discovery
+
+Authorization servers advertise that they support clients using Client ID Metadata Documents by including the following property in their OAuth Authorization Server metadata:
+
+```json
+{
+  "client_id_metadata_document_supported": true
+}
+```
+
+MCP clients **SHOULD** check for this capability and **MAY** fall back to Dynamic Client Registration
+or pre-registration if unavailable.
+
+### Preregistration
+
+MCP clients **SHOULD** support an option for static client credentials such as those supplied by a preregistration flow. This could be:
+
+1. Hardcode a client ID (and, if applicable, client credentials) specifically for the MCP client to use when
+   interacting with that authorization server, or
+2. Present a UI to users that allows them to enter these details, after registering an
+   OAuth client themselves (e.g., through a configuration interface hosted by the
+   server).
+
+### Dynamic Client Registration
+
+MCP clients and authorization servers **MAY** support the
+OAuth 2.0 Dynamic Client Registration Protocol [RFC7591](https://datatracker.ietf.org/doc/html/rfc7591)
+to allow MCP clients to obtain OAuth client IDs without user interaction.
+This option is included for backwards compatibility with earlier versions of the MCP authorization spec.
+
+## Scope Selection Strategy
+
+When implementing authorization flows, MCP clients **SHOULD** follow the principle of least privilege by requesting
+only the scopes necessary for their intended operations. During the initial authorization handshake, MCP clients
+**SHOULD** follow this priority order for scope selection:
+
+1. **Use `scope` parameter** from the initial `WWW-Authenticate` header in the 401 response, if provided
+2. **If `scope` is not available**, use all scopes defined in `scopes_supported` from the Protected Resource Metadata document, omitting the `scope` parameter if `scopes_supported` is undefined.
+
+This approach accommodates the general-purpose nature of MCP clients, which typically lack domain-specific knowledge to make informed decisions about individual scope selection. Requesting all available scopes allows the authorization server and end-user to determine appropriate permissions during the consent process.
+
+This approach minimizes user friction while following the principle of least privilege.
+The `scopes_supported` field is intended to represent the minimal set of scopes necessary
+for basic functionality (see [Scope Minimization](/specification/2025-11-25/basic/security_best_practices#scope-minimization)),
+with additional scopes requested incrementally through the step-up authorization flow steps
+described in the [Scope Challenge Handling](#scope-challenge-handling) section.
+
+## Authorization Flow Steps
+
+The complete Authorization flow proceeds as follows:
+
+```mermaid
+sequenceDiagram
+    participant B as User-Agent (Browser)
+    participant C as Client
+    participant M as MCP Server (Resource Server)
+    participant A as Authorization Server
+
+    C->>M: MCP request without token
+    M->>C: HTTP 401 Unauthorized with WWW-Authenticate header
+    Note over C: Extract resource_metadata URL from WWW-Authenticate
+
+    C->>M: Request Protected Resource Metadata
+    M->>C: Return metadata
+
+    Note over C: Parse metadata and extract authorization server(s)<br/>Client determines AS to use
+
+    C->>A: GET Authorization server metadata endpoint
+    Note over C,A: Try OAuth 2.0 and OpenID Connect<br/>discovery endpoints in priority order
+    A-->>C: Authorization server metadata
+
+    alt Client ID Metadata Documents
+        Note over C: Client uses HTTPS URL as client_id
+        Note over A: Server detects URL-formatted client_id
+        A->>C: Fetch metadata from client_id URL
+        C-->>A: JSON metadata document
+        Note over A: Validate metadata and redirect_uris
+    else Dynamic client registration
+        C->>A: POST /register
+        A->>C: Client Credentials
+    else Pre-registered client
+        Note over C: Use existing client_id
+    end
+
+    Note over C: Generate PKCE parameters<br/>Include resource parameter<br/>Apply scope selection strategy
+    C->>B: Open browser with authorization URL + code_challenge + resource
+    B->>A: Authorization request with resource parameter
+    Note over A: User authorizes
+    A->>B: Redirect to callback with authorization code
+    B->>C: Authorization code callback
+    C->>A: Token request + code_verifier + resource
+    A->>C: Access token (+ refresh token)
+    C->>M: MCP request with access token
+    M-->>C: MCP response
+    Note over C,M: MCP communication continues with valid token
+```
+
+## Resource Parameter Implementation
+
+MCP clients **MUST** implement Resource Indicators for OAuth 2.0 as defined in [RFC 8707](https://www.rfc-editor.org/rfc/rfc8707.html)
+to explicitly specify the target resource for which the token is being requested. The `resource` parameter:
+
+1. **MUST** be included in both authorization requests and token requests.
+2. **MUST** identify the MCP server that the client intends to use the token with.
+3. **MUST** use the canonical URI of the MCP server as defined in [RFC 8707 Section 2](https://www.rfc-editor.org/rfc/rfc8707.html#name-access-token-request).
+
+### Canonical Server URI
+
+For the purposes of this specification, the canonical URI of an MCP server is defined as the resource identifier as specified in
+[RFC 8707 Section 2](https://www.rfc-editor.org/rfc/rfc8707.html#section-2) and aligns with the `resource` parameter in
+[RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728).
+
+MCP clients **SHOULD** provide the most specific URI that they can for the MCP server they intend to access, following the guidance in [RFC 8707](https://www.rfc-editor.org/rfc/rfc8707). While the canonical form uses lowercase scheme and host components, implementations **SHOULD** accept uppercase scheme and host components for robustness and interoperability.
+
+Examples of valid canonical URIs:
+
+- `https://mcp.example.com/mcp`
+- `https://mcp.example.com`
+- `https://mcp.example.com:8443`
+- `https://mcp.example.com/server/mcp` (when path component is necessary to identify individual MCP server)
+
+Examples of invalid canonical URIs:
+
+- `mcp.example.com` (missing scheme)
+- `https://mcp.example.com#fragment` (contains fragment)
+
+> **Note:** While both `https://mcp.example.com/` (with trailing slash) and `https://mcp.example.com` (without trailing slash) are technically valid absolute URIs according to [RFC 3986](https://www.rfc-editor.org/rfc/rfc3986), implementations **SHOULD** consistently use the form without the trailing slash for better interoperability unless the trailing slash is semantically significant for the specific resource.
+
+For example, if accessing an MCP server at `https://mcp.example.com`, the authorization request would include:
+
+```
+&resource=https%3A%2F%2Fmcp.example.com
+```
+
+MCP clients **MUST** send this parameter regardless of whether authorization servers support it.
+
+## Access Token Usage
+
+### Token Requirements
+
+Access token handling when making requests to MCP servers **MUST** conform to the requirements defined in
+[OAuth 2.1 Section 5 "Resource Requests"](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-13#section-5).
+Specifically:
+
+1. MCP client **MUST** use the Authorization request header field defined in
+   [OAuth 2.1 Section 5.1.1](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-13#section-5.1.1):
+
+```
+Authorization: Bearer <access-token>
+```
+
+Note that authorization **MUST** be included in every HTTP request from client to server,
+even if they are part of the same logical session.
+
+2. Access tokens **MUST NOT** be included in the URI query string
+
+Example request:
+
+```http
+GET /mcp HTTP/1.1
+Host: mcp.example.com
+Authorization: Bearer eyJhbGciOiJIUzI1NiIs...
+```
+
+### Token Handling
+
+MCP servers, acting in their role as an OAuth 2.1 resource server, **MUST** validate access tokens as described in
+[OAuth 2.1 Section 5.2](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-13#section-5.2).
+MCP servers **MUST** validate that access tokens were issued specifically for them as the intended audience,
+according to [RFC 8707 Section 2](https://www.rfc-editor.org/rfc/rfc8707.html#section-2).
+If validation fails, servers **MUST** respond according to
+[OAuth 2.1 Section 5.3](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-13#section-5.3)
+error handling requirements. Invalid or expired tokens **MUST** receive a HTTP 401
+response.
+
+MCP clients **MUST NOT** send tokens to the MCP server other than ones issued by the MCP server's authorization server.
+
+MCP servers **MUST** only accept tokens that are valid for use with their
+own resources.
+
+MCP servers **MUST NOT** accept or transit any other tokens.
+
+## Error Handling
+
+Servers **MUST** return appropriate HTTP status codes for authorization errors:
+
+| Status Code | Description  | Usage                                      |
+| ----------- | ------------ | ------------------------------------------ |
+| 401         | Unauthorized | Authorization required or token invalid    |
+| 403         | Forbidden    | Invalid scopes or insufficient permissions |
+| 400         | Bad Request  | Malformed authorization request            |
+
+### Scope Challenge Handling
+
+This section covers handling insufficient scope errors during runtime operations when
+a client already has a token but needs additional permissions. This follows the error
+handling patterns defined in [OAuth 2.1 Section 5](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-13#section-5)
+and leverages the metadata fields from [RFC 9728 (OAuth 2.0 Protected Resource Metadata)](https://datatracker.ietf.org/doc/html/rfc9728).
+
+#### Runtime Insufficient Scope Errors
+
+When a client makes a request with an access token with insufficient
+scope during runtime operations, the server **SHOULD** respond with:
+
+- `HTTP 403 Forbidden` status code (per [RFC 6750 Section 3.1](https://datatracker.ietf.org/doc/html/rfc6750#section-3.1))
+- `WWW-Authenticate` header with the `Bearer` scheme and additional parameters:
+  - `error="insufficient_scope"` - indicating the specific type of authorization failure
+  - `scope="required_scope1 required_scope2"` - specifying the minimum scopes needed for the operation
+  - `resource_metadata` - the URI of the Protected Resource Metadata document (for consistency with 401 responses)
+  - `error_description` (optional) - human-readable description of the error
+
+**Server Scope Management**: When responding with insufficient scope errors, servers
+**SHOULD** include the scopes needed to satisfy the current request in the `scope`
+parameter.
+
+Servers have flexibility in determining which scopes to include:
+
+- **Minimum approach**: Include the newly-required scopes for the specific operation. Include any existing granted scopes as well, if they are required, to prevent clients from losing previously granted permissions.
+- **Recommended approach**: Include both existing relevant scopes and newly required scopes to prevent clients from losing previously granted permissions
+- **Extended approach**: Include existing scopes, newly required scopes, and related scopes that commonly work together
+
+The choice depends on the server's assessment of user experience impact and authorization friction.
+
+Servers **SHOULD** be consistent in their scope inclusion strategy to provide predictable behavior for clients.
+
+Servers **SHOULD** consider the user experience impact when determining which scopes to include in the
+response, as misconfigured scopes may require frequent user interaction.
+
+Example insufficient scope response:
+
+```http
+HTTP/1.1 403 Forbidden
+WWW-Authenticate: Bearer error="insufficient_scope",
+                         scope="files:read files:write user:profile",
+                         resource_metadata="https://mcp.example.com/.well-known/oauth-protected-resource",
+                         error_description="Additional file write permission required"
+```
+
+#### Step-Up Authorization Flow
+
+Clients will receive scope-related errors during initial authorization or at runtime (`insufficient_scope`).
+Clients **SHOULD** respond to these errors by requesting a new access token with an increased set of scopes via a step-up authorization flow or handle the errors in other, appropriate ways.
+Clients acting on behalf of a user **SHOULD** attempt the step-up authorization flow. Clients acting on their own behalf (`client_credentials` clients)
+**MAY** attempt the step-up authorization flow or abort the request immediately.
+
+The flow is as follows:
+
+1. **Parse error information** from the authorization server response or `WWW-Authenticate` header
+2. **Determine required scopes** as outlined in [Scope Selection Strategy](#scope-selection-strategy).
+3. **Initiate (re-)authorization** with the determined scope set
+4. **Retry the original request** with the new authorization no more than a few times and treat this as a permanent authorization failure
+
+Clients **SHOULD** implement retry limits and **SHOULD** track scope upgrade attempts to avoid
+repeated failures for the same resource and operation combination.
+
+## Security Considerations
+
+Implementations **MUST** follow OAuth 2.1 security best practices as laid out in [OAuth 2.1 Section 7. "Security Considerations"](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-13#name-security-considerations).
+
+### Token Audience Binding and Validation
+
+[RFC 8707](https://www.rfc-editor.org/rfc/rfc8707.html) Resource Indicators provide critical security benefits by binding tokens to their intended
+audiences **when the Authorization Server supports the capability**. To enable current and future adoption:
+
+- MCP clients **MUST** include the `resource` parameter in authorization and token requests as specified in the [Resource Parameter Implementation](#resource-parameter-implementation) section
+- MCP servers **MUST** validate that tokens presented to them were specifically issued for their use
+
+The [Security Best Practices document](/specification/2025-11-25/basic/security_best_practices#token-passthrough)
+outlines why token audience validation is crucial and why token passthrough is explicitly forbidden.
+
+### Token Theft
+
+Attackers who obtain tokens stored by the client, or tokens cached or logged on the server can access protected resources with
+requests that appear legitimate to resource servers.
+
+Clients and servers **MUST** implement secure token storage and follow OAuth best practices,
+as outlined in [OAuth 2.1, Section 7.1](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-13#section-7.1).
+
+Authorization servers **SHOULD** issue short-lived access tokens to reduce the impact of leaked tokens.
+For public clients, authorization servers **MUST** rotate refresh tokens as described in [OAuth 2.1 Section 4.3.1 "Token Endpoint Extension"](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-13#section-4.3.1).
+
+### Communication Security
+
+Implementations **MUST** follow [OAuth 2.1 Section 1.5 "Communication Security"](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-13#section-1.5).
+
+Specifically:
+
+1. All authorization server endpoints **MUST** be served over HTTPS.
+1. All redirect URIs **MUST** be either `localhost` or use HTTPS.
+
+### Authorization Code Protection
+
+An attacker who has gained access to an authorization code contained in an authorization response can try to redeem the authorization code for an access token or otherwise make use of the authorization code.
+(Further described in [OAuth 2.1 Section 7.5](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-13#section-7.5))
+
+To mitigate this, MCP clients **MUST** implement PKCE according to [OAuth 2.1 Section 7.5.2](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-13#section-7.5.2) and **MUST** verify PKCE support before proceeding with authorization.
+PKCE helps prevent authorization code interception and injection attacks by requiring clients to create a secret verifier-challenge pair, ensuring that only the original requestor can exchange an authorization code for tokens.
+
+MCP clients **MUST** use the `S256` code challenge method when technically capable, as required by [OAuth 2.1 Section 4.1.1](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-13#section-4.1.1).
+
+Since OAuth 2.1 and PKCE specifications do not define a mechanism for clients to discover PKCE support, MCP clients **MUST** rely on authorization server metadata to verify this capability:
+
+- **OAuth 2.0 Authorization Server Metadata**: If `code_challenge_methods_supported` is absent, the authorization server does not support PKCE and MCP clients **MUST** refuse to proceed.
+
+- **OpenID Connect Discovery 1.0**: While the [OpenID Provider Metadata](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata) does not define `code_challenge_methods_supported`, this field is commonly included by OpenID providers. MCP clients **MUST** verify the presence of `code_challenge_methods_supported` in the provider metadata response. If the field is absent, MCP clients **MUST** refuse to proceed.
+
+Authorization servers providing OpenID Connect Discovery 1.0 **MUST** include `code_challenge_methods_supported` in their metadata to ensure MCP compatibility.
+
+### Open Redirection
+
+An attacker may craft malicious redirect URIs to direct users to phishing sites.
+
+MCP clients **MUST** have redirect URIs registered with the authorization server.
+
+Authorization servers **MUST** validate exact redirect URIs against pre-registered values to prevent redirection attacks.
+
+MCP clients **SHOULD** use and verify state parameters in the authorization code flow
+and discard any results that do not include or have a mismatch with the original state.
+
+Authorization servers **MUST** take precautions to prevent redirecting user agents to untrusted URI's, following suggestions laid out in [OAuth 2.1 Section 7.12.2](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-13#section-7.12.2)
+
+Authorization servers **SHOULD** only automatically redirect the user agent if it trusts the redirection URI. If the URI is not trusted, the authorization server MAY inform the user and rely on the user to make the correct decision.
+
+### Client ID Metadata Document Security
+
+When implementing Client ID Metadata Documents, authorization servers **MUST** consider the security implications
+detailed in [OAuth Client ID Metadata Document, Section 6](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-client-id-metadata-document-00#name-security-considerations).
+Key considerations include:
+
+#### Authorization Server Abuse Protection
+
+The authorization server takes a URL as input from an unknown client and fetches that URL.
+A malicious client could use this to trigger the authorization server to make requests to arbitrary URLs,
+such as requests to private administration endpoints the authorization server has access to.
+
+Authorization servers fetching metadata documents **SHOULD** consider
+[Server-Side Request Forgery (SSRF)](https://developer.mozilla.org/docs/Web/Security/Attacks/SSRF) risks, as described in [OAuth Client ID Metadata Document: Server Side Request Forgery (SSRF) Attacks](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-client-id-metadata-document-00#name-server-side-request-forgery).
+
+#### Localhost Redirect URI Risks
+
+Client ID Metadata Documents cannot prevent `localhost` URL impersonation by themselves. An attacker can claim to be any client by:
+
+1. Providing the legitimate client's metadata URL as their `client_id`
+2. Binding to the any `localhost` port, and providing that address as the redirect_uri
+3. Receiving the authorization code via the redirect when the user approves
+
+The server will see the legitimate client's metadata document and the user will see the legitimate client's name, making attack detection difficult.
+
+Authorization servers:
+
+- **SHOULD** display additional warnings for `localhost`-only redirect URIs
+- **MAY** require additional attestation mechanisms for enhanced security
+- **MUST** clearly display the redirect URI hostname during authorization
+
+#### Trust Policies
+
+Authorization servers **MAY** implement domain-based trust policies:
+
+- Allowlists for trusted domains (for protected servers)
+- Accept any HTTPS `client_id` (for open servers)
+- Reputation checks for unknown domains
+- Restrictions based on domain age or certificate validation
+- Display the CIMD and other associated client hostnames prominently to prevent phishing
+
+Servers maintain full control over their access policies.
+
+### Confused Deputy Problem
+
+Attackers can exploit MCP servers acting as intermediaries to third-party APIs, leading to [confused deputy vulnerabilities](/specification/2025-11-25/basic/security_best_practices#confused-deputy-problem).
+By using stolen authorization codes, they can obtain access tokens without user consent.
+
+MCP proxy servers using static client IDs **MUST** obtain user consent for each dynamically
+registered client before forwarding to third-party authorization servers (which may require additional consent).
+
+### Access Token Privilege Restriction
+
+An attacker can gain unauthorized access or otherwise compromise an MCP server if the server accepts tokens issued for other resources.
+
+This vulnerability has two critical dimensions:
+
+1. **Audience validation failures.** When an MCP server doesn't verify that tokens were specifically intended for it (for example, via the audience claim, as mentioned in [RFC9068](https://www.rfc-editor.org/rfc/rfc9068.html)), it may accept tokens originally issued for other services. This breaks a fundamental OAuth security boundary, allowing attackers to reuse legitimate tokens across different services than intended.
+2. **Token passthrough.** If the MCP server not only accepts tokens with incorrect audiences but also forwards these unmodified tokens to downstream services, it can potentially cause the ["confused deputy" problem](#confused-deputy-problem), where the downstream API may incorrectly trust the token as if it came from the MCP server or assume the token was validated by the upstream API. See the [Token Passthrough section](/specification/2025-11-25/basic/security_best_practices#token-passthrough) of the Security Best Practices guide for additional details.
+
+MCP servers **MUST** validate access tokens before processing the request, ensuring the access token is issued specifically for the MCP server, and take all necessary steps to ensure no data is returned to unauthorized parties.
+
+A MCP server **MUST** follow the guidelines in [OAuth 2.1 - Section 5.2](https://www.ietf.org/archive/id/draft-ietf-oauth-v2-1-13.html#section-5.2) to validate inbound tokens.
+
+MCP servers **MUST** only accept tokens specifically intended for themselves and **MUST** reject tokens that do not include them in the audience claim or otherwise verify that they are the intended recipient of the token. See the [Security Best Practices Token Passthrough section](/specification/2025-11-25/basic/security_best_practices#token-passthrough) for details.
+
+If the MCP server makes requests to upstream APIs, it may act as an OAuth client to them. The access token used at the upstream API is a separate token, issued by the upstream authorization server. The MCP server **MUST NOT** pass through the token it received from the MCP client.
+
+MCP clients **MUST** implement and use the `resource` parameter as defined in [RFC 8707 - Resource Indicators for OAuth 2.0](https://www.rfc-editor.org/rfc/rfc8707.html)
+to explicitly specify the target resource for which the token is being requested. This requirement aligns with the recommendation in
+[RFC 9728 Section 7.4](https://datatracker.ietf.org/doc/html/rfc9728#section-7.4). This ensures that access tokens are bound to their intended resources and
+cannot be misused across different services.
+
+## MCP Authorization Extensions
+
+There are several authorization extensions to the core protocol that define additional authorization mechanisms. These extensions are:
+
+- **Optional** - Implementations can choose to adopt these extensions
+- **Additive** - Extensions do not modify or break core protocol functionality; they add new capabilities while preserving core protocol behavior
+- **Composable** - Extensions are modular and designed to work together without conflicts, allowing implementations to adopt multiple extensions simultaneously
+- **Versioned independently** - Extensions follow the core MCP versioning cycle but may adopt independent versioning as needed
+
+A list of supported extensions can be found in the [MCP Authorization Extensions](https://github.com/modelcontextprotocol/ext-auth) repository.

--- a/.agents/skills/mcp-knowledge/references/2025-11-25/cancellation.md
+++ b/.agents/skills/mcp-knowledge/references/2025-11-25/cancellation.md
@@ -1,0 +1,81 @@
+<!-- markdownlint-disable -->
+# Cancellation
+
+The Model Context Protocol (MCP) supports optional cancellation of in-progress requests
+through notification messages. Either side can send a cancellation notification to
+indicate that a previously-issued request should be terminated.
+
+## Cancellation Flow
+
+When a party wants to cancel an in-progress request, it sends a `notifications/cancelled`
+notification containing:
+
+- The ID of the request to cancel
+- An optional reason string that can be logged or displayed
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/cancelled",
+  "params": {
+    "requestId": "123",
+    "reason": "User requested cancellation"
+  }
+}
+```
+
+## Behavior Requirements
+
+1. Cancellation notifications **MUST** only reference requests that:
+   - Were previously issued in the same direction
+   - Are believed to still be in-progress
+1. The `initialize` request **MUST NOT** be cancelled by clients
+1. For [task-augmented requests](./tasks), the `tasks/cancel` request **MUST** be used instead of the `notifications/cancelled` notification. Tasks have their own dedicated cancellation mechanism that returns the final task state.
+1. Receivers of cancellation notifications **SHOULD**:
+   - Stop processing the cancelled request
+   - Free associated resources
+   - Not send a response for the cancelled request
+1. Receivers **MAY** ignore cancellation notifications if:
+   - The referenced request is unknown
+   - Processing has already completed
+   - The request cannot be cancelled
+1. The sender of the cancellation notification **SHOULD** ignore any response to the
+   request that arrives afterward
+
+## Timing Considerations
+
+Due to network latency, cancellation notifications may arrive after request processing
+has completed, and potentially after a response has already been sent.
+
+Both parties **MUST** handle these race conditions gracefully:
+
+```mermaid
+sequenceDiagram
+   participant Client
+   participant Server
+
+   Client->>Server: Request (ID: 123)
+   Note over Server: Processing starts
+   Client--)Server: notifications/cancelled (ID: 123)
+   alt
+      Note over Server: Processing may have<br/>completed before<br/>cancellation arrives
+   else If not completed
+      Note over Server: Stop processing
+   end
+```
+
+## Implementation Notes
+
+- Both parties **SHOULD** log cancellation reasons for debugging
+- Application UIs **SHOULD** indicate when cancellation is requested
+
+## Error Handling
+
+Invalid cancellation notifications **SHOULD** be ignored:
+
+- Unknown request IDs
+- Already completed requests
+- Malformed notifications
+
+This maintains the "fire and forget" nature of notifications while allowing for race
+conditions in asynchronous communication.

--- a/.agents/skills/mcp-knowledge/references/2025-11-25/changelog.md
+++ b/.agents/skills/mcp-knowledge/references/2025-11-25/changelog.md
@@ -1,0 +1,46 @@
+<!-- markdownlint-disable -->
+# Key Changes
+
+This document lists changes made to the Model Context Protocol (MCP) specification since
+the previous revision, [2025-06-18](/specification/2025-06-18).
+
+## Major changes
+
+1. Enhance authorization server discovery with support for [OpenID Connect Discovery 1.0](https://openid.net/specs/openid-connect-discovery-1_0.html). (PR [#797](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/797))
+2. Allow servers to expose icons as additional metadata for tools, resources, resource templates, and prompts ([SEP-973](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/973)).
+3. Enhance authorization flows with incremental scope consent via `WWW-Authenticate` ([SEP-835](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/835))
+4. Provide guidance on tool names ([SEP-986](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/1603))
+5. Update `ElicitResult` and `EnumSchema` to use a more standards-based approach and support titled, untitled, single-select, and multi-select enums ([SEP-1330](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1330)).
+6. Added support for [URL mode elicitation](/specification/2025-11-25/client/elicitation#url-elicitation-requests) ([SEP-1036](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/887))
+7. Add tool calling support to sampling via `tools` and `toolChoice` parameters ([SEP-1577](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1577))
+8. Add support for OAuth Client ID Metadata Documents as a recommended client registration mechanism ([SEP-991](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/991), PR [#1296](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/1296))
+9. Add experimental support for [tasks](/specification/2025-11-25/basic/utilities/tasks) to enable tracking durable requests with polling and deferred result retrieval ([SEP-1686](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1686)).
+
+## Minor changes
+
+1. Clarify that servers using stdio transport may use stderr for all types of logging, not just error messages (PR [#670](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/670)).
+2. Add optional `description` field to `Implementation` interface to align with MCP registry server.json format and provide human-readable context during initialization.
+3. Clarify that servers must respond with HTTP 403 Forbidden for invalid Origin headers in Streamable HTTP transport. (PR [#1439](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/1439))
+4. Updated the [Security Best Practices guidance](https://modelcontextprotocol.io/specification/draft/basic/security_best_practices).
+5. Clarify that input validation errors should be returned as Tool Execution Errors rather than Protocol Errors to enable model self-correction ([SEP-1303](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1303)).
+6. Support polling SSE streams by allowing servers to disconnect at will ([SEP-1699](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1699)).
+7. Clarify SEP-1699: GET streams support polling, resumption always via GET regardless of stream origin, event IDs should encode stream identity, disconnection includes server-initiated closure (Issue [#1847](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1847)).
+8. Align OAuth 2.0 Protected Resource Metadata discovery with RFC 9728, making `WWW-Authenticate` header optional with fallback to `.well-known` endpoint ([SEP-985](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/985)).
+9. Add support for default values in all primitive types (string, number, enum) for elicitation schemas ([SEP-1034](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1034)).
+10. Establish JSON Schema 2020-12 as the default dialect for MCP schema definitions ([SEP-1613](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1613)).
+
+## Other schema changes
+
+1. Decouple request payloads from RPC method definitions into standalone parameter schemas. ([SEP-1319](https://github.com/modelcontextprotocol/specification/issues/1319), PR [#1284](https://github.com/modelcontextprotocol/specification/pull/1284))
+
+## Governance and process updates
+
+1. Formalize Model Context Protocol governance structure ([SEP-932](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/932)).
+2. Establish shared communication practices and guidelines for the MCP community ([SEP-994](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/994)).
+3. Formalize Working Groups and Interest Groups in MCP governance ([SEP-1302](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1302)).
+4. Establish SDK tiering system with clear requirements for feature support and maintenance commitments ([SEP-1730](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1730)).
+
+## Full changelog
+
+For a complete list of all changes that have been made since the last protocol revision,
+[see GitHub](https://github.com/modelcontextprotocol/specification/compare/2025-06-18...2025-11-25).

--- a/.agents/skills/mcp-knowledge/references/2025-11-25/completion.md
+++ b/.agents/skills/mcp-knowledge/references/2025-11-25/completion.md
@@ -1,0 +1,199 @@
+<!-- markdownlint-disable -->
+# Completion
+
+The Model Context Protocol (MCP) provides a standardized way for servers to offer
+autocompletion suggestions for the arguments of prompts and resource templates. When
+users are filling in argument values for a specific prompt (identified by name) or
+resource template (identified by URI), servers can provide contextual suggestions.
+
+## User Interaction Model
+
+Completion in MCP is designed to support interactive user experiences similar to IDE code
+completion.
+
+For example, applications may show completion suggestions in a dropdown or popup menu as
+users type, with the ability to filter and select from available options.
+
+However, implementations are free to expose completion through any interface pattern that
+suits their needs&mdash;the protocol itself does not mandate any specific user
+interaction model.
+
+## Capabilities
+
+Servers that support completions **MUST** declare the `completions` capability:
+
+```json
+{
+  "capabilities": {
+    "completions": {}
+  }
+}
+```
+
+## Protocol Messages
+
+### Requesting Completions
+
+To get completion suggestions, clients send a `completion/complete` request specifying
+what is being completed through a reference type:
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "completion/complete",
+  "params": {
+    "ref": {
+      "type": "ref/prompt",
+      "name": "code_review"
+    },
+    "argument": {
+      "name": "language",
+      "value": "py"
+    }
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "completion": {
+      "values": ["python", "pytorch", "pyside"],
+      "total": 10,
+      "hasMore": true
+    }
+  }
+}
+```
+
+For prompts or URI templates with multiple arguments, clients should include previous completions in the `context.arguments` object to provide context for subsequent requests.
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "completion/complete",
+  "params": {
+    "ref": {
+      "type": "ref/prompt",
+      "name": "code_review"
+    },
+    "argument": {
+      "name": "framework",
+      "value": "fla"
+    },
+    "context": {
+      "arguments": {
+        "language": "python"
+      }
+    }
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "completion": {
+      "values": ["flask"],
+      "total": 1,
+      "hasMore": false
+    }
+  }
+}
+```
+
+### Reference Types
+
+The protocol supports two types of completion references:
+
+| Type           | Description                 | Example                                             |
+| -------------- | --------------------------- | --------------------------------------------------- |
+| `ref/prompt`   | References a prompt by name | `{"type": "ref/prompt", "name": "code_review"}`     |
+| `ref/resource` | References a resource URI   | `{"type": "ref/resource", "uri": "file:///{path}"}` |
+
+### Completion Results
+
+Servers return an array of completion values ranked by relevance, with:
+
+- Maximum 100 items per response
+- Optional total number of available matches
+- Boolean indicating if additional results exist
+
+## Message Flow
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Server
+
+    Note over Client: User types argument
+    Client->>Server: completion/complete
+    Server-->>Client: Completion suggestions
+
+    Note over Client: User continues typing
+    Client->>Server: completion/complete
+    Server-->>Client: Refined suggestions
+```
+
+## Data Types
+
+### CompleteRequest
+
+- `ref`: A `PromptReference` or `ResourceReference`
+- `argument`: Object containing:
+  - `name`: Argument name
+  - `value`: Current value
+- `context`: Object containing:
+  - `arguments`: A mapping of already-resolved argument names to their values.
+
+### CompleteResult
+
+- `completion`: Object containing:
+  - `values`: Array of suggestions (max 100)
+  - `total`: Optional total matches
+  - `hasMore`: Additional results flag
+
+## Error Handling
+
+Servers **SHOULD** return standard JSON-RPC errors for common failure cases:
+
+- Method not found: `-32601` (Capability not supported)
+- Invalid prompt name: `-32602` (Invalid params)
+- Missing required arguments: `-32602` (Invalid params)
+- Internal errors: `-32603` (Internal error)
+
+## Implementation Considerations
+
+1. Servers **SHOULD**:
+   - Return suggestions sorted by relevance
+   - Implement fuzzy matching where appropriate
+   - Rate limit completion requests
+   - Validate all inputs
+
+2. Clients **SHOULD**:
+   - Debounce rapid completion requests
+   - Cache completion results where appropriate
+   - Handle missing or partial results gracefully
+
+## Security
+
+Implementations **MUST**:
+
+- Validate all completion inputs
+- Implement appropriate rate limiting
+- Control access to sensitive suggestions
+- Prevent completion-based information disclosure

--- a/.agents/skills/mcp-knowledge/references/2025-11-25/elicitation.md
+++ b/.agents/skills/mcp-knowledge/references/2025-11-25/elicitation.md
@@ -1,0 +1,769 @@
+<!-- markdownlint-disable -->
+# Elicitation
+
+The Model Context Protocol (MCP) provides a standardized way for servers to request additional
+information from users through the client during interactions. This flow allows clients to
+maintain control over user interactions and data sharing while enabling servers to gather
+necessary information dynamically.
+
+Elicitation supports two modes:
+
+- **Form mode**: Servers can request structured data from users with optional JSON schemas to validate responses
+- **URL mode**: Servers can direct users to external URLs for sensitive interactions that must _not_ pass through the MCP client
+
+## User Interaction Model
+
+Elicitation in MCP allows servers to implement interactive workflows by enabling user input
+requests to occur _nested_ inside other MCP server features.
+
+Implementations are free to expose elicitation through any interface pattern that suits
+their needs&mdash;the protocol itself does not mandate any specific user interaction
+model.
+
+> **Warning:**
+> For trust & safety and security:
+>
+> - Servers **MUST NOT** use form mode elicitation to request sensitive information such as
+>   passwords, API keys, access tokens, or payment credentials
+> - Servers **MUST** use [URL mode](#url-mode-elicitation-requests) for interactions involving
+>   such sensitive information
+>
+> "Sensitive information" in this context refers to secrets and credentials that grant access or
+> authorize transactions. General contact or profile information (such as a name, email address,
+> or username) is not categorically prohibited; whether to request such data via form mode is at
+> the discretion of the server and subject to the user's ability to review and decline.
+>
+> MCP clients **MUST**:
+>
+> - Provide UI that makes it clear which server is requesting information
+> - Respect user privacy and provide clear decline and cancel options
+> - For form mode, allow users to review and modify their responses before sending
+> - For URL mode, clearly display the target domain/host and gather user consent before navigation to the target URL
+
+## Capabilities
+
+Clients that support elicitation **MUST** declare the `elicitation` capability during
+[initialization](../basic/lifecycle#initialization):
+
+```json
+{
+  "capabilities": {
+    "elicitation": {
+      "form": {},
+      "url": {}
+    }
+  }
+}
+```
+
+For backwards compatibility, an empty capabilities object is equivalent to declaring support for `form` mode only:
+
+```jsonc
+{
+  "capabilities": {
+    "elicitation": {}, // Equivalent to { "form": {} }
+  },
+}
+```
+
+Clients declaring the `elicitation` capability **MUST** support at least one mode (`form` or `url`).
+
+Servers **MUST NOT** send elicitation requests with modes that are not supported by the client.
+
+## Protocol Messages
+
+### Elicitation Requests
+
+To request information from a user, servers send an `elicitation/create` request.
+
+All elicitation requests **MUST** include the following parameters:
+
+| Name      | Type   | Options       | Description                                                                            |
+| --------- | ------ | ------------- | -------------------------------------------------------------------------------------- |
+| `mode`    | string | `form`, `url` | The mode of the elicitation. Optional for form mode (defaults to `"form"` if omitted). |
+| `message` | string |               | A human-readable message explaining why the interaction is needed.                     |
+
+The `mode` parameter specifies the type of elicitation:
+
+- `"form"`: In-band structured data collection with optional schema validation. Data is exposed to the client.
+- `"url"`: Out-of-band interaction via URL navigation. Data (other than the URL itself) is **not** exposed to the client.
+
+For backwards compatibility, servers **MAY** omit the `mode` field for form mode elicitation requests. Clients **MUST** treat requests without a `mode` field as form mode.
+
+### Form Mode Elicitation Requests
+
+Form mode elicitation allows servers to collect structured data directly through the MCP client.
+
+Form mode elicitation requests **MUST** either specify `mode: "form"` or omit the `mode` field, and include these additional parameters:
+
+| Name              | Type   | Description                                                    |
+| ----------------- | ------ | -------------------------------------------------------------- |
+| `requestedSchema` | object | A JSON Schema defining the structure of the expected response. |
+
+#### Requested Schema
+
+The `requestedSchema` parameter allows servers to define the structure of the expected
+response using a restricted subset of JSON Schema.
+
+To simplify client user experience, form mode elicitation schemas are limited to flat objects
+with primitive properties only.
+
+The schema is restricted to these primitive types:
+
+1. **String Schema**
+
+   ```json
+   {
+     "type": "string",
+     "title": "Display Name",
+     "description": "Description text",
+     "minLength": 3,
+     "maxLength": 50,
+     "pattern": "^[A-Za-z]+$",
+     "format": "email",
+     "default": "user@example.com"
+   }
+   ```
+
+   Supported formats: `email`, `uri`, `date`, `date-time`
+
+2. **Number Schema**
+
+   ```json
+   {
+     "type": "number", // or "integer"
+     "title": "Display Name",
+     "description": "Description text",
+     "minimum": 0,
+     "maximum": 100,
+     "default": 50
+   }
+   ```
+
+3. **Boolean Schema**
+
+   ```json
+   {
+     "type": "boolean",
+     "title": "Display Name",
+     "description": "Description text",
+     "default": false
+   }
+   ```
+
+4. **Enum Schema**
+
+   Single-select enum (without titles):
+
+   ```json
+   {
+     "type": "string",
+     "title": "Color Selection",
+     "description": "Choose your favorite color",
+     "enum": ["Red", "Green", "Blue"],
+     "default": "Red"
+   }
+   ```
+
+   Single-select enum (with titles):
+
+   ```json
+   {
+     "type": "string",
+     "title": "Color Selection",
+     "description": "Choose your favorite color",
+     "oneOf": [
+       { "const": "#FF0000", "title": "Red" },
+       { "const": "#00FF00", "title": "Green" },
+       { "const": "#0000FF", "title": "Blue" }
+     ],
+     "default": "#FF0000"
+   }
+   ```
+
+   Multi-select enum (without titles):
+
+   ```json
+   {
+     "type": "array",
+     "title": "Color Selection",
+     "description": "Choose your favorite colors",
+     "minItems": 1,
+     "maxItems": 2,
+     "items": {
+       "type": "string",
+       "enum": ["Red", "Green", "Blue"]
+     },
+     "default": ["Red", "Green"]
+   }
+   ```
+
+   Multi-select enum (with titles):
+
+   ```json
+   {
+     "type": "array",
+     "title": "Color Selection",
+     "description": "Choose your favorite colors",
+     "minItems": 1,
+     "maxItems": 2,
+     "items": {
+       "anyOf": [
+         { "const": "#FF0000", "title": "Red" },
+         { "const": "#00FF00", "title": "Green" },
+         { "const": "#0000FF", "title": "Blue" }
+       ]
+     },
+     "default": ["#FF0000", "#00FF00"]
+   }
+   ```
+
+Clients can use this schema to:
+
+1. Generate appropriate input forms
+2. Validate user input before sending
+3. Provide better guidance to users
+
+All primitive types support optional default values to provide sensible starting points. Clients that support defaults SHOULD pre-populate form fields with these values.
+
+Note that complex nested structures, arrays of objects (beyond enums), and other advanced JSON Schema features are intentionally not supported to simplify client user experience.
+
+#### Example: Simple Text Request
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "elicitation/create",
+  "params": {
+    "mode": "form",
+    "message": "Please provide your GitHub username",
+    "requestedSchema": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": ["name"]
+    }
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "action": "accept",
+    "content": {
+      "name": "octocat"
+    }
+  }
+}
+```
+
+#### Example: Structured Data Request
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "elicitation/create",
+  "params": {
+    "mode": "form",
+    "message": "Please provide your contact information",
+    "requestedSchema": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Your full name"
+        },
+        "email": {
+          "type": "string",
+          "format": "email",
+          "description": "Your email address"
+        },
+        "age": {
+          "type": "number",
+          "minimum": 18,
+          "description": "Your age"
+        }
+      },
+      "required": ["name", "email"]
+    }
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "action": "accept",
+    "content": {
+      "name": "Monalisa Octocat",
+      "email": "octocat@github.com",
+      "age": 30
+    }
+  }
+}
+```
+
+### URL Mode Elicitation Requests
+
+> **Note:**
+> **New feature:** URL mode elicitation is introduced in the `2025-11-25` version of the MCP specification. Its design and implementation may change in future protocol revisions.
+
+URL mode elicitation enables servers to direct users to external URLs for out-of-band interactions that must not pass through the MCP client. This is essential for auth flows, payment processing, and other sensitive or secure operations.
+
+URL mode elicitation requests **MUST** specify `mode: "url"`, a `message`, and include these additional parameters:
+
+| Name            | Type   | Description                               |
+| --------------- | ------ | ----------------------------------------- |
+| `url`           | string | The URL that the user should navigate to. |
+| `elicitationId` | string | A unique identifier for the elicitation.  |
+
+The `url` parameter **MUST** contain a valid URL.
+
+> **Note:**
+> **Important**: URL mode elicitation is *not* for authorizing the MCP client's
+>   access to the MCP server (that's handled by [MCP
+>   authorization](../basic/authorization)). Instead, it's used when the MCP
+>   server needs to obtain sensitive information or third-party authorization on
+>   behalf of the user. The MCP client's bearer token remains unchanged. The
+>   client's only responsibility is to provide the user with context about the
+>   elicitation URL the server wants them to open.
+
+#### Example: Request Sensitive Data
+
+This example shows a URL mode elicitation request directing the user to a secure URL where they can provide sensitive information (an API key, for example).
+The same request could direct the user into an OAuth authorization flow, or a payment flow. The only difference is the URL and the message.
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "method": "elicitation/create",
+  "params": {
+    "mode": "url",
+    "elicitationId": "550e8400-e29b-41d4-a716-446655440000",
+    "url": "https://mcp.example.com/ui/set_api_key",
+    "message": "Please provide your API key to continue."
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "result": {
+    "action": "accept"
+  }
+}
+```
+
+The response with `action: "accept"` indicates that the user has consented to the
+interaction. It does not mean that the interaction is complete. The interaction occurs out
+of band and the client is not aware of the outcome until and unless the server sends a notification indicating completion.
+
+### Completion Notifications for URL Mode Elicitation
+
+Servers **MAY** send a `notifications/elicitation/complete` notification when an
+out-of-band interaction started by URL mode elicitation is completed. This allows clients to react programmatically if appropriate.
+
+Servers sending notifications:
+
+- **MUST** only send the notification to the client that initiated the elicitation request.
+- **MUST** include the `elicitationId` established in the original `elicitation/create` request.
+
+Clients:
+
+- **MUST** ignore notifications referencing unknown or already-completed IDs.
+- **MAY** wait for this notification to automatically retry requests that received a [URLElicitationRequiredError](#error-handling), update the user interface, or otherwise continue an interaction.
+- **SHOULD** still provide manual controls that let the user retry or cancel the original request (or otherwise resume interacting with the client) if the notification never arrives.
+
+#### Example
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/elicitation/complete",
+  "params": {
+    "elicitationId": "550e8400-e29b-41d4-a716-446655440000"
+  }
+}
+```
+
+### URL Elicitation Required Error
+
+When a request cannot be processed until an elicitation is completed, the server **MAY** return a [`URLElicitationRequiredError`](#error-handling) (code `-32042`) to indicate to the client that a URL mode elicitation is required. The server **MUST NOT** return this error except when URL mode elicitation is required.
+
+The error **MUST** include a list of elicitations that are required to complete before the original can be retried.
+
+Any elicitations returned in the error **MUST** be URL mode elicitations and have an `elicitationId` property.
+
+**Error Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "error": {
+    "code": -32042, // URL_ELICITATION_REQUIRED
+    "message": "This request requires more information.",
+    "data": {
+      "elicitations": [
+        {
+          "mode": "url",
+          "elicitationId": "550e8400-e29b-41d4-a716-446655440000",
+          "url": "https://mcp.example.com/connect?elicitationId=550e8400-e29b-41d4-a716-446655440000",
+          "message": "Authorization is required to access your Example Co files."
+        }
+      ]
+    }
+  }
+}
+```
+
+## Message Flow
+
+### Form Mode Flow
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Client
+    participant Server
+
+    Note over Server: Server initiates elicitation
+    Server->>Client: elicitation/create (mode: form)
+
+    Note over User,Client: Present elicitation UI
+    User-->>Client: Provide requested information
+
+    Note over Server,Client: Complete request
+    Client->>Server: Return user response
+
+    Note over Server: Continue processing with new information
+```
+
+### URL Mode Flow
+
+```mermaid
+sequenceDiagram
+    participant UserAgent as User Agent (Browser)
+    participant User
+    participant Client
+    participant Server
+
+    Note over Server: Server initiates elicitation
+    Server->>Client: elicitation/create (mode: url)
+
+    Client->>User: Present consent to open URL
+    User-->>Client: Provide consent
+
+    Client->>UserAgent: Open URL
+    Client->>Server: Accept response
+
+    Note over User,UserAgent: User interaction
+    UserAgent-->>Server: Interaction complete
+    Server-->>Client: notifications/elicitation/complete (optional)
+
+    Note over Server: Continue processing with new information
+```
+
+### URL Mode With Elicitation Required Error Flow
+
+```mermaid
+sequenceDiagram
+    participant UserAgent as User Agent (Browser)
+    participant User
+    participant Client
+    participant Server
+
+    Client->>Server: tools/call
+
+    Note over Server: Server needs authorization
+    Server->>Client: URLElicitationRequiredError
+    Note over Client: Client notes the original request can be retried after elicitation
+
+    Client->>User: Present consent to open URL
+    User-->>Client: Provide consent
+
+    Client->>UserAgent: Open URL
+
+    Note over User,UserAgent: User interaction
+
+    UserAgent-->>Server: Interaction complete
+    Server-->>Client: notifications/elicitation/complete (optional)
+
+    Client->>Server: Retry tools/call (optional)
+```
+
+## Response Actions
+
+Elicitation responses use a three-action model to clearly distinguish between different user actions. These actions apply to both form and URL elicitation modes.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "action": "accept", // or "decline" or "cancel"
+    "content": {
+      "propertyName": "value",
+      "anotherProperty": 42
+    }
+  }
+}
+```
+
+The three response actions are:
+
+1. **Accept** (`action: "accept"`): User explicitly approved and submitted with data
+   - For form mode: The `content` field contains the submitted data matching the requested schema
+   - For URL mode: The `content` field is omitted
+   - Example: User clicked "Submit", "OK", "Confirm", etc.
+
+2. **Decline** (`action: "decline"`): User explicitly declined the request
+   - The `content` field is typically omitted
+   - Example: User clicked "Reject", "Decline", "No", etc.
+
+3. **Cancel** (`action: "cancel"`): User dismissed without making an explicit choice
+   - The `content` field is typically omitted
+   - Example: User closed the dialog, clicked outside, pressed Escape, browser failed to load, etc.
+
+Servers should handle each state appropriately:
+
+- **Accept**: Process the submitted data
+- **Decline**: Handle explicit decline (e.g., offer alternatives)
+- **Cancel**: Handle dismissal (e.g., prompt again later)
+
+## Implementation Considerations
+
+### Statefulness
+
+Most practical uses of elicitation require that the server maintain state about users:
+
+- Whether required information has been collected (e.g., the user's display name via form mode elicitation)
+- Status of resource access (e.g., API keys or a payment flow via URL mode elicitation)
+
+Servers implementing elicitation **MUST** securely associate this state with individual users following the guidelines in the [security best practices](../basic/security_best_practices) document. Specifically:
+
+- State **MUST NOT** be associated with session IDs alone
+- State storage **MUST** be protected against unauthorized access
+- For remote MCP servers, user identification **MUST** be derived from credentials acquired via [MCP authorization](../basic/authorization) when possible (e.g. `sub` claim)
+
+> **Note:**
+> The examples in this section are non-normative and illustrate potential uses
+>   of elicitation. Implementers should adapt these patterns to their specific
+>   requirements while maintaining security best practices.
+
+### URL Mode Elicitation for Sensitive Data
+
+For servers that interact with external APIs requiring sensitive information (e.g., credentials, payment information), URL mode elicitation provides a secure mechanism for users to provide this information without exposing it to the MCP client.
+
+In this pattern:
+
+1. The server directs users to a secure web page (served over HTTPS)
+2. The page presents a branded form UI on a domain the user trusts
+3. Users enter sensitive credentials directly into the secure form
+4. The server stores credentials securely, bound to the user's identity
+5. Subsequent MCP requests use these stored credentials for API access
+
+This approach ensures that sensitive credentials never pass through the LLM context, MCP client or any intermediate MCP servers, reducing the risk of exposure through client-side logging or other attack vectors.
+
+### URL Mode Elicitation for OAuth Flows
+
+URL mode elicitation enables a pattern where MCP servers act as OAuth clients to third-party resource servers.
+Authorization with external APIs enabled by URL mode elicitation is separate from [MCP authorization](../basic/authorization). MCP servers **MUST NOT** rely on URL mode elicitation to authorize users for themselves.
+
+#### Understanding the Distinction
+
+- **MCP Authorization**: Required OAuth flow between the MCP client and MCP server (covered in the [authorization specification](../basic/authorization))
+- **External (third-party) Authorization**: Optional authorization between the MCP server and a third-party resource server, initiated via URL mode elicitation
+
+In external authorization, the server acts as both:
+
+- An OAuth resource server (to the MCP client)
+- An OAuth client (to the third-party resource server)
+
+Example scenario:
+
+- An MCP client connects to an MCP server
+- The MCP server integrates with various different third-party services
+- When the MCP client calls a tool that requires access to a third-party service, the MCP server needs credentials for that service
+
+The critical security requirements are:
+
+1. **The third-party credentials MUST NOT transit through the MCP client**: The client must never see third-party credentials to protect the security boundary
+2. **The MCP server MUST NOT use the client's credentials for the third-party service**: That would be [token passthrough](../basic/security_best_practices#token-passthrough), which is forbidden
+3. **The user MUST authorize the MCP server directly**: The interaction happens outside the MCP protocol, without involving the MCP client
+4. **The MCP server is responsible for tokens**: The MCP server is responsible for storing and managing the third-party tokens obtained through the URL mode elicitation (in other words, the MCP server must be stateful).
+
+Credentials obtained via URL mode elicitation are distinct from the MCP server credentials used by the MCP client. The MCP server **MUST NOT** transmit credentials obtained through URL mode elicitation to the MCP client.
+
+> **Note:**
+> For additional background, refer to the [token passthrough
+>   section](../basic/security_best_practices#token-passthrough) of the Security
+>   Best Practices document to understand why MCP servers cannot act as
+>   pass-through proxies.
+
+#### Implementation Pattern
+
+When implementing external authorization via URL mode elicitation:
+
+1. The MCP server generates an authorization URL, acting as an OAuth client to the third-party service
+2. The MCP server stores internal state that associates (binds) the elicitation request with the user's identity.
+3. The MCP server sends a URL mode elicitation request to the client with a URL that can start the authorization flow.
+4. The user completes the OAuth flow directly with the third-party authorization server
+5. The third-party authorization server redirects back to the MCP server
+6. The MCP server securely stores the third-party tokens, bound to the user's identity
+7. Future MCP requests can leverage these stored tokens for API access to the third-party resource server
+
+The following is a non-normative example of how this pattern could be implemented:
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant UserAgent as User Agent (Browser)
+    participant 3AS as 3rd Party AS
+    participant 3RS as 3rd Party RS
+    participant Client as MCP Client
+    participant Server as MCP Server
+
+    Client->>Server: tools/call
+    Note over Server: Needs 3rd-party authorization for user
+    Note over Server: Store state (bind the elicitation request to the user)
+    Server->>Client: URLElicitationRequiredError<br> (mode: "url", url: "https://mcp.example.com/connect?...")
+    Note over Client: Client notes the tools/call request can be retried later
+    Client->>User: Present consent to open URL
+    User->>Client: Provide consent
+    Client->>UserAgent: Open URL
+    Client->>Server: Accept response
+    UserAgent->>Server: Load connect route
+    Note over Server: Confirm: user is logged into MCP Server or MCP AS<br>Confirm: elicitation user matches session user
+    Server->>UserAgent: Redirect to third-party authorization endpoint
+    UserAgent->>3AS: Load authorize route
+    Note over 3AS,User: User interaction (OAuth flow):<br>User consents to scoped MCP Server access
+    3AS->>UserAgent: redirect to MCP Server's redirect_uri
+    UserAgent->>Server: load redirect_uri page
+    Note over Server: Confirm: redirect_uri belongs to MCP Server
+    Server->>3AS: Exchange authorization code for  OAuth tokens
+    3AS->>Server: Grants tokens
+    Note over Server: Bind tokens to MCP user identity
+    Server-->>Client: notifications/elicitation/complete (optional)
+    Client->>Server: Retry tools/call
+    Note over Server: Retrieve token bound to user identity
+    Server->>3RS: Call 3rd-party API
+```
+
+This pattern maintains clear security boundaries while enabling rich integrations with third-party services that require user authorization.
+
+## Error Handling
+
+Servers **MUST** return standard JSON-RPC errors for common failure cases:
+
+- When a request cannot be processed until an elicitation is completed: `-32042` (`URLElicitationRequiredError`)
+
+Clients **MUST** return standard JSON-RPC errors for common failure cases:
+
+- Server sends an `elicitation/create` request with a mode not declared in client capabilities: `-32602` (Invalid params)
+
+## Security Considerations
+
+1. Servers **MUST** bind elicitation requests to the client and user identity
+1. Clients **MUST** provide clear indication of which server is requesting information
+1. Clients **SHOULD** implement user approval controls
+1. Clients **SHOULD** allow users to decline elicitation requests at any time
+1. Clients **SHOULD** implement rate limiting
+1. Clients **SHOULD** present elicitation requests in a way that makes it clear what information is being requested and why
+
+### Safe URL Handling
+
+MCP servers requesting elicitation:
+
+1. **MUST NOT** include sensitive information about the end-user, including credentials, personal identifiable information, etc., in the URL sent to the client in a URL elicitation request.
+2. **MUST NOT** provide a URL which is pre-authenticated to access a protected resource, as the URL could be used to impersonate the user by a malicious client.
+3. **SHOULD NOT** include URLs intended to be clickable in any field of a form mode elicitation request.
+4. **SHOULD** use HTTPS URLs for non-development environments.
+
+These server requirements ensure that client implementations have clear rules about when to present a URL to the user, so that the client-side rules (below) can be consistently applied.
+
+Clients implementing URL mode elicitation **MUST** handle URLs carefully to prevent users from unknowingly clicking malicious links.
+
+When handling URL mode elicitation requests, MCP clients:
+
+1. **MUST NOT** automatically pre-fetch the URL or any of its metadata.
+2. **MUST NOT** open the URL without explicit consent from the user.
+3. **MUST** show the full URL to the user for examination before consent.
+4. **MUST** open the URL provided by the server in a secure manner that does not enable the client or LLM to inspect the content or user inputs.
+   For example, on iOS, [SFSafariViewController](https://developer.apple.com/documentation/safariservices/sfsafariviewcontroller) is good, but [WkWebView](https://developer.apple.com/documentation/webkit/wkwebview) is not.
+5. **SHOULD** highlight the domain of the URL to mitigate subdomain spoofing.
+6. **SHOULD** have warnings for ambiguous/suspicious URIs (i.e., containing Punycode).
+7. **SHOULD NOT** render URLs as clickable in any field of an elicitation request, except for the `url` field in a URL elicitation request (with the restrictions detailed above).
+
+### Identifying the User
+
+Servers **MUST NOT** rely on client-provided user identification without server verification, as this can be forged.
+Instead, servers **SHOULD** follow [security best practices](../basic/security_best_practices).
+
+Non-normative examples:
+
+- Incorrect: Treat user input like "I am joe@example.com" as authoritative
+- Correct: Rely on [authorization](../basic/authorization) to identify the user
+
+### Form Mode Security
+
+1. Servers **MUST NOT** request sensitive information (passwords, API keys, etc.) via form mode
+2. Clients **SHOULD** validate all responses against the provided schema
+3. Servers **SHOULD** validate received data matches the requested schema
+
+#### Phishing
+
+URL mode elicitation returns a URL that an attacker can use to send to a victim. The MCP Server **MUST** verify the identity of the user who opens the URL before accepting information.
+
+Typically identity verification is done by leveraging the [MCP authorization server](../basic/authorization) to identify the user, through a session cookie or equivalent in the browser.
+
+For example, URL mode elicitation may be used to perform OAuth flows where the server acts as an OAuth client of another resource server. Without proper mitigation, the following phishing attack is possible:
+
+1. A malicious user (Alice) connected to a benign server triggers an elicitation request
+2. The benign server generates an authorization URL, acting as an OAuth client of a third-party authorization server
+3. Alice's client displays the URL and asks for consent
+4. Instead of clicking on the link, Alice tricks a victim user (Bob) of the same benign server into clicking it
+5. Bob opens the link and completes the authorization, thinking they are authorizing their own connection to the benign server
+6. The benign server receives a callback/redirect form the third-party authorization server, and assumes it's Alice's request
+7. The tokens for the third-party server are bound to Alice's session and identity, instead of Bob's, resulting in an account takeover
+
+To prevent this attack, the server **MUST** ensure that the user who started the elicitation request (the end-user who is accessing the server via the MCP client) is the same user who completes the authorization flow.
+
+There are many ways to achieve this and the best way will depend on the specific implementation.
+
+As a common, non-normative example, consider a case where the MCP server is accessible via the web and desires to perform a third-party authorization code flow.
+To prevent the phishing attack, the server would create a URL mode elicitation to `https://mcp.example.com/connect?elicitationId=...` rather than the third-party authorization endpoint.
+This "connect URL" must ensure the user who opened the page is the same user who the elicitation was generated for.
+It would, for example, check that the user has a valid session cookie and that the session cookie is for the same user who was using the MCP client to generate the URL mode elicitation.
+This could be done by comparing the authoritative subject (`sub` claim) from the MCP server's authorization server to the subject from the session cookie.
+Once that page ensures the same user, it can send the user to the third-party authorization server at `https://example.com/authorize?...` where a normal OAuth flow can be completed.
+
+In other cases, the server may not be accessible via the web and may not be able to use a session cookie to identify the user.
+In this case, the server must use a different mechanism to identify the user who opens the elicitation URL is the same user who the elicitation was generated for.
+
+In all implementations, the server **MUST** ensure that the mechanism to determine the user's identity is resilient to attacks where an attacker can modify the elicitation URL.

--- a/.agents/skills/mcp-knowledge/references/2025-11-25/lifecycle.md
+++ b/.agents/skills/mcp-knowledge/references/2025-11-25/lifecycle.md
@@ -1,0 +1,282 @@
+<!-- markdownlint-disable -->
+# Lifecycle
+
+The Model Context Protocol (MCP) defines a rigorous lifecycle for client-server
+connections that ensures proper capability negotiation and state management.
+
+1. **Initialization**: Capability negotiation and protocol version agreement
+2. **Operation**: Normal protocol communication
+3. **Shutdown**: Graceful termination of the connection
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Server
+
+    Note over Client,Server: Initialization Phase
+    activate Client
+    Client->>+Server: initialize request
+    Server-->>Client: initialize response
+    Client--)Server: initialized notification
+
+    Note over Client,Server: Operation Phase
+    rect rgb(200, 220, 250)
+        note over Client,Server: Normal protocol operations
+    end
+
+    Note over Client,Server: Shutdown
+    Client--)-Server: Disconnect
+    deactivate Server
+    Note over Client,Server: Connection closed
+```
+
+## Lifecycle Phases
+
+### Initialization
+
+The initialization phase **MUST** be the first interaction between client and server.
+During this phase, the client and server:
+
+- Establish protocol version compatibility
+- Exchange and negotiate capabilities
+- Share implementation details
+
+The client **MUST** initiate this phase by sending an `initialize` request containing:
+
+- Protocol version supported
+- Client capabilities
+- Client implementation information
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "initialize",
+  "params": {
+    "protocolVersion": "2025-11-25",
+    "capabilities": {
+      "roots": {
+        "listChanged": true
+      },
+      "sampling": {},
+      "elicitation": {
+        "form": {},
+        "url": {}
+      },
+      "tasks": {
+        "requests": {
+          "elicitation": {
+            "create": {}
+          },
+          "sampling": {
+            "createMessage": {}
+          }
+        }
+      }
+    },
+    "clientInfo": {
+      "name": "ExampleClient",
+      "title": "Example Client Display Name",
+      "version": "1.0.0",
+      "description": "An example MCP client application",
+      "icons": [
+        {
+          "src": "https://example.com/icon.png",
+          "mimeType": "image/png",
+          "sizes": ["48x48"]
+        }
+      ],
+      "websiteUrl": "https://example.com"
+    }
+  }
+}
+```
+
+The server **MUST** respond with its own capabilities and information:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "protocolVersion": "2025-11-25",
+    "capabilities": {
+      "logging": {},
+      "prompts": {
+        "listChanged": true
+      },
+      "resources": {
+        "subscribe": true,
+        "listChanged": true
+      },
+      "tools": {
+        "listChanged": true
+      },
+      "tasks": {
+        "list": {},
+        "cancel": {},
+        "requests": {
+          "tools": {
+            "call": {}
+          }
+        }
+      }
+    },
+    "serverInfo": {
+      "name": "ExampleServer",
+      "title": "Example Server Display Name",
+      "version": "1.0.0",
+      "description": "An example MCP server providing tools and resources",
+      "icons": [
+        {
+          "src": "https://example.com/server-icon.svg",
+          "mimeType": "image/svg+xml",
+          "sizes": ["any"]
+        }
+      ],
+      "websiteUrl": "https://example.com/server"
+    },
+    "instructions": "Optional instructions for the client"
+  }
+}
+```
+
+After successful initialization, the client **MUST** send an `initialized` notification
+to indicate it is ready to begin normal operations:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/initialized"
+}
+```
+
+- The client **SHOULD NOT** send requests other than
+  [pings](/specification/2025-11-25/basic/utilities/ping) before the server has responded to the
+  `initialize` request.
+- The server **SHOULD NOT** send requests other than
+  [pings](/specification/2025-11-25/basic/utilities/ping) and
+  [logging](/specification/2025-11-25/server/utilities/logging) before receiving the `initialized`
+  notification.
+
+#### Version Negotiation
+
+In the `initialize` request, the client **MUST** send a protocol version it supports.
+This **SHOULD** be the _latest_ version supported by the client.
+
+If the server supports the requested protocol version, it **MUST** respond with the same
+version. Otherwise, the server **MUST** respond with another protocol version it
+supports. This **SHOULD** be the _latest_ version supported by the server.
+
+If the client does not support the version in the server's response, it **SHOULD**
+disconnect.
+
+> **Note:**
+> If using HTTP, the client **MUST** include the `MCP-Protocol-Version:
+> <protocol-version>` HTTP header on all subsequent requests to the MCP
+> server.
+> For details, see [the Protocol Version Header section in Transports](/specification/2025-11-25/basic/transports#protocol-version-header).
+
+#### Capability Negotiation
+
+Client and server capabilities establish which optional protocol features will be
+available during the session.
+
+Key capabilities include:
+
+| Category | Capability     | Description                                                                                   |
+| -------- | -------------- | --------------------------------------------------------------------------------------------- |
+| Client   | `roots`        | Ability to provide filesystem [roots](/specification/2025-11-25/client/roots)                 |
+| Client   | `sampling`     | Support for LLM [sampling](/specification/2025-11-25/client/sampling) requests                |
+| Client   | `elicitation`  | Support for server [elicitation](/specification/2025-11-25/client/elicitation) requests       |
+| Client   | `tasks`        | Support for [task-augmented](/specification/2025-11-25/basic/utilities/tasks) client requests |
+| Client   | `experimental` | Describes support for non-standard experimental features                                      |
+| Server   | `prompts`      | Offers [prompt templates](/specification/2025-11-25/server/prompts)                           |
+| Server   | `resources`    | Provides readable [resources](/specification/2025-11-25/server/resources)                     |
+| Server   | `tools`        | Exposes callable [tools](/specification/2025-11-25/server/tools)                              |
+| Server   | `logging`      | Emits structured [log messages](/specification/2025-11-25/server/utilities/logging)           |
+| Server   | `completions`  | Supports argument [autocompletion](/specification/2025-11-25/server/utilities/completion)     |
+| Server   | `tasks`        | Support for [task-augmented](/specification/2025-11-25/basic/utilities/tasks) server requests |
+| Server   | `experimental` | Describes support for non-standard experimental features                                      |
+
+Capability objects can describe sub-capabilities like:
+
+- `listChanged`: Support for list change notifications (for prompts, resources, and
+  tools)
+- `subscribe`: Support for subscribing to individual items' changes (resources only)
+
+### Operation
+
+During the operation phase, the client and server exchange messages according to the
+negotiated capabilities.
+
+Both parties **MUST**:
+
+- Respect the negotiated protocol version
+- Only use capabilities that were successfully negotiated
+
+### Shutdown
+
+During the shutdown phase, one side (usually the client) cleanly terminates the protocol
+connection. No specific shutdown messages are defined—instead, the underlying transport
+mechanism should be used to signal connection termination:
+
+#### stdio
+
+For the stdio [transport](/specification/2025-11-25/basic/transports), the client **SHOULD** initiate
+shutdown by:
+
+1. First, closing the input stream to the child process (the server)
+2. Waiting for the server to exit, or sending `SIGTERM` if the server does not exit
+   within a reasonable time
+3. Sending `SIGKILL` if the server does not exit within a reasonable time after `SIGTERM`
+
+The server **MAY** initiate shutdown by closing its output stream to the client and
+exiting.
+
+#### HTTP
+
+For HTTP [transports](/specification/2025-11-25/basic/transports), shutdown is indicated by closing the
+associated HTTP connection(s).
+
+## Timeouts
+
+Implementations **SHOULD** establish timeouts for all sent requests, to prevent hung
+connections and resource exhaustion. When the request has not received a success or error
+response within the timeout period, the sender **SHOULD** issue a [cancellation
+notification](/specification/2025-11-25/basic/utilities/cancellation) for that request and stop waiting for
+a response.
+
+SDKs and other middleware **SHOULD** allow these timeouts to be configured on a
+per-request basis.
+
+Implementations **MAY** choose to reset the timeout clock when receiving a [progress
+notification](/specification/2025-11-25/basic/utilities/progress) corresponding to the request, as this
+implies that work is actually happening. However, implementations **SHOULD** always
+enforce a maximum timeout, regardless of progress notifications, to limit the impact of a
+misbehaving client or server.
+
+## Error Handling
+
+Implementations **SHOULD** be prepared to handle these error cases:
+
+- Protocol version mismatch
+- Failure to negotiate required capabilities
+- Request [timeouts](#timeouts)
+
+Example initialization error:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "error": {
+    "code": -32602,
+    "message": "Unsupported protocol version",
+    "data": {
+      "supported": ["2024-11-05"],
+      "requested": "1.0.0"
+    }
+  }
+}
+```

--- a/.agents/skills/mcp-knowledge/references/2025-11-25/logging.md
+++ b/.agents/skills/mcp-knowledge/references/2025-11-25/logging.md
@@ -1,0 +1,137 @@
+<!-- markdownlint-disable -->
+# Logging
+
+The Model Context Protocol (MCP) provides a standardized way for servers to send
+structured log messages to clients. Clients can control logging verbosity by setting
+minimum log levels, with servers sending notifications containing severity levels,
+optional logger names, and arbitrary JSON-serializable data.
+
+## User Interaction Model
+
+Implementations are free to expose logging through any interface pattern that suits their
+needs&mdash;the protocol itself does not mandate any specific user interaction model.
+
+## Capabilities
+
+Servers that emit log message notifications **MUST** declare the `logging` capability:
+
+```json
+{
+  "capabilities": {
+    "logging": {}
+  }
+}
+```
+
+## Log Levels
+
+The protocol follows the standard syslog severity levels specified in
+[RFC 5424](https://datatracker.ietf.org/doc/html/rfc5424#section-6.2.1):
+
+| Level     | Description                      | Example Use Case           |
+| --------- | -------------------------------- | -------------------------- |
+| debug     | Detailed debugging information   | Function entry/exit points |
+| info      | General informational messages   | Operation progress updates |
+| notice    | Normal but significant events    | Configuration changes      |
+| warning   | Warning conditions               | Deprecated feature usage   |
+| error     | Error conditions                 | Operation failures         |
+| critical  | Critical conditions              | System component failures  |
+| alert     | Action must be taken immediately | Data corruption detected   |
+| emergency | System is unusable               | Complete system failure    |
+
+## Protocol Messages
+
+### Setting Log Level
+
+To configure the minimum log level, clients **MAY** send a `logging/setLevel` request:
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "logging/setLevel",
+  "params": {
+    "level": "info"
+  }
+}
+```
+
+### Log Message Notifications
+
+Servers send log messages using `notifications/message` notifications:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/message",
+  "params": {
+    "level": "error",
+    "logger": "database",
+    "data": {
+      "error": "Connection failed",
+      "details": {
+        "host": "localhost",
+        "port": 5432
+      }
+    }
+  }
+}
+```
+
+## Message Flow
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Server
+
+    Note over Client,Server: Configure Logging
+    Client->>Server: logging/setLevel (info)
+    Server-->>Client: Empty Result
+
+    Note over Client,Server: Server Activity
+    Server--)Client: notifications/message (info)
+    Server--)Client: notifications/message (warning)
+    Server--)Client: notifications/message (error)
+
+    Note over Client,Server: Level Change
+    Client->>Server: logging/setLevel (error)
+    Server-->>Client: Empty Result
+    Note over Server: Only sends error level<br/>and above
+```
+
+## Error Handling
+
+Servers **SHOULD** return standard JSON-RPC errors for common failure cases:
+
+- Invalid log level: `-32602` (Invalid params)
+- Configuration errors: `-32603` (Internal error)
+
+## Implementation Considerations
+
+1. Servers **SHOULD**:
+   - Rate limit log messages
+   - Include relevant context in data field
+   - Use consistent logger names
+   - Remove sensitive information
+
+2. Clients **MAY**:
+   - Present log messages in the UI
+   - Implement log filtering/search
+   - Display severity visually
+   - Persist log messages
+
+## Security
+
+1. Log messages **MUST NOT** contain:
+   - Credentials or secrets
+   - Personal identifying information
+   - Internal system details that could aid attacks
+
+2. Implementations **SHOULD**:
+   - Rate limit messages
+   - Validate all data fields
+   - Control log access
+   - Monitor for sensitive content

--- a/.agents/skills/mcp-knowledge/references/2025-11-25/pagination.md
+++ b/.agents/skills/mcp-knowledge/references/2025-11-25/pagination.md
@@ -1,0 +1,94 @@
+<!-- markdownlint-disable -->
+# Pagination
+
+The Model Context Protocol (MCP) supports paginating list operations that may return
+large result sets. Pagination allows servers to yield results in smaller chunks rather
+than all at once.
+
+Pagination is especially important when connecting to external services over the
+internet, but also useful for local integrations to avoid performance issues with large
+data sets.
+
+## Pagination Model
+
+Pagination in MCP uses an opaque cursor-based approach, instead of numbered pages.
+
+- The **cursor** is an opaque string token, representing a position in the result set
+- **Page size** is determined by the server, and clients **MUST NOT** assume a fixed page
+  size
+
+## Response Format
+
+Pagination starts when the server sends a **response** that includes:
+
+- The current page of results
+- An optional `nextCursor` field if more results exist
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "123",
+  "result": {
+    "resources": [...],
+    "nextCursor": "eyJwYWdlIjogM30="
+  }
+}
+```
+
+## Request Format
+
+After receiving a cursor, the client can _continue_ paginating by issuing a request
+including that cursor:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "124",
+  "method": "resources/list",
+  "params": {
+    "cursor": "eyJwYWdlIjogMn0="
+  }
+}
+```
+
+## Pagination Flow
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Server
+
+    Client->>Server: List Request (no cursor)
+    loop Pagination Loop
+      Server-->>Client: Page of results + nextCursor
+      Client->>Server: List Request (with cursor)
+    end
+```
+
+## Operations Supporting Pagination
+
+The following MCP operations support pagination:
+
+- `resources/list` - List available resources
+- `resources/templates/list` - List resource templates
+- `prompts/list` - List available prompts
+- `tools/list` - List available tools
+
+## Implementation Guidelines
+
+1. Servers **SHOULD**:
+   - Provide stable cursors
+   - Handle invalid cursors gracefully
+
+2. Clients **SHOULD**:
+   - Treat a missing `nextCursor` as the end of results
+   - Support both paginated and non-paginated flows
+
+3. Clients **MUST** treat cursors as opaque tokens:
+   - Don't make assumptions about cursor format
+   - Don't attempt to parse or modify cursors
+   - Don't persist cursors across sessions
+
+## Error Handling
+
+Invalid cursors **SHOULD** result in an error with code -32602 (Invalid params).

--- a/.agents/skills/mcp-knowledge/references/2025-11-25/ping.md
+++ b/.agents/skills/mcp-knowledge/references/2025-11-25/ping.md
@@ -1,0 +1,63 @@
+<!-- markdownlint-disable -->
+# Ping
+
+The Model Context Protocol includes an optional ping mechanism that allows either party
+to verify that their counterpart is still responsive and the connection is alive.
+
+## Overview
+
+The ping functionality is implemented through a simple request/response pattern. Either
+the client or server can initiate a ping by sending a `ping` request.
+
+## Message Format
+
+A ping request is a standard JSON-RPC request with no parameters:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "123",
+  "method": "ping"
+}
+```
+
+## Behavior Requirements
+
+1. The receiver **MUST** respond promptly with an empty response:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "123",
+  "result": {}
+}
+```
+
+2. If no response is received within a reasonable timeout period, the sender **MAY**:
+   - Consider the connection stale
+   - Terminate the connection
+   - Attempt reconnection procedures
+
+## Usage Patterns
+
+```mermaid
+sequenceDiagram
+    participant Sender
+    participant Receiver
+
+    Sender->>Receiver: ping request
+    Receiver->>Sender: empty response
+```
+
+## Implementation Considerations
+
+- Implementations **SHOULD** periodically issue pings to detect connection health
+- The frequency of pings **SHOULD** be configurable
+- Timeouts **SHOULD** be appropriate for the network environment
+- Excessive pinging **SHOULD** be avoided to reduce network overhead
+
+## Error Handling
+
+- Timeouts **SHOULD** be treated as connection failures
+- Multiple failed pings **MAY** trigger connection reset
+- Implementations **SHOULD** log ping failures for diagnostics

--- a/.agents/skills/mcp-knowledge/references/2025-11-25/progress.md
+++ b/.agents/skills/mcp-knowledge/references/2025-11-25/progress.md
@@ -1,0 +1,91 @@
+<!-- markdownlint-disable -->
+# Progress
+
+The Model Context Protocol (MCP) supports optional progress tracking for long-running
+operations through notification messages. Either side can send progress notifications to
+provide updates about operation status.
+
+## Progress Flow
+
+When a party wants to _receive_ progress updates for a request, it includes a
+`progressToken` in the request metadata.
+
+- Progress tokens **MUST** be a string or integer value
+- Progress tokens can be chosen by the sender using any means, but **MUST** be unique
+  across all active requests.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "some_method",
+  "params": {
+    "_meta": {
+      "progressToken": "abc123"
+    }
+  }
+}
+```
+
+The receiver **MAY** then send progress notifications containing:
+
+- The original progress token
+- The current progress value so far
+- An optional "total" value
+- An optional "message" value
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/progress",
+  "params": {
+    "progressToken": "abc123",
+    "progress": 50,
+    "total": 100,
+    "message": "Reticulating splines..."
+  }
+}
+```
+
+- The `progress` value **MUST** increase with each notification, even if the total is
+  unknown.
+- The `progress` and the `total` values **MAY** be floating point.
+- The `message` field **SHOULD** provide relevant human readable progress information.
+
+## Behavior Requirements
+
+1. Progress notifications **MUST** only reference tokens that:
+   - Were provided in an active request
+   - Are associated with an in-progress operation
+
+2. Receivers of progress requests **MAY**:
+   - Choose not to send any progress notifications
+   - Send notifications at whatever frequency they deem appropriate
+   - Omit the total value if unknown
+
+3. For [task-augmented requests](./tasks), the `progressToken` provided in the original request **MUST** continue to be used for progress notifications throughout the task's lifetime, even after the `CreateTaskResult` has been returned. The progress token remains valid and associated with the task until the task reaches a terminal status.
+   - Progress notifications for tasks **MUST** use the same `progressToken` that was provided in the initial task-augmented request
+   - Progress notifications for tasks **MUST** stop after the task reaches a terminal status (`completed`, `failed`, or `cancelled`)
+
+```mermaid
+sequenceDiagram
+    participant Sender
+    participant Receiver
+
+    Note over Sender,Receiver: Request with progress token
+    Sender->>Receiver: Method request with progressToken
+
+    Note over Sender,Receiver: Progress updates
+    Receiver-->>Sender: Progress notification (0.2/1.0)
+    Receiver-->>Sender: Progress notification (0.6/1.0)
+    Receiver-->>Sender: Progress notification (1.0/1.0)
+
+    Note over Sender,Receiver: Operation complete
+    Receiver->>Sender: Method response
+```
+
+## Implementation Notes
+
+- Senders and receivers **SHOULD** track active progress tokens
+- Both parties **SHOULD** implement rate limiting to prevent flooding
+- Progress notifications **MUST** stop after completion

--- a/.agents/skills/mcp-knowledge/references/2025-11-25/prompts.md
+++ b/.agents/skills/mcp-knowledge/references/2025-11-25/prompts.md
@@ -1,0 +1,282 @@
+<!-- markdownlint-disable -->
+# Prompts
+
+The Model Context Protocol (MCP) provides a standardized way for servers to expose prompt
+templates to clients. Prompts allow servers to provide structured messages and
+instructions for interacting with language models. Clients can discover available
+prompts, retrieve their contents, and provide arguments to customize them.
+
+## User Interaction Model
+
+Prompts are designed to be **user-controlled**, meaning they are exposed from servers to
+clients with the intention of the user being able to explicitly select them for use.
+
+Typically, prompts would be triggered through user-initiated commands in the user
+interface, which allows users to naturally discover and invoke available prompts.
+
+For example, as slash commands:
+
+![Example of prompt exposed as slash command](/specification/2025-11-25/server/slash-command.png)
+
+However, implementors are free to expose prompts through any interface pattern that suits
+their needs&mdash;the protocol itself does not mandate any specific user interaction
+model.
+
+## Capabilities
+
+Servers that support prompts **MUST** declare the `prompts` capability during
+[initialization](/specification/2025-11-25/basic/lifecycle#initialization):
+
+```json
+{
+  "capabilities": {
+    "prompts": {
+      "listChanged": true
+    }
+  }
+}
+```
+
+`listChanged` indicates whether the server will emit notifications when the list of
+available prompts changes.
+
+## Protocol Messages
+
+### Listing Prompts
+
+To retrieve available prompts, clients send a `prompts/list` request. This operation
+supports [pagination](/specification/2025-11-25/server/utilities/pagination).
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "prompts/list",
+  "params": {
+    "cursor": "optional-cursor-value"
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "prompts": [
+      {
+        "name": "code_review",
+        "title": "Request Code Review",
+        "description": "Asks the LLM to analyze code quality and suggest improvements",
+        "arguments": [
+          {
+            "name": "code",
+            "description": "The code to review",
+            "required": true
+          }
+        ],
+        "icons": [
+          {
+            "src": "https://example.com/review-icon.svg",
+            "mimeType": "image/svg+xml",
+            "sizes": ["any"]
+          }
+        ]
+      }
+    ],
+    "nextCursor": "next-page-cursor"
+  }
+}
+```
+
+### Getting a Prompt
+
+To retrieve a specific prompt, clients send a `prompts/get` request. Arguments may be
+auto-completed through [the completion API](/specification/2025-11-25/server/utilities/completion).
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "prompts/get",
+  "params": {
+    "name": "code_review",
+    "arguments": {
+      "code": "def hello():\n    print('world')"
+    }
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "description": "Code review prompt",
+    "messages": [
+      {
+        "role": "user",
+        "content": {
+          "type": "text",
+          "text": "Please review this Python code:\ndef hello():\n    print('world')"
+        }
+      }
+    ]
+  }
+}
+```
+
+### List Changed Notification
+
+When the list of available prompts changes, servers that declared the `listChanged`
+capability **SHOULD** send a notification:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/prompts/list_changed"
+}
+```
+
+## Message Flow
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Server
+
+    Note over Client,Server: Discovery
+    Client->>Server: prompts/list
+    Server-->>Client: List of prompts
+
+    Note over Client,Server: Usage
+    Client->>Server: prompts/get
+    Server-->>Client: Prompt content
+
+    opt listChanged
+      Note over Client,Server: Changes
+      Server--)Client: prompts/list_changed
+      Client->>Server: prompts/list
+      Server-->>Client: Updated prompts
+    end
+```
+
+## Data Types
+
+### Prompt
+
+A prompt definition includes:
+
+- `name`: Unique identifier for the prompt
+- `title`: Optional human-readable name of the prompt for display purposes.
+- `description`: Optional human-readable description
+- `icons`: Optional array of icons for display in user interfaces
+- `arguments`: Optional list of arguments for customization
+
+### PromptMessage
+
+Messages in a prompt can contain:
+
+- `role`: Either "user" or "assistant" to indicate the speaker
+- `content`: One of the following content types:
+
+> **Note:**
+> All content types in prompt messages support optional
+>   [annotations](./resources#annotations) for metadata about audience, priority,
+>   and modification times.
+
+#### Text Content
+
+Text content represents plain text messages:
+
+```json
+{
+  "type": "text",
+  "text": "The text content of the message"
+}
+```
+
+This is the most common content type used for natural language interactions.
+
+#### Image Content
+
+Image content allows including visual information in messages:
+
+```json
+{
+  "type": "image",
+  "data": "base64-encoded-image-data",
+  "mimeType": "image/png"
+}
+```
+
+The image data **MUST** be base64-encoded and include a valid MIME type. This enables
+multi-modal interactions where visual context is important.
+
+#### Audio Content
+
+Audio content allows including audio information in messages:
+
+```json
+{
+  "type": "audio",
+  "data": "base64-encoded-audio-data",
+  "mimeType": "audio/wav"
+}
+```
+
+The audio data MUST be base64-encoded and include a valid MIME type. This enables
+multi-modal interactions where audio context is important.
+
+#### Embedded Resources
+
+Embedded resources allow referencing server-side resources directly in messages:
+
+```json
+{
+  "type": "resource",
+  "resource": {
+    "uri": "resource://example",
+    "mimeType": "text/plain",
+    "text": "Resource content"
+  }
+}
+```
+
+Resources can contain either text or binary (blob) data and **MUST** include:
+
+- A valid resource URI
+- The appropriate MIME type
+- Either text content or base64-encoded blob data
+
+Embedded resources enable prompts to seamlessly incorporate server-managed content like
+documentation, code samples, or other reference materials directly into the conversation
+flow.
+
+## Error Handling
+
+Servers **SHOULD** return standard JSON-RPC errors for common failure cases:
+
+- Invalid prompt name: `-32602` (Invalid params)
+- Missing required arguments: `-32602` (Invalid params)
+- Internal errors: `-32603` (Internal error)
+
+## Implementation Considerations
+
+1. Servers **SHOULD** validate prompt arguments before processing
+2. Clients **SHOULD** handle pagination for large prompt lists
+3. Both parties **SHOULD** respect capability negotiation
+
+## Security
+
+Implementations **MUST** carefully validate all prompt inputs and outputs to prevent
+injection attacks or unauthorized access to resources.

--- a/.agents/skills/mcp-knowledge/references/2025-11-25/resources.md
+++ b/.agents/skills/mcp-knowledge/references/2025-11-25/resources.md
@@ -1,0 +1,409 @@
+<!-- markdownlint-disable -->
+# Resources
+
+The Model Context Protocol (MCP) provides a standardized way for servers to expose
+resources to clients. Resources allow servers to share data that provides context to
+language models, such as files, database schemas, or application-specific information.
+Each resource is uniquely identified by a
+[URI](https://datatracker.ietf.org/doc/html/rfc3986).
+
+## User Interaction Model
+
+Resources in MCP are designed to be **application-driven**, with host applications
+determining how to incorporate context based on their needs.
+
+For example, applications could:
+
+- Expose resources through UI elements for explicit selection, in a tree or list view
+- Allow the user to search through and filter available resources
+- Implement automatic context inclusion, based on heuristics or the AI model's selection
+
+![Example of resource context picker](/specification/2025-11-25/server/resource-picker.png)
+
+However, implementations are free to expose resources through any interface pattern that
+suits their needs&mdash;the protocol itself does not mandate any specific user
+interaction model.
+
+## Capabilities
+
+Servers that support resources **MUST** declare the `resources` capability:
+
+```json
+{
+  "capabilities": {
+    "resources": {
+      "subscribe": true,
+      "listChanged": true
+    }
+  }
+}
+```
+
+The capability supports two optional features:
+
+- `subscribe`: whether the client can subscribe to be notified of changes to individual
+  resources.
+- `listChanged`: whether the server will emit notifications when the list of available
+  resources changes.
+
+Both `subscribe` and `listChanged` are optional&mdash;servers can support neither,
+either, or both:
+
+```json
+{
+  "capabilities": {
+    "resources": {} // Neither feature supported
+  }
+}
+```
+
+```json
+{
+  "capabilities": {
+    "resources": {
+      "subscribe": true // Only subscriptions supported
+    }
+  }
+}
+```
+
+```json
+{
+  "capabilities": {
+    "resources": {
+      "listChanged": true // Only list change notifications supported
+    }
+  }
+}
+```
+
+## Protocol Messages
+
+### Listing Resources
+
+To discover available resources, clients send a `resources/list` request. This operation
+supports [pagination](/specification/2025-11-25/server/utilities/pagination).
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "resources/list",
+  "params": {
+    "cursor": "optional-cursor-value"
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "resources": [
+      {
+        "uri": "file:///project/src/main.rs",
+        "name": "main.rs",
+        "title": "Rust Software Application Main File",
+        "description": "Primary application entry point",
+        "mimeType": "text/x-rust",
+        "icons": [
+          {
+            "src": "https://example.com/rust-file-icon.png",
+            "mimeType": "image/png",
+            "sizes": ["48x48"]
+          }
+        ]
+      }
+    ],
+    "nextCursor": "next-page-cursor"
+  }
+}
+```
+
+### Reading Resources
+
+To retrieve resource contents, clients send a `resources/read` request:
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "resources/read",
+  "params": {
+    "uri": "file:///project/src/main.rs"
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "contents": [
+      {
+        "uri": "file:///project/src/main.rs",
+        "mimeType": "text/x-rust",
+        "text": "fn main() {\n    println!(\"Hello world!\");\n}"
+      }
+    ]
+  }
+}
+```
+
+### Resource Templates
+
+Resource templates allow servers to expose parameterized resources using
+[URI templates](https://datatracker.ietf.org/doc/html/rfc6570). Arguments may be
+auto-completed through [the completion API](/specification/2025-11-25/server/utilities/completion).
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "method": "resources/templates/list"
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "result": {
+    "resourceTemplates": [
+      {
+        "uriTemplate": "file:///{path}",
+        "name": "Project Files",
+        "title": "📁 Project Files",
+        "description": "Access files in the project directory",
+        "mimeType": "application/octet-stream",
+        "icons": [
+          {
+            "src": "https://example.com/folder-icon.png",
+            "mimeType": "image/png",
+            "sizes": ["48x48"]
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### List Changed Notification
+
+When the list of available resources changes, servers that declared the `listChanged`
+capability **SHOULD** send a notification:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/resources/list_changed"
+}
+```
+
+### Subscriptions
+
+The protocol supports optional subscriptions to resource changes. Clients can subscribe
+to specific resources and receive notifications when they change:
+
+**Subscribe Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 4,
+  "method": "resources/subscribe",
+  "params": {
+    "uri": "file:///project/src/main.rs"
+  }
+}
+```
+
+**Update Notification:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/resources/updated",
+  "params": {
+    "uri": "file:///project/src/main.rs"
+  }
+}
+```
+
+## Message Flow
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Server
+
+    Note over Client,Server: Resource Discovery
+    Client->>Server: resources/list
+    Server-->>Client: List of resources
+
+    Note over Client,Server: Resource Template Discovery
+    Client->>Server: resources/templates/list
+    Server-->>Client: List of resource templates
+
+    Note over Client,Server: Resource Access
+    Client->>Server: resources/read
+    Server-->>Client: Resource contents
+
+    Note over Client,Server: Subscriptions
+    Client->>Server: resources/subscribe
+    Server-->>Client: Subscription confirmed
+
+    Note over Client,Server: Updates
+    Server--)Client: notifications/resources/updated
+    Client->>Server: resources/read
+    Server-->>Client: Updated contents
+```
+
+## Data Types
+
+### Resource
+
+A resource definition includes:
+
+- `uri`: Unique identifier for the resource
+- `name`: The name of the resource.
+- `title`: Optional human-readable name of the resource for display purposes.
+- `description`: Optional description
+- `icons`: Optional array of icons for display in user interfaces
+- `mimeType`: Optional MIME type
+- `size`: Optional size in bytes
+
+### Resource Contents
+
+Resources can contain either text or binary data:
+
+#### Text Content
+
+```json
+{
+  "uri": "file:///example.txt",
+  "mimeType": "text/plain",
+  "text": "Resource content"
+}
+```
+
+#### Binary Content
+
+```json
+{
+  "uri": "file:///example.png",
+  "mimeType": "image/png",
+  "blob": "base64-encoded-data"
+}
+```
+
+### Annotations
+
+Resources, resource templates and content blocks support optional annotations that provide hints to clients about how to use or display the resource:
+
+- **`audience`**: An array indicating the intended audience(s) for this resource. Valid values are `"user"` and `"assistant"`. For example, `["user", "assistant"]` indicates content useful for both.
+- **`priority`**: A number from 0.0 to 1.0 indicating the importance of this resource. A value of 1 means "most important" (effectively required), while 0 means "least important" (entirely optional).
+- **`lastModified`**: An ISO 8601 formatted timestamp indicating when the resource was last modified (e.g., `"2025-01-12T15:00:58Z"`).
+
+Example resource with annotations:
+
+```json
+{
+  "uri": "file:///project/README.md",
+  "name": "README.md",
+  "title": "Project Documentation",
+  "mimeType": "text/markdown",
+  "annotations": {
+    "audience": ["user"],
+    "priority": 0.8,
+    "lastModified": "2025-01-12T15:00:58Z"
+  }
+}
+```
+
+Clients can use these annotations to:
+
+- Filter resources based on their intended audience
+- Prioritize which resources to include in context
+- Display modification times or sort by recency
+
+## Common URI Schemes
+
+The protocol defines several standard URI schemes. This list not
+exhaustive&mdash;implementations are always free to use additional, custom URI schemes.
+
+### https://
+
+Used to represent a resource available on the web.
+
+Servers **SHOULD** use this scheme only when the client is able to fetch and load the
+resource directly from the web on its own—that is, it doesn’t need to read the resource
+via the MCP server.
+
+For other use cases, servers **SHOULD** prefer to use another URI scheme, or define a
+custom one, even if the server will itself be downloading resource contents over the
+internet.
+
+### file://
+
+Used to identify resources that behave like a filesystem. However, the resources do not
+need to map to an actual physical filesystem.
+
+MCP servers **MAY** identify file:// resources with an
+[XDG MIME type](https://specifications.freedesktop.org/shared-mime-info-spec/0.14/ar01s02.html#id-1.3.14),
+like `inode/directory`, to represent non-regular files (such as directories) that don’t
+otherwise have a standard MIME type.
+
+### git://
+
+Git version control integration.
+
+### Custom URI Schemes
+
+Custom URI schemes **MUST** be in accordance with [RFC3986](https://datatracker.ietf.org/doc/html/rfc3986),
+taking the above guidance in to account.
+
+## Error Handling
+
+Servers **SHOULD** return standard JSON-RPC errors for common failure cases:
+
+- Resource not found: `-32002`
+- Internal errors: `-32603`
+
+Example error:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 5,
+  "error": {
+    "code": -32002,
+    "message": "Resource not found",
+    "data": {
+      "uri": "file:///nonexistent.txt"
+    }
+  }
+}
+```
+
+## Security Considerations
+
+1. Servers **MUST** validate all resource URIs
+2. Access controls **SHOULD** be implemented for sensitive resources
+3. Binary data **MUST** be properly encoded
+4. Resource permissions **SHOULD** be checked before operations

--- a/.agents/skills/mcp-knowledge/references/2025-11-25/roots.md
+++ b/.agents/skills/mcp-knowledge/references/2025-11-25/roots.md
@@ -1,0 +1,185 @@
+<!-- markdownlint-disable -->
+# Roots
+
+The Model Context Protocol (MCP) provides a standardized way for clients to expose
+filesystem "roots" to servers. Roots define the boundaries of where servers can operate
+within the filesystem, allowing them to understand which directories and files they have
+access to. Servers can request the list of roots from supporting clients and receive
+notifications when that list changes.
+
+## User Interaction Model
+
+Roots in MCP are typically exposed through workspace or project configuration interfaces.
+
+For example, implementations could offer a workspace/project picker that allows users to
+select directories and files the server should have access to. This can be combined with
+automatic workspace detection from version control systems or project files.
+
+However, implementations are free to expose roots through any interface pattern that
+suits their needs&mdash;the protocol itself does not mandate any specific user
+interaction model.
+
+## Capabilities
+
+Clients that support roots **MUST** declare the `roots` capability during
+[initialization](/specification/2025-11-25/basic/lifecycle#initialization):
+
+```json
+{
+  "capabilities": {
+    "roots": {
+      "listChanged": true
+    }
+  }
+}
+```
+
+`listChanged` indicates whether the client will emit notifications when the list of roots
+changes.
+
+## Protocol Messages
+
+### Listing Roots
+
+To retrieve roots, servers send a `roots/list` request:
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "roots/list"
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "roots": [
+      {
+        "uri": "file:///home/user/projects/myproject",
+        "name": "My Project"
+      }
+    ]
+  }
+}
+```
+
+### Root List Changes
+
+When roots change, clients that support `listChanged` **MUST** send a notification:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/roots/list_changed"
+}
+```
+
+## Message Flow
+
+```mermaid
+sequenceDiagram
+    participant Server
+    participant Client
+
+    Note over Server,Client: Discovery
+    Server->>Client: roots/list
+    Client-->>Server: Available roots
+
+    Note over Server,Client: Changes
+    Client--)Server: notifications/roots/list_changed
+    Server->>Client: roots/list
+    Client-->>Server: Updated roots
+```
+
+## Data Types
+
+### Root
+
+A root definition includes:
+
+- `uri`: Unique identifier for the root. This **MUST** be a `file://` URI in the current
+  specification.
+- `name`: Optional human-readable name for display purposes.
+
+Example roots for different use cases:
+
+#### Project Directory
+
+```json
+{
+  "uri": "file:///home/user/projects/myproject",
+  "name": "My Project"
+}
+```
+
+#### Multiple Repositories
+
+```json
+[
+  {
+    "uri": "file:///home/user/repos/frontend",
+    "name": "Frontend Repository"
+  },
+  {
+    "uri": "file:///home/user/repos/backend",
+    "name": "Backend Repository"
+  }
+]
+```
+
+## Error Handling
+
+Clients **SHOULD** return standard JSON-RPC errors for common failure cases:
+
+- Client does not support roots: `-32601` (Method not found)
+- Internal errors: `-32603`
+
+Example error:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "error": {
+    "code": -32601,
+    "message": "Roots not supported",
+    "data": {
+      "reason": "Client does not have roots capability"
+    }
+  }
+}
+```
+
+## Security Considerations
+
+1. Clients **MUST**:
+   - Only expose roots with appropriate permissions
+   - Validate all root URIs to prevent path traversal
+   - Implement proper access controls
+   - Monitor root accessibility
+
+2. Servers **SHOULD**:
+   - Handle cases where roots become unavailable
+   - Respect root boundaries during operations
+   - Validate all paths against provided roots
+
+## Implementation Guidelines
+
+1. Clients **SHOULD**:
+   - Prompt users for consent before exposing roots to servers
+   - Provide clear user interfaces for root management
+   - Validate root accessibility before exposing
+   - Monitor for root changes
+
+2. Servers **SHOULD**:
+   - Check for roots capability before usage
+   - Handle root list changes gracefully
+   - Respect root boundaries in operations
+   - Cache root information appropriately

--- a/.agents/skills/mcp-knowledge/references/2025-11-25/sampling.md
+++ b/.agents/skills/mcp-knowledge/references/2025-11-25/sampling.md
@@ -1,0 +1,628 @@
+<!-- markdownlint-disable -->
+# Sampling
+
+The Model Context Protocol (MCP) provides a standardized way for servers to request LLM
+sampling ("completions" or "generations") from language models via clients. This flow
+allows clients to maintain control over model access, selection, and permissions while
+enabling servers to leverage AI capabilities&mdash;with no server API keys necessary.
+Servers can request text, audio, or image-based interactions and optionally include
+context from MCP servers in their prompts.
+
+## User Interaction Model
+
+Sampling in MCP allows servers to implement agentic behaviors, by enabling LLM calls to
+occur _nested_ inside other MCP server features.
+
+Implementations are free to expose sampling through any interface pattern that suits
+their needs&mdash;the protocol itself does not mandate any specific user interaction
+model.
+
+> **Warning:**
+> For trust & safety and security, there **SHOULD** always
+> be a human in the loop with the ability to deny sampling requests.
+>
+> Applications **SHOULD**:
+>
+> - Provide UI that makes it easy and intuitive to review sampling requests
+> - Allow users to view and edit prompts before sending
+> - Present generated responses for review before delivery
+
+## Tools in Sampling
+
+Servers can request that the client's LLM use tools during sampling by providing a `tools` array and optional `toolChoice` configuration in their sampling requests. This enables servers to implement agentic behaviors where the LLM can call tools, receive results, and continue the conversation - all within a single sampling request flow.
+
+Clients **MUST** declare support for tool use via the `sampling.tools` capability to receive tool-enabled sampling requests. Servers **MUST NOT** send tool-enabled sampling requests to Clients that have not declared support for tool use via the `sampling.tools` capability.
+
+## Capabilities
+
+Clients that support sampling **MUST** declare the `sampling` capability during
+[initialization](/specification/2025-11-25/basic/lifecycle#initialization):
+
+**Basic sampling:**
+
+```json
+{
+  "capabilities": {
+    "sampling": {}
+  }
+}
+```
+
+**With tool use support:**
+
+```json
+{
+  "capabilities": {
+    "sampling": {
+      "tools": {}
+    }
+  }
+}
+```
+
+**With context inclusion support (soft-deprecated):**
+
+```json
+{
+  "capabilities": {
+    "sampling": {
+      "context": {}
+    }
+  }
+}
+```
+
+> **Note:**
+> The `includeContext` parameter values `"thisServer"` and `"allServers"` are
+>   soft-deprecated. Servers **SHOULD** avoid using these values (e.g. can just
+>   omit `includeContext` since it defaults to `"none"`), and **SHOULD NOT** use
+>   them unless the client declares `sampling.context` capability. These values
+>   may be removed in future spec releases.
+
+## Protocol Messages
+
+### Creating Messages
+
+To request a language model generation, servers send a `sampling/createMessage` request:
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "sampling/createMessage",
+  "params": {
+    "messages": [
+      {
+        "role": "user",
+        "content": {
+          "type": "text",
+          "text": "What is the capital of France?"
+        }
+      }
+    ],
+    "modelPreferences": {
+      "hints": [
+        {
+          "name": "claude-3-sonnet"
+        }
+      ],
+      "intelligencePriority": 0.8,
+      "speedPriority": 0.5
+    },
+    "systemPrompt": "You are a helpful assistant.",
+    "maxTokens": 100
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "role": "assistant",
+    "content": {
+      "type": "text",
+      "text": "The capital of France is Paris."
+    },
+    "model": "claude-3-sonnet-20240307",
+    "stopReason": "endTurn"
+  }
+}
+```
+
+### Sampling with Tools
+
+The following diagram illustrates the complete flow of sampling with tools, including the multi-turn tool loop:
+
+```mermaid
+sequenceDiagram
+    participant Server
+    participant Client
+    participant User
+    participant LLM
+
+    Note over Server,Client: Initial request with tools
+    Server->>Client: sampling/createMessage<br/>(messages + tools)
+
+    Note over Client,User: Human-in-the-loop review
+    Client->>User: Present request for approval
+    User-->>Client: Approve/modify
+
+    Client->>LLM: Forward request with tools
+    LLM-->>Client: Response with tool_use<br/>(stopReason: "toolUse")
+
+    Client->>User: Present tool calls for review
+    User-->>Client: Approve tool calls
+    Client-->>Server: Return tool_use response
+
+    Note over Server: Execute tool(s)
+    Server->>Server: Run get_weather("Paris")<br/>Run get_weather("London")
+
+    Note over Server,Client: Continue with tool results
+    Server->>Client: sampling/createMessage<br/>(history + tool_results + tools)
+
+    Client->>User: Present continuation
+    User-->>Client: Approve
+
+    Client->>LLM: Forward with tool results
+    LLM-->>Client: Final text response<br/>(stopReason: "endTurn")
+
+    Client->>User: Present response
+    User-->>Client: Approve
+    Client-->>Server: Return final response
+
+    Note over Server: Server processes result<br/>(may continue conversation...)
+```
+
+To request LLM generation with tool use capabilities, servers include `tools` and optionally `toolChoice` in the request:
+
+**Request (Server -> Client):**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "sampling/createMessage",
+  "params": {
+    "messages": [
+      {
+        "role": "user",
+        "content": {
+          "type": "text",
+          "text": "What's the weather like in Paris and London?"
+        }
+      }
+    ],
+    "tools": [
+      {
+        "name": "get_weather",
+        "description": "Get current weather for a city",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "city": {
+              "type": "string",
+              "description": "City name"
+            }
+          },
+          "required": ["city"]
+        }
+      }
+    ],
+    "toolChoice": {
+      "mode": "auto"
+    },
+    "maxTokens": 1000
+  }
+}
+```
+
+**Response (Client -> Server):**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "role": "assistant",
+    "content": [
+      {
+        "type": "tool_use",
+        "id": "call_abc123",
+        "name": "get_weather",
+        "input": {
+          "city": "Paris"
+        }
+      },
+      {
+        "type": "tool_use",
+        "id": "call_def456",
+        "name": "get_weather",
+        "input": {
+          "city": "London"
+        }
+      }
+    ],
+    "model": "claude-3-sonnet-20240307",
+    "stopReason": "toolUse"
+  }
+}
+```
+
+### Multi-turn Tool Loop
+
+After receiving tool use requests from the LLM, the server typically:
+
+1. Executes the requested tool uses.
+2. Sends a new sampling request with the tool results appended
+3. Receives the LLM's response (which might contain new tool uses)
+4. Repeats as many times as needed (server might cap the maximum number of iterations, and e.g. pass `toolChoice: {mode: "none"}` on the last iteration to force a final result)
+
+**Follow-up request (Server -> Client) with tool results:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "sampling/createMessage",
+  "params": {
+    "messages": [
+      {
+        "role": "user",
+        "content": {
+          "type": "text",
+          "text": "What's the weather like in Paris and London?"
+        }
+      },
+      {
+        "role": "assistant",
+        "content": [
+          {
+            "type": "tool_use",
+            "id": "call_abc123",
+            "name": "get_weather",
+            "input": { "city": "Paris" }
+          },
+          {
+            "type": "tool_use",
+            "id": "call_def456",
+            "name": "get_weather",
+            "input": { "city": "London" }
+          }
+        ]
+      },
+      {
+        "role": "user",
+        "content": [
+          {
+            "type": "tool_result",
+            "toolUseId": "call_abc123",
+            "content": [
+              {
+                "type": "text",
+                "text": "Weather in Paris: 18°C, partly cloudy"
+              }
+            ]
+          },
+          {
+            "type": "tool_result",
+            "toolUseId": "call_def456",
+            "content": [
+              {
+                "type": "text",
+                "text": "Weather in London: 15°C, rainy"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "tools": [
+      {
+        "name": "get_weather",
+        "description": "Get current weather for a city",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "city": { "type": "string" }
+          },
+          "required": ["city"]
+        }
+      }
+    ],
+    "maxTokens": 1000
+  }
+}
+```
+
+**Final response (Client -> Server):**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "role": "assistant",
+    "content": {
+      "type": "text",
+      "text": "Based on the current weather data:\n\n- **Paris**: 18°C and partly cloudy - quite pleasant!\n- **London**: 15°C and rainy - you'll want an umbrella.\n\nParis has slightly warmer and drier conditions today."
+    },
+    "model": "claude-3-sonnet-20240307",
+    "stopReason": "endTurn"
+  }
+}
+```
+
+## Message Content Constraints
+
+### Tool Result Messages
+
+When a user message contains tool results (type: "tool_result"), it **MUST** contain ONLY tool results. Mixing tool results with other content types (text, image, audio) in the same message is not allowed.
+
+This constraint ensures compatibility with provider APIs that use dedicated roles for tool results (e.g., OpenAI's "tool" role, Gemini's "function" role).
+
+**Valid - single tool result:**
+
+```json
+{
+  "role": "user",
+  "content": {
+    "type": "tool_result",
+    "toolUseId": "call_123",
+    "content": [{ "type": "text", "text": "Result data" }]
+  }
+}
+```
+
+**Valid - multiple tool results:**
+
+```json
+{
+  "role": "user",
+  "content": [
+    {
+      "type": "tool_result",
+      "toolUseId": "call_123",
+      "content": [{ "type": "text", "text": "Result 1" }]
+    },
+    {
+      "type": "tool_result",
+      "toolUseId": "call_456",
+      "content": [{ "type": "text", "text": "Result 2" }]
+    }
+  ]
+}
+```
+
+**Invalid - mixed content:**
+
+```json
+{
+  "role": "user",
+  "content": [
+    {
+      "type": "text",
+      "text": "Here are the results:"
+    },
+    {
+      "type": "tool_result",
+      "toolUseId": "call_123",
+      "content": [{ "type": "text", "text": "Result data" }]
+    }
+  ]
+}
+```
+
+### Tool Use and Result Balance
+
+When using tool use in sampling, every assistant message containing `ToolUseContent` blocks **MUST** be followed by a user message that consists entirely of `ToolResultContent` blocks, with each tool use (e.g. with `id: $id`) matched by a corresponding tool result (with `toolUseId: $id`), before any other message.
+
+This requirement ensures:
+
+- Tool uses are always resolved before the conversation continues
+- Provider APIs can concurrently process multiple tool uses and fetch their results in parallel
+- The conversation maintains a consistent request-response pattern
+
+**Example valid sequence:**
+
+1. User message: "What's the weather like in Paris and London?"
+2. Assistant message: `ToolUseContent` (`id: "call_abc123", name: "get_weather", input: {city: "Paris"}`) + `ToolUseContent` (`id: "call_def456", name: "get_weather", input: {city: "London"}`)
+3. User message: `ToolResultContent` (`toolUseId: "call_abc123", content: "18°C, partly cloudy"`) + `ToolResultContent` (`toolUseId: "call_def456", content: "15°C, rainy"`)
+4. Assistant message: Text response comparing the weather in both cities
+
+**Invalid sequence - missing tool result:**
+
+1. User message: "What's the weather like in Paris and London?"
+2. Assistant message: `ToolUseContent` (`id: "call_abc123", name: "get_weather", input: {city: "Paris"}`) + `ToolUseContent` (`id: "call_def456", name: "get_weather", input: {city: "London"}`)
+3. User message: `ToolResultContent` (`toolUseId: "call_abc123", content: "18°C, partly cloudy"`) ← Missing result for call_def456
+4. Assistant message: Text response (invalid - not all tool uses were resolved)
+
+## Cross-API Compatibility
+
+The sampling specification is designed to work across multiple LLM provider APIs (Claude, OpenAI, Gemini, etc.). Key design decisions for compatibility:
+
+### Message Roles
+
+MCP uses two roles: "user" and "assistant".
+
+Tool use requests are sent in CreateMessageResult with the "assistant" role.
+Tool results are sent back in messages with the "user" role.
+Messages with tool results cannot contain other kinds of content.
+
+### Tool Choice Modes
+
+`CreateMessageRequest.params.toolChoice` controls the tool use ability of the model:
+
+- `{mode: "auto"}`: Model decides whether to use tools (default)
+- `{mode: "required"}`: Model MUST use at least one tool before completing
+- `{mode: "none"}`: Model MUST NOT use any tools
+
+### Parallel Tool Use
+
+MCP allows models to make multiple tool use requests in parallel (returning an array of `ToolUseContent`). All major provider APIs support this:
+
+- **Claude**: Supports parallel tool use natively
+- **OpenAI**: Supports parallel tool calls (can be disabled with `parallel_tool_calls: false`)
+- **Gemini**: Supports parallel function calls natively
+
+Implementations wrapping providers that support disabling parallel tool use MAY expose this as an extension, but it is not part of the core MCP specification.
+
+## Message Flow
+
+```mermaid
+sequenceDiagram
+    participant Server
+    participant Client
+    participant User
+    participant LLM
+
+    Note over Server,Client: Server initiates sampling
+    Server->>Client: sampling/createMessage
+
+    Note over Client,User: Human-in-the-loop review
+    Client->>User: Present request for approval
+    User-->>Client: Review and approve/modify
+
+    Note over Client,LLM: Model interaction
+    Client->>LLM: Forward approved request
+    LLM-->>Client: Return generation
+
+    Note over Client,User: Response review
+    Client->>User: Present response for approval
+    User-->>Client: Review and approve/modify
+
+    Note over Server,Client: Complete request
+    Client-->>Server: Return approved response
+```
+
+## Data Types
+
+### Messages
+
+Sampling messages can contain:
+
+#### Text Content
+
+```json
+{
+  "type": "text",
+  "text": "The message content"
+}
+```
+
+#### Image Content
+
+```json
+{
+  "type": "image",
+  "data": "base64-encoded-image-data",
+  "mimeType": "image/jpeg"
+}
+```
+
+#### Audio Content
+
+```json
+{
+  "type": "audio",
+  "data": "base64-encoded-audio-data",
+  "mimeType": "audio/wav"
+}
+```
+
+### Model Preferences
+
+Model selection in MCP requires careful abstraction since servers and clients may use
+different AI providers with distinct model offerings. A server cannot simply request a
+specific model by name since the client may not have access to that exact model or may
+prefer to use a different provider's equivalent model.
+
+To solve this, MCP implements a preference system that combines abstract capability
+priorities with optional model hints:
+
+#### Capability Priorities
+
+Servers express their needs through three normalized priority values (0-1):
+
+- `costPriority`: How important is minimizing costs? Higher values prefer cheaper models.
+- `speedPriority`: How important is low latency? Higher values prefer faster models.
+- `intelligencePriority`: How important are advanced capabilities? Higher values prefer
+  more capable models.
+
+#### Model Hints
+
+While priorities help select models based on characteristics, `hints` allow servers to
+suggest specific models or model families:
+
+- Hints are treated as substrings that can match model names flexibly
+- Multiple hints are evaluated in order of preference
+- Clients **MAY** map hints to equivalent models from different providers
+- Hints are advisory&mdash;clients make final model selection
+
+For example:
+
+```json
+{
+  "hints": [
+    { "name": "claude-3-sonnet" }, // Prefer Sonnet-class models
+    { "name": "claude" } // Fall back to any Claude model
+  ],
+  "costPriority": 0.3, // Cost is less important
+  "speedPriority": 0.8, // Speed is very important
+  "intelligencePriority": 0.5 // Moderate capability needs
+}
+```
+
+The client processes these preferences to select an appropriate model from its available
+options. For instance, if the client doesn't have access to Claude models but has Gemini,
+it might map the sonnet hint to `gemini-1.5-pro` based on similar capabilities.
+
+## Error Handling
+
+Clients **SHOULD** return errors for common failure cases:
+
+- User rejected sampling request: `-1`
+- Tool result missing in request: `-32602` (Invalid params)
+- Tool results mixed with other content: `-32602` (Invalid params)
+
+Example errors:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "error": {
+    "code": -1,
+    "message": "User rejected sampling request"
+  }
+}
+```
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 4,
+  "error": {
+    "code": -32602,
+    "message": "Tool result missing in request"
+  }
+}
+```
+
+## Security Considerations
+
+1. Clients **SHOULD** implement user approval controls
+2. Both parties **SHOULD** validate message content
+3. Clients **SHOULD** respect model preference hints
+4. Clients **SHOULD** implement rate limiting
+5. Both parties **MUST** handle sensitive data appropriately
+
+When tools are used in sampling, additional security considerations apply:
+
+6. Servers **MUST** ensure that when replying to a `stopReason: "toolUse"`, each `ToolUseContent` item is responded to with a `ToolResultContent` item with a matching `toolUseId`, and that the user message contains only tool results (no other content types)
+7. Both parties **SHOULD** implement iteration limits for tool loops

--- a/.agents/skills/mcp-knowledge/references/2025-11-25/tasks.md
+++ b/.agents/skills/mcp-knowledge/references/2025-11-25/tasks.md
@@ -1,0 +1,879 @@
+<!-- markdownlint-disable -->
+# Tasks
+
+> **Note:**
+> Tasks were introduced in version 2025-11-25 of the MCP specification and are currently considered **experimental**.
+> The design and behavior of tasks may evolve in future protocol versions.
+
+The Model Context Protocol (MCP) allows requestors — which can be either clients or servers, depending on the direction of communication — to augment their requests with **tasks**. Tasks are durable state machines that carry information about the underlying execution state of the request they wrap, and are intended for requestor polling and deferred result retrieval. Each task is uniquely identifiable by a receiver-generated **task ID**.
+
+Tasks are useful for representing expensive computations and batch processing requests, and integrate seamlessly with external job APIs.
+
+## Definitions
+
+Tasks represent parties as either "requestors" or "receivers," defined as follows:
+
+- **Requestor:** The sender of a task-augmented request. This can be the client or the server — either can create tasks.
+- **Receiver:** The receiver of a task-augmented request, and the entity executing the task. This can be the client or the server — either can receive and execute tasks.
+
+## User Interaction Model
+
+Tasks are designed to be **requestor-driven** - requestors are responsible for augmenting requests with tasks and for polling for the results of those tasks; meanwhile, receivers tightly control which requests (if any) support task-based execution and manages the lifecycles of those tasks.
+
+This requestor-driven approach ensures deterministic response handling and enables sophisticated patterns such as dispatching concurrent requests, which only the requestor has sufficient context to orchestrate.
+
+Implementations are free to expose tasks through any interface pattern that suits their needs — the protocol itself does not mandate any specific user interaction model.
+
+## Capabilities
+
+Servers and clients that support task-augmented requests **MUST** declare a `tasks` capability during initialization. The `tasks` capability is structured by request category, with boolean properties indicating which specific request types support task augmentation.
+
+### Server Capabilities
+
+Servers declare if they support tasks, and if so, which server-side requests can be augmented with tasks.
+
+| Capability                  | Description                                          |
+| --------------------------- | ---------------------------------------------------- |
+| `tasks.list`                | Server supports the `tasks/list` operation           |
+| `tasks.cancel`              | Server supports the `tasks/cancel` operation         |
+| `tasks.requests.tools.call` | Server supports task-augmented `tools/call` requests |
+
+```json
+{
+  "capabilities": {
+    "tasks": {
+      "list": {},
+      "cancel": {},
+      "requests": {
+        "tools": {
+          "call": {}
+        }
+      }
+    }
+  }
+}
+```
+
+### Client Capabilities
+
+Clients declare if they support tasks, and if so, which client-side requests can be augmented with tasks.
+
+| Capability                              | Description                                                      |
+| --------------------------------------- | ---------------------------------------------------------------- |
+| `tasks.list`                            | Client supports the `tasks/list` operation                       |
+| `tasks.cancel`                          | Client supports the `tasks/cancel` operation                     |
+| `tasks.requests.sampling.createMessage` | Client supports task-augmented `sampling/createMessage` requests |
+| `tasks.requests.elicitation.create`     | Client supports task-augmented `elicitation/create` requests     |
+
+```json
+{
+  "capabilities": {
+    "tasks": {
+      "list": {},
+      "cancel": {},
+      "requests": {
+        "sampling": {
+          "createMessage": {}
+        },
+        "elicitation": {
+          "create": {}
+        }
+      }
+    }
+  }
+}
+```
+
+### Capability Negotiation
+
+During the initialization phase, both parties exchange their `tasks` capabilities to establish which operations support task-based execution. Requestors **SHOULD** only augment requests with a task if the corresponding capability has been declared by the receiver.
+
+For example, if a server's capabilities include `tasks.requests.tools.call: {}`, then clients may augment `tools/call` requests with a task. If a client's capabilities include `tasks.requests.sampling.createMessage: {}`, then servers may augment `sampling/createMessage` requests with a task.
+
+If `capabilities.tasks` is not defined, the peer **SHOULD NOT** attempt to create tasks during requests.
+
+The set of capabilities in `capabilities.tasks.requests` is exhaustive. If a request type is not present, it does not support task-augmentation.
+
+`capabilities.tasks.list` controls if the `tasks/list` operation is supported by the party.
+
+`capabilities.tasks.cancel` controls if the `tasks/cancel` operation is supported by the party.
+
+### Tool-Level Negotiation
+
+Tool calls are given special consideration for the purpose of task augmentation. In the result of `tools/list`, tools declare support for tasks via `execution.taskSupport`, which if present can have a value of `"required"`, `"optional"`, or `"forbidden"`.
+
+This is to be interpreted as a fine-grained layer in addition to capabilities, following these rules:
+
+1. If a server's capabilities do not include `tasks.requests.tools.call`, then clients **MUST NOT** attempt to use task augmentation on that server's tools, regardless of the `execution.taskSupport` value.
+1. If a server's capabilities include `tasks.requests.tools.call`, then clients consider the value of `execution.taskSupport`, and handle it accordingly:
+   1. If `execution.taskSupport` is not present or `"forbidden"`, clients **MUST NOT** attempt to invoke the tool as a task. Servers **SHOULD** return a `-32601` (Method not found) error if a client attempts to do so. This is the default behavior.
+   1. If `execution.taskSupport` is `"optional"`, clients **MAY** invoke the tool as a task or as a normal request.
+   1. If `execution.taskSupport` is `"required"`, clients **MUST** invoke the tool as a task. Servers **MUST** return a `-32601` (Method not found) error if a client does not attempt to do so.
+
+## Protocol Messages
+
+### Creating Tasks
+
+Task-augmented requests follow a two-phase response pattern that differs from normal requests:
+
+- **Normal requests**: The server processes the request and returns the actual operation result directly.
+- **Task-augmented requests**: The server accepts the request and immediately returns a `CreateTaskResult` containing task data. The actual operation result becomes available later through `tasks/result` after the task completes.
+
+To create a task, requestors send a request with the `task` field included in the request params. Requestors **MAY** include a `ttl` value indicating the desired task lifetime duration (in milliseconds) since its creation.
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "get_weather",
+    "arguments": {
+      "city": "New York"
+    },
+    "task": {
+      "ttl": 60000
+    }
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "task": {
+      "taskId": "786512e2-9e0d-44bd-8f29-789f320fe840",
+      "status": "working",
+      "statusMessage": "The operation is now in progress.",
+      "createdAt": "2025-11-25T10:30:00Z",
+      "lastUpdatedAt": "2025-11-25T10:40:00Z",
+      "ttl": 60000,
+      "pollInterval": 5000
+    }
+  }
+}
+```
+
+When a receiver accepts a task-augmented request, it returns a [`CreateTaskResult`](/specification/2025-11-25/schema#createtaskresult) containing task data. The response does not include the actual operation result. The actual result (e.g., tool result for `tools/call`) becomes available only through `tasks/result` after the task completes.
+
+> **Note:**
+> When a task is created in response to a `tools/call` request, host applications may wish to return control to the model while the task is executing. This allows the model to continue processing other requests or perform additional work while waiting for the task to complete.
+>
+> To support this pattern, servers can provide an optional `io.modelcontextprotocol/model-immediate-response` key in the `_meta` field of the `CreateTaskResult`. The value of this key should be a string intended to be passed as an immediate tool result to the model.
+> If a server does not provide this field, the host application can fall back to its own predefined message.
+>
+> This guidance is non-binding and is provisional logic intended to account for the specific use case. This behavior may be formalized or modified as part of `CreateTaskResult` in future protocol versions.
+
+### Getting Tasks
+
+> **Note:**
+> In the Streamable HTTP (SSE) transport, clients **MAY** disconnect from an SSE stream opened by the server in response to a `tasks/get` request at any time.
+>
+> While this note is not prescriptive regarding the specific usage of SSE streams, all implementations **MUST** continue to comply with the existing [Streamable HTTP transport specification](../transports#sending-messages-to-the-server).
+
+Requestors poll for task completion by sending [`tasks/get`](/specification/2025-11-25/schema#tasks%2Fget) requests.
+Requestors **SHOULD** respect the `pollInterval` provided in responses when determining polling frequency.
+
+Requestors **SHOULD** continue polling until the task reaches a terminal status (`completed`, `failed`, or `cancelled`), or until encountering the [`input_required`](#input-required-status) status. Note that invoking `tasks/result` does not imply that the requestor needs to stop polling - requestors **SHOULD** continue polling the task status via `tasks/get` if they are not actively waiting for `tasks/result` to complete.
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "method": "tasks/get",
+  "params": {
+    "taskId": "786512e2-9e0d-44bd-8f29-789f320fe840"
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "result": {
+    "taskId": "786512e2-9e0d-44bd-8f29-789f320fe840",
+    "status": "working",
+    "statusMessage": "The operation is now in progress.",
+    "createdAt": "2025-11-25T10:30:00Z",
+    "lastUpdatedAt": "2025-11-25T10:40:00Z",
+    "ttl": 30000,
+    "pollInterval": 5000
+  }
+}
+```
+
+### Retrieving Task Results
+
+> **Note:**
+> In the Streamable HTTP (SSE) transport, clients **MAY** disconnect from an SSE stream opened by the server in response to a `tasks/result` request at any time.
+>
+> While this note is not prescriptive regarding the specific usage of SSE streams, all implementations **MUST** continue to comply with the existing [Streamable HTTP transport specification](../transports#sending-messages-to-the-server).
+
+After a task completes the operation result is retrieved via [`tasks/result`](/specification/2025-11-25/schema#tasks%2Fresult). This is distinct from the initial `CreateTaskResult` response, which contains only task data. The result structure matches the original request type (e.g., `CallToolResult` for `tools/call`).
+
+To retrieve the result of a completed task, requestors can send a `tasks/result` request:
+
+While `tasks/result` blocks until the task reaches a terminal status, requestors can continue polling via `tasks/get` in parallel if they are not actively blocked waiting for the result, such as if their previous `tasks/result` request failed or was cancelled. This allows requestors to monitor status changes or display progress updates while the task executes, even after invoking `tasks/result`.
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 4,
+  "method": "tasks/result",
+  "params": {
+    "taskId": "786512e2-9e0d-44bd-8f29-789f320fe840"
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 4,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "Current weather in New York:\nTemperature: 72°F\nConditions: Partly cloudy"
+      }
+    ],
+    "isError": false,
+    "_meta": {
+      "io.modelcontextprotocol/related-task": {
+        "taskId": "786512e2-9e0d-44bd-8f29-789f320fe840"
+      }
+    }
+  }
+}
+```
+
+### Task Status Notification
+
+When a task status changes, receivers **MAY** send a [`notifications/tasks/status`](/specification/2025-11-25/schema#notifications%2Ftasks%2Fstatus) notification to inform the requestor of the change. This notification includes the full task state.
+
+**Notification:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/tasks/status",
+  "params": {
+    "taskId": "786512e2-9e0d-44bd-8f29-789f320fe840",
+    "status": "completed",
+    "createdAt": "2025-11-25T10:30:00Z",
+    "lastUpdatedAt": "2025-11-25T10:50:00Z",
+    "ttl": 60000,
+    "pollInterval": 5000
+  }
+}
+```
+
+The notification includes the full [`Task`](/specification/2025-11-25/schema#task) object, including the updated `status` and `statusMessage` (if present). This allows requestors to access the complete task state without making an additional `tasks/get` request.
+
+Requestors **MUST NOT** rely on receiving this notifications, as it is optional. Receivers are not required to send status notifications and may choose to only send them for certain status transitions. Requestors **SHOULD** continue to poll via `tasks/get` to ensure they receive status updates.
+
+### Listing Tasks
+
+To retrieve a list of tasks, requestors can send a [`tasks/list`](/specification/2025-11-25/schema#tasks%2Flist) request. This operation supports pagination.
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 5,
+  "method": "tasks/list",
+  "params": {
+    "cursor": "optional-cursor-value"
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 5,
+  "result": {
+    "tasks": [
+      {
+        "taskId": "786512e2-9e0d-44bd-8f29-789f320fe840",
+        "status": "working",
+        "createdAt": "2025-11-25T10:30:00Z",
+        "lastUpdatedAt": "2025-11-25T10:40:00Z",
+        "ttl": 30000,
+        "pollInterval": 5000
+      },
+      {
+        "taskId": "abc123-def456-ghi789",
+        "status": "completed",
+        "createdAt": "2025-11-25T09:15:00Z",
+        "lastUpdatedAt": "2025-11-25T10:40:00Z",
+        "ttl": 60000
+      }
+    ],
+    "nextCursor": "next-page-cursor"
+  }
+}
+```
+
+### Cancelling Tasks
+
+To explicitly cancel a task, requestors can send a [`tasks/cancel`](/specification/2025-11-25/schema#tasks%2Fcancel) request.
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 6,
+  "method": "tasks/cancel",
+  "params": {
+    "taskId": "786512e2-9e0d-44bd-8f29-789f320fe840"
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 6,
+  "result": {
+    "taskId": "786512e2-9e0d-44bd-8f29-789f320fe840",
+    "status": "cancelled",
+    "statusMessage": "The task was cancelled by request.",
+    "createdAt": "2025-11-25T10:30:00Z",
+    "lastUpdatedAt": "2025-11-25T10:40:00Z",
+    "ttl": 30000,
+    "pollInterval": 5000
+  }
+}
+```
+
+## Behavior Requirements
+
+These requirements apply to all parties that support receiving task-augmented requests.
+
+### Task Support and Handling
+
+1. Receivers that do not declare the task capability for a request type **MUST** process requests of that type normally, ignoring any task-augmentation metadata if present.
+1. Receivers that declare the task capability for a request type **MAY** return an error for non-task-augmented requests, requiring requestors to use task augmentation.
+
+### Task ID Requirements
+
+1. Task IDs **MUST** be a string value.
+1. Task IDs **MUST** be generated by the receiver when creating a task.
+1. Task IDs **MUST** be unique among all tasks controlled by the receiver.
+
+### Task Status Lifecycle
+
+1. Tasks **MUST** begin in the `working` status when created.
+1. Receivers **MUST** only transition tasks through the following valid paths:
+   1. From `working`: may move to `input_required`, `completed`, `failed`, or `cancelled`
+   1. From `input_required`: may move to `working`, `completed`, `failed`, or `cancelled`
+   1. Tasks with a `completed`, `failed`, or `cancelled` status are in a terminal state and **MUST NOT** transition to any other status
+
+**Task Status State Diagram:**
+
+```mermaid
+stateDiagram-v2
+    [*] --> working
+
+    working --> input_required
+    working --> terminal
+
+    input_required --> working
+    input_required --> terminal
+
+    terminal --> [*]
+
+    note right of terminal
+        Terminal states:
+        • completed
+        • failed
+        • cancelled
+    end note
+```
+
+### Input Required Status
+
+> **Note:**
+> With the Streamable HTTP (SSE) transport, servers often close SSE streams after delivering a response message, which can lead to ambiguity regarding the stream used for subsequent task messages.
+>
+> Servers can handle this by enqueueing messages to the client to side-channel task-related messages alongside other responses.
+>
+> Servers have flexibility in how they manage SSE streams during task polling and result retrieval, and clients **SHOULD** expect messages to be delivered on any SSE stream, including the HTTP GET stream.
+> One possible approach is maintaining an SSE stream on `tasks/result` (see notes on the `input_required` status).
+> Where possible, servers **SHOULD NOT** upgrade to an SSE stream in response to a `tasks/get` request, as the client has indicated it wishes to poll for a result.
+>
+> While this note is not prescriptive regarding the specific usage of SSE streams, all implementations **MUST** continue to comply with the existing [Streamable HTTP transport specification](../transports#sending-messages-to-the-server).
+
+1. When the task receiver has messages for the requestor that are necessary to complete the task, the receiver **SHOULD** move the task to the `input_required` status.
+1. The receiver **MUST** include the `io.modelcontextprotocol/related-task` metadata in the request to associate it with the task.
+1. When the requestor encounters the `input_required` status, it **SHOULD** preemptively call `tasks/result`.
+1. When the receiver receives all required input, the task **SHOULD** transition out of `input_required` status (typically back to `working`).
+
+### TTL and Resource Management
+
+1. Receivers **MUST** include a `createdAt` [ISO 8601](https://datatracker.ietf.org/doc/html/rfc3339#section-5)-formatted timestamp in all task responses to indicate when the task was created.
+1. Receivers **MUST** include a `lastUpdatedAt` [ISO 8601](https://datatracker.ietf.org/doc/html/rfc3339#section-5)-formatted timestamp in all task responses to indicate when the task was last updated.
+1. Receivers **MAY** override the requested `ttl` duration.
+1. Receivers **MUST** include the actual `ttl` duration (or `null` for unlimited) in `tasks/get` responses.
+1. After a task's `ttl` lifetime has elapsed, receivers **MAY** delete the task and its results, regardless of the task status.
+1. Receivers **MAY** include a `pollInterval` value (in milliseconds) in `tasks/get` responses to suggest polling intervals. Requestors **SHOULD** respect this value when provided.
+
+### Result Retrieval
+
+1. Receivers that accept a task-augmented request **MUST** return a `CreateTaskResult` as the response. This result **SHOULD** be returned as soon as possible after accepting the task.
+1. When a receiver receives a `tasks/result` request for a task in a terminal status (`completed`, `failed`, or `cancelled`), it **MUST** return the final result of the underlying request, whether that is a successful result or a JSON-RPC error.
+1. When a receiver receives a `tasks/result` request for a task in any other non-terminal status (`working` or `input_required`), it **MUST** block the response until the task reaches a terminal status.
+1. For tasks in a terminal status, receivers **MUST** return from `tasks/result` exactly what the underlying request would have returned, whether that is a successful result or a JSON-RPC error.
+
+### Associating Task-Related Messages
+
+1. All requests, notifications, and responses related to a task **MUST** include the `io.modelcontextprotocol/related-task` key in their `_meta` field, with the value set to an object with a `taskId` matching the associated task ID.
+   1. For example, an elicitation that a task-augmented tool call depends on **MUST** share the same related task ID with that tool call's task.
+1. For the `tasks/get`, `tasks/result`, and `tasks/cancel` operations, the `taskId` parameter in the request **MUST** be used as the source of truth for identifying the target task. Requestors **SHOULD NOT** include `io.modelcontextprotocol/related-task` metadata in these requests, and receivers **MUST** ignore such metadata if present in favor of the RPC method parameter.
+   Similarly, for the `tasks/get`, `tasks/list`, and `tasks/cancel` operations, receivers **SHOULD NOT** include `io.modelcontextprotocol/related-task` metadata in the result messages, as the `taskId` is already present in the response structure.
+
+### Task Notifications
+
+1. Receivers **MAY** send `notifications/tasks/status` notifications when a task's status changes.
+1. Requestors **MUST NOT** rely on receiving the `notifications/tasks/status` notification, as it is optional.
+1. When sent, the `notifications/tasks/status` notification **SHOULD NOT** include the `io.modelcontextprotocol/related-task` metadata, as the task ID is already present in the notification parameters.
+
+### Task Progress Notifications
+
+Task-augmented requests support progress notifications as defined in the [progress](./progress) specification. The `progressToken` provided in the initial request remains valid throughout the task lifetime.
+
+### Task Listing
+
+1. Receivers **SHOULD** use cursor-based pagination to limit the number of tasks returned in a single response.
+1. Receivers **MUST** include a `nextCursor` in the response if more tasks are available.
+1. Requestors **MUST** treat cursors as opaque tokens and not attempt to parse or modify them.
+1. If a task is retrievable via `tasks/get` for a requestor, it **MUST** be retrievable via `tasks/list` for that requestor.
+
+### Task Cancellation
+
+1. Receivers **MUST** reject cancellation requests for tasks already in a terminal status (`completed`, `failed`, or `cancelled`) with error code `-32602` (Invalid params).
+1. Upon receiving a valid cancellation request, receivers **SHOULD** attempt to stop the task execution and **MUST** transition the task to `cancelled` status before sending the response.
+1. Once a task is cancelled, it **MUST** remain in `cancelled` status even if execution continues to completion or fails.
+1. The `tasks/cancel` operation does not define deletion behavior. However, receivers **MAY** delete cancelled tasks at their discretion at any time, including immediately after cancellation or after the task `ttl` expires.
+1. Requestors **SHOULD NOT** rely on cancelled tasks being retained for any specific duration and should retrieve any needed information before cancelling.
+
+## Message Flow
+
+### Basic Task Lifecycle
+
+```mermaid
+sequenceDiagram
+    participant C as Client (Requestor)
+    participant S as Server (Receiver)
+    Note over C,S: 1. Task Creation
+    C->>S: Request with task field (ttl)
+    activate S
+    S->>C: CreateTaskResult (taskId, status: working, ttl, pollInterval)
+    deactivate S
+    Note over C,S: 2. Task Polling
+    C->>S: tasks/get (taskId)
+    activate S
+    S->>C: working
+    deactivate S
+    Note over S: Task processing continues...
+    C->>S: tasks/get (taskId)
+    activate S
+    S->>C: working
+    deactivate S
+    Note over S: Task completes
+    C->>S: tasks/get (taskId)
+    activate S
+    S->>C: completed
+    deactivate S
+    Note over C,S: 3. Result Retrieval
+    C->>S: tasks/result (taskId)
+    activate S
+    S->>C: Result content
+    deactivate S
+    Note over C,S: 4. Cleanup
+    Note over S: After ttl period from creation, task is cleaned up
+```
+
+### Task-Augmented Tool Call With Elicitation
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant LLM
+    participant C as Client (Requestor)
+    participant S as Server (Receiver)
+
+    Note over LLM,C: LLM initiates request
+    LLM->>C: Request operation
+
+    Note over C,S: Client augments with task
+    C->>S: tools/call (ttl: 3600000)
+    activate S
+    S->>C: CreateTaskResult (task-123, status: working)
+    deactivate S
+
+    Note over LLM,C: Client continues processing other requests<br/>while task executes in background
+    LLM->>C: Request other operation
+    C->>LLM: Other operation result
+
+    Note over C,S: Client polls for status
+    C->>S: tasks/get (task-123)
+    activate S
+    S->>C: working
+    deactivate S
+
+    Note over S: Server needs information from client<br/>Task moves to input_required
+
+    Note over C,S: Client polls and discovers input_required
+    C->>S: tasks/get (task-123)
+    activate S
+    S->>C: input_required
+    deactivate S
+
+    Note over C,S: Client opens result stream
+    C->>S: tasks/result (task-123)
+    activate S
+    S->>C: elicitation/create (related-task: task-123)
+    activate C
+    C->>U: Prompt user for input
+    U->>C: Provide information
+    C->>S: elicitation response (related-task: task-123)
+    deactivate C
+    deactivate S
+
+    Note over C,S: Client closes result stream and resumes polling
+
+    Note over S: Task continues processing...<br/>Task moves back to working
+
+    C->>S: tasks/get (task-123)
+    activate S
+    S->>C: working
+    deactivate S
+
+    Note over S: Task completes
+
+    Note over C,S: Client polls and discovers completion
+    C->>S: tasks/get (task-123)
+    activate S
+    S->>C: completed
+    deactivate S
+
+    Note over C,S: Client retrieves final results
+    C->>S: tasks/result (task-123)
+    activate S
+    S->>C: Result content
+    deactivate S
+    C->>LLM: Process result
+
+    Note over S: Results retained for ttl period from creation
+```
+
+### Task-Augmented Sampling Request
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant LLM
+    participant C as Client (Receiver)
+    participant S as Server (Requestor)
+
+    Note over S: Server decides to initiate request
+
+    Note over S,C: Server requests client operation (task-augmented)
+    S->>C: sampling/createMessage (ttl: 3600000)
+    activate C
+    C->>S: CreateTaskResult (request-789, status: working)
+    deactivate C
+
+    Note over S: Server continues processing<br/>while waiting for result
+
+    Note over S,C: Server polls for result
+    S->>C: tasks/get (request-789)
+    activate C
+    C->>S: working
+    deactivate C
+
+    Note over C,U: Client may present request to user
+    C->>U: Review request
+    U->>C: Approve request
+
+    Note over C,LLM: Client may involve LLM
+    C->>LLM: Request completion
+    LLM->>C: Return completion
+
+    Note over C,U: Client may present result to user
+    C->>U: Review result
+    U->>C: Approve result
+
+    Note over S,C: Server polls and discovers completion
+    S->>C: tasks/get (request-789)
+    activate C
+    C->>S: completed
+    deactivate C
+
+    Note over S,C: Server retrieves result
+    S->>C: tasks/result (request-789)
+    activate C
+    C->>S: Result content
+    deactivate C
+
+    Note over S: Server continues processing
+
+    Note over C: Results retained for ttl period from creation
+```
+
+### Task Cancellation Flow
+
+```mermaid
+sequenceDiagram
+    participant C as Client (Requestor)
+    participant S as Server (Receiver)
+
+    Note over C,S: 1. Task Creation
+    C->>S: tools/call (request ID: 42, ttl: 60000)
+    activate S
+    S->>C: CreateTaskResult (task-123, status: working)
+    deactivate S
+
+    Note over C,S: 2. Task Processing
+    C->>S: tasks/get (task-123)
+    activate S
+    S->>C: working
+    deactivate S
+
+    Note over C,S: 3. Client Cancellation
+    Note over C: User requests cancellation
+    C->>S: tasks/cancel (taskId: task-123)
+    activate S
+
+    Note over S: Server stops execution (best effort)
+    Note over S: Task moves to cancelled status
+
+    S->>C: Task (status: cancelled)
+    deactivate S
+
+    Note over C: Client receives confirmation
+
+    Note over S: Server may delete task at its discretion
+```
+
+## Data Types
+
+### Task
+
+A task represents the execution state of a request. The task state includes:
+
+- `taskId`: Unique identifier for the task
+- `status`: Current state of the task execution
+- `statusMessage`: Optional human-readable message describing the current state (can be present for any status, including error details for failed tasks)
+- `createdAt`: ISO 8601 timestamp when the task was created
+- `ttl`: Time in milliseconds from creation before task may be deleted
+- `pollInterval`: Suggested time in milliseconds between status checks
+- `lastUpdatedAt`: ISO 8601 timestamp when the task status was last updated
+
+### Task Status
+
+Tasks can be in one of the following states:
+
+- `working`: The request is currently being processed.
+- `input_required`: The receiver needs input from the requestor. The requestor should call `tasks/result` to receive input requests, even though the task has not reached a terminal state.
+- `completed`: The request completed successfully and results are available.
+- `failed`: The associated request did not complete successfully. For tool calls specifically, this includes cases where the tool call result has `isError` set to true.
+- `cancelled`: The request was cancelled before completion.
+
+### Task Parameters
+
+When augmenting a request with task execution, the `task` field is included in the request parameters:
+
+```json
+{
+  "task": {
+    "ttl": 60000
+  }
+}
+```
+
+Fields:
+
+- `ttl` (number, optional): Requested duration in milliseconds to retain task from creation
+
+### Related Task Metadata
+
+All requests, responses, and notifications associated with a task **MUST** include the `io.modelcontextprotocol/related-task` key in `_meta`:
+
+```json
+{
+  "io.modelcontextprotocol/related-task": {
+    "taskId": "786512e2-9e0d-44bd-8f29-789f320fe840"
+  }
+}
+```
+
+This associates messages with their originating task across the entire request lifecycle.
+
+For the `tasks/get`, `tasks/list`, and `tasks/cancel` operations, requestors and receivers **SHOULD NOT** include this metadata in their messages, as the `taskId` is already present in the message structure.
+The `tasks/result` operation **MUST** include this metadata in its response, as the result structure itself does not contain the task ID.
+
+## Error Handling
+
+Tasks use two error reporting mechanisms:
+
+1. **Protocol Errors**: Standard JSON-RPC errors for protocol-level issues
+1. **Task Execution Errors**: Errors in the underlying request execution, reported through task status
+
+### Protocol Errors
+
+Receivers **MUST** return standard JSON-RPC errors for the following protocol error cases:
+
+- Invalid or nonexistent `taskId` in `tasks/get`, `tasks/result`, or `tasks/cancel`: `-32602` (Invalid params)
+- Invalid or nonexistent cursor in `tasks/list`: `-32602` (Invalid params)
+- Attempt to cancel a task already in a terminal status: `-32602` (Invalid params)
+- Internal errors: `-32603` (Internal error)
+
+Additionally, receivers **MAY** return the following errors:
+
+- Non-task-augmented request when receiver requires task augmentation for that request type: `-32600` (Invalid request)
+
+Receivers **SHOULD** provide informative error messages to describe the cause of errors.
+
+**Example: Task augmentation required**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "error": {
+    "code": -32600,
+    "message": "Task augmentation required for tools/call requests"
+  }
+}
+```
+
+**Example: Task not found**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 70,
+  "error": {
+    "code": -32602,
+    "message": "Failed to retrieve task: Task not found"
+  }
+}
+```
+
+**Example: Task expired**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 71,
+  "error": {
+    "code": -32602,
+    "message": "Failed to retrieve task: Task has expired"
+  }
+}
+```
+
+> **Note:**
+> Receivers are not required to retain tasks indefinitely. It is compliant behavior for a receiver to return an error stating the task cannot be found if it has purged an expired task.
+
+**Example: Task cancellation rejected (already terminal)**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 74,
+  "error": {
+    "code": -32602,
+    "message": "Cannot cancel task: already in terminal status 'completed'"
+  }
+}
+```
+
+### Task Execution Errors
+
+When the underlying request does not complete successfully, the task moves to the `failed` status. This includes JSON-RPC protocol errors during request execution, or for tool calls specifically, when the tool result has `isError` set to true. The `tasks/get` response **SHOULD** include a `statusMessage` field with diagnostic information about the failure.
+
+**Example: Task with execution error**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 4,
+  "result": {
+    "taskId": "786512e2-9e0d-44bd-8f29-789f820fe840",
+    "status": "failed",
+    "createdAt": "2025-11-25T10:30:00Z",
+    "lastUpdatedAt": "2025-11-25T10:40:00Z",
+    "ttl": 30000,
+    "statusMessage": "Tool execution failed: API rate limit exceeded"
+  }
+}
+```
+
+For tasks that wrap tool call requests, when the tool result has `isError` set to `true`, the task should reach `failed` status.
+
+The `tasks/result` endpoint returns exactly what the underlying request would have returned:
+
+- If the underlying request resulted in a JSON-RPC error, `tasks/result` **MUST** return that same JSON-RPC error.
+- If the request completed with a JSON-RPC response, `tasks/result` **MUST** return a successful JSON-RPC response containing that result.
+
+## Security Considerations
+
+### Task Isolation and Access Control
+
+Task IDs are the primary mechanism for accessing task state and results. Without proper access controls, any party that can guess or obtain a task ID could potentially access sensitive information or manipulate tasks they did not create.
+
+When an authorization context is provided, receivers **MUST** bind tasks to said context.
+
+Context-binding is not practical for all applications. Some MCP servers operate in environments without authorization, such as single-user tools, or use transports that don't support authorization.
+In these scenarios, receivers **SHOULD** document this limitation clearly, as task results may be accessible to any requestor that can guess the task ID.
+If context-binding is unavailable, receivers **MUST** generate cryptographically secure task IDs with enough entropy to prevent guessing and should consider using shorter TTL durations to reduce the exposure window.
+Furthermore, receivers that cannot identify requestors **SHOULD NOT** declare the `tasks.list` capability, as listing tasks would expose task metadata to any requestor regardless of task ID entropy.
+
+If context-binding is available, receivers **MUST** reject `tasks/get`, `tasks/result`, and `tasks/cancel` requests for tasks that do not belong to the same authorization context as the requestor. For `tasks/list` requests, receivers **MUST** ensure the returned task list includes only tasks associated with the requestor's authorization context.
+
+Additionally, receivers **SHOULD** implement rate limiting on task operations to prevent denial-of-service and enumeration attacks.
+
+### Resource Management
+
+1. Receivers **SHOULD**:
+   1. Enforce limits on concurrent tasks per requestor
+   1. Enforce maximum `ttl` durations to prevent indefinite resource retention
+   1. Clean up expired tasks promptly to free resources
+   1. Document maximum supported `ttl` duration
+   1. Document maximum concurrent tasks per requestor
+   1. Implement monitoring and alerting for resource usage
+
+### Audit and Logging
+
+1. Receivers **SHOULD**:
+   1. Log task creation, completion, and retrieval events for audit purposes
+   1. Include auth context in logs when available
+   1. Monitor for suspicious patterns (e.g., many failed task lookups, excessive polling)
+1. Requestors **SHOULD**:
+   1. Log task lifecycle events for debugging and audit purposes
+   1. Track task IDs and their associated operations

--- a/.agents/skills/mcp-knowledge/references/2025-11-25/tools.md
+++ b/.agents/skills/mcp-knowledge/references/2025-11-25/tools.md
@@ -1,0 +1,508 @@
+<!-- markdownlint-disable -->
+# Tools
+
+The Model Context Protocol (MCP) allows servers to expose tools that can be invoked by
+language models. Tools enable models to interact with external systems, such as querying
+databases, calling APIs, or performing computations. Each tool is uniquely identified by
+a name and includes metadata describing its schema.
+
+## User Interaction Model
+
+Tools in MCP are designed to be **model-controlled**, meaning that the language model can
+discover and invoke tools automatically based on its contextual understanding and the
+user's prompts.
+
+However, implementations are free to expose tools through any interface pattern that
+suits their needs&mdash;the protocol itself does not mandate any specific user
+interaction model.
+
+> **Warning:**
+> For trust & safety and security, there **SHOULD** always
+> be a human in the loop with the ability to deny tool invocations.
+>
+> Applications **SHOULD**:
+>
+> - Provide UI that makes clear which tools are being exposed to the AI model
+> - Insert clear visual indicators when tools are invoked
+> - Present confirmation prompts to the user for operations, to ensure a human is in the
+>   loop
+
+## Capabilities
+
+Servers that support tools **MUST** declare the `tools` capability:
+
+```json
+{
+  "capabilities": {
+    "tools": {
+      "listChanged": true
+    }
+  }
+}
+```
+
+`listChanged` indicates whether the server will emit notifications when the list of
+available tools changes.
+
+## Protocol Messages
+
+### Listing Tools
+
+To discover available tools, clients send a `tools/list` request. This operation supports
+[pagination](/specification/2025-11-25/server/utilities/pagination).
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/list",
+  "params": {
+    "cursor": "optional-cursor-value"
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "tools": [
+      {
+        "name": "get_weather",
+        "title": "Weather Information Provider",
+        "description": "Get current weather information for a location",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "location": {
+              "type": "string",
+              "description": "City name or zip code"
+            }
+          },
+          "required": ["location"]
+        },
+        "icons": [
+          {
+            "src": "https://example.com/weather-icon.png",
+            "mimeType": "image/png",
+            "sizes": ["48x48"]
+          }
+        ],
+        "execution": {
+          "taskSupport": "optional"
+        }
+      }
+    ],
+    "nextCursor": "next-page-cursor"
+  }
+}
+```
+
+### Calling Tools
+
+To invoke a tool, clients send a `tools/call` request:
+
+**Request:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "tools/call",
+  "params": {
+    "name": "get_weather",
+    "arguments": {
+      "location": "New York"
+    }
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "Current weather in New York:\nTemperature: 72°F\nConditions: Partly cloudy"
+      }
+    ],
+    "isError": false
+  }
+}
+```
+
+### List Changed Notification
+
+When the list of available tools changes, servers that declared the `listChanged`
+capability **SHOULD** send a notification:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/tools/list_changed"
+}
+```
+
+## Message Flow
+
+```mermaid
+sequenceDiagram
+    participant LLM
+    participant Client
+    participant Server
+
+    Note over Client,Server: Discovery
+    Client->>Server: tools/list
+    Server-->>Client: List of tools
+
+    Note over Client,LLM: Tool Selection
+    LLM->>Client: Select tool to use
+
+    Note over Client,Server: Invocation
+    Client->>Server: tools/call
+    Server-->>Client: Tool result
+    Client->>LLM: Process result
+
+    Note over Client,Server: Updates
+    Server--)Client: tools/list_changed
+    Client->>Server: tools/list
+    Server-->>Client: Updated tools
+```
+
+## Data Types
+
+### Tool
+
+A tool definition includes:
+
+- `name`: Unique identifier for the tool
+- `title`: Optional human-readable name of the tool for display purposes.
+- `description`: Human-readable description of functionality
+- `icons`: Optional array of icons for display in user interfaces
+- `inputSchema`: JSON Schema defining expected parameters
+  - Follows the [JSON Schema usage guidelines](/specification/2025-11-25/basic#json-schema-usage)
+  - Defaults to 2020-12 if no `$schema` field is present
+  - **MUST** be a valid JSON Schema object (not `null`)
+  - For tools with no parameters, use one of these valid approaches:
+    - `{ "type": "object", "additionalProperties": false }` - **Recommended**: explicitly accepts only empty objects
+    - `{ "type": "object" }` - accepts any object (including with properties)
+- `outputSchema`: Optional JSON Schema defining expected output structure
+  - Follows the [JSON Schema usage guidelines](/specification/2025-11-25/basic#json-schema-usage)
+  - Defaults to 2020-12 if no `$schema` field is present
+- `annotations`: Optional properties describing tool behavior
+- `execution`: Optional object describing execution-related properties
+  - `taskSupport`: Indicates whether this tool supports [task-augmented execution](/specification/2025-11-25/basic/utilities/tasks#tool-level-negotiation). Values: `"forbidden"` (default), `"optional"`, or `"required"`
+
+> **Warning:**
+> For trust & safety and security, clients **MUST** consider tool annotations to
+>   be untrusted unless they come from trusted servers.
+
+#### Tool Names
+
+- Tool names **SHOULD** be between 1 and 128 characters in length (inclusive).
+- Tool names **SHOULD** be considered case-sensitive.
+- The following **SHOULD** be the only allowed characters: uppercase and lowercase ASCII letters (A-Z, a-z), digits
+  (0-9), underscore (\_), hyphen (-), and dot (.)
+- Tool names **SHOULD NOT** contain spaces, commas, or other special characters.
+- Tool names **SHOULD** be unique within a server.
+- Example valid tool names:
+  - getUser
+  - DATA_EXPORT_v2
+  - admin.tools.list
+
+### Tool Result
+
+Tool results may contain [**structured**](#structured-content) or **unstructured** content.
+
+**Unstructured** content is returned in the `content` field of a result, and can contain multiple content items of different types:
+
+> **Note:**
+> All content types (text, image, audio, resource links, and embedded resources)
+>   support optional
+>   [annotations](/specification/2025-11-25/server/resources#annotations) that
+>   provide metadata about audience, priority, and modification times. This is the
+>   same annotation format used by resources and prompts.
+
+#### Text Content
+
+```json
+{
+  "type": "text",
+  "text": "Tool result text"
+}
+```
+
+#### Image Content
+
+```json
+{
+  "type": "image",
+  "data": "base64-encoded-data",
+  "mimeType": "image/png",
+  "annotations": {
+    "audience": ["user"],
+    "priority": 0.9
+  }
+}
+```
+
+#### Audio Content
+
+```json
+{
+  "type": "audio",
+  "data": "base64-encoded-audio-data",
+  "mimeType": "audio/wav"
+}
+```
+
+#### Resource Links
+
+A tool **MAY** return links to [Resources](/specification/2025-11-25/server/resources), to provide additional context
+or data. In this case, the tool will return a URI that can be subscribed to or fetched by the client:
+
+```json
+{
+  "type": "resource_link",
+  "uri": "file:///project/src/main.rs",
+  "name": "main.rs",
+  "description": "Primary application entry point",
+  "mimeType": "text/x-rust"
+}
+```
+
+Resource links support the same [Resource annotations](/specification/2025-11-25/server/resources#annotations) as regular resources to help clients understand how to use them.
+
+> **Info:**
+> Resource links returned by tools are not guaranteed to appear in the results
+>   of a `resources/list` request.
+
+#### Embedded Resources
+
+[Resources](/specification/2025-11-25/server/resources) **MAY** be embedded to provide additional context
+or data using a suitable [URI scheme](./resources#common-uri-schemes). Servers that use embedded resources **SHOULD** implement the `resources` capability:
+
+```json
+{
+  "type": "resource",
+  "resource": {
+    "uri": "file:///project/src/main.rs",
+    "mimeType": "text/x-rust",
+    "text": "fn main() {\n    println!(\"Hello world!\");\n}",
+    "annotations": {
+      "audience": ["user", "assistant"],
+      "priority": 0.7,
+      "lastModified": "2025-05-03T14:30:00Z"
+    }
+  }
+}
+```
+
+Embedded resources support the same [Resource annotations](/specification/2025-11-25/server/resources#annotations) as regular resources to help clients understand how to use them.
+
+#### Structured Content
+
+**Structured** content is returned as a JSON object in the `structuredContent` field of a result.
+
+For backwards compatibility, a tool that returns structured content SHOULD also return the serialized JSON in a TextContent block.
+
+#### Output Schema
+
+Tools may also provide an output schema for validation of structured results.
+If an output schema is provided:
+
+- Servers **MUST** provide structured results that conform to this schema.
+- Clients **SHOULD** validate structured results against this schema.
+
+Example tool with output schema:
+
+```json
+{
+  "name": "get_weather_data",
+  "title": "Weather Data Retriever",
+  "description": "Get current weather data for a location",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "location": {
+        "type": "string",
+        "description": "City name or zip code"
+      }
+    },
+    "required": ["location"]
+  },
+  "outputSchema": {
+    "type": "object",
+    "properties": {
+      "temperature": {
+        "type": "number",
+        "description": "Temperature in celsius"
+      },
+      "conditions": {
+        "type": "string",
+        "description": "Weather conditions description"
+      },
+      "humidity": {
+        "type": "number",
+        "description": "Humidity percentage"
+      }
+    },
+    "required": ["temperature", "conditions", "humidity"]
+  }
+}
+```
+
+Example valid response for this tool:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 5,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "{\"temperature\": 22.5, \"conditions\": \"Partly cloudy\", \"humidity\": 65}"
+      }
+    ],
+    "structuredContent": {
+      "temperature": 22.5,
+      "conditions": "Partly cloudy",
+      "humidity": 65
+    }
+  }
+}
+```
+
+Providing an output schema helps clients and LLMs understand and properly handle structured tool outputs by:
+
+- Enabling strict schema validation of responses
+- Providing type information for better integration with programming languages
+- Guiding clients and LLMs to properly parse and utilize the returned data
+- Supporting better documentation and developer experience
+
+### Schema Examples
+
+#### Tool with default 2020-12 schema:
+
+```json
+{
+  "name": "calculate_sum",
+  "description": "Add two numbers",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "a": { "type": "number" },
+      "b": { "type": "number" }
+    },
+    "required": ["a", "b"]
+  }
+}
+```
+
+#### Tool with explicit draft-07 schema:
+
+```json
+{
+  "name": "calculate_sum",
+  "description": "Add two numbers",
+  "inputSchema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+      "a": { "type": "number" },
+      "b": { "type": "number" }
+    },
+    "required": ["a", "b"]
+  }
+}
+```
+
+#### Tool with no parameters:
+
+```json
+{
+  "name": "get_current_time",
+  "description": "Returns the current server time",
+  "inputSchema": {
+    "type": "object",
+    "additionalProperties": false
+  }
+}
+```
+
+## Error Handling
+
+Tools use two error reporting mechanisms:
+
+1. **Protocol Errors**: Standard JSON-RPC errors for issues like:
+   - Unknown tools
+   - Malformed requests (requests that fail to satisfy [CallToolRequest schema](/specification/2025-11-25/schema#calltoolrequest))
+   - Server errors
+
+2. **Tool Execution Errors**: Reported in tool results with `isError: true`:
+   - API failures
+   - Input validation errors (e.g., date in wrong format, value out of range)
+   - Business logic errors
+
+**Tool Execution Errors** contain actionable feedback that language models can use to self-correct and retry with adjusted parameters.
+**Protocol Errors** indicate issues with the request structure itself that models are less likely to be able to fix.
+Clients **SHOULD** provide tool execution errors to language models to enable self-correction.
+Clients **MAY** provide protocol errors to language models, though these are less likely to result in successful recovery.
+
+Example protocol error:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "error": {
+    "code": -32602,
+    "message": "Unknown tool: invalid_tool_name"
+  }
+}
+```
+
+Example tool execution error (input validation):
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 4,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "Invalid departure date: must be in the future. Current date is 08/08/2025."
+      }
+    ],
+    "isError": true
+  }
+}
+```
+
+## Security Considerations
+
+1. Servers **MUST**:
+   - Validate all tool inputs
+   - Implement proper access controls
+   - Rate limit tool invocations
+   - Sanitize tool outputs
+
+2. Clients **SHOULD**:
+   - Prompt for user confirmation on sensitive operations
+   - Show tool inputs to the user before calling the server, to avoid malicious or
+     accidental data exfiltration
+   - Validate tool results before passing to LLM
+   - Implement timeouts for tool calls
+   - Log tool usage for audit purposes

--- a/.agents/skills/mcp-knowledge/references/2025-11-25/transports.md
+++ b/.agents/skills/mcp-knowledge/references/2025-11-25/transports.md
@@ -1,0 +1,314 @@
+<!-- markdownlint-disable -->
+# Transports
+
+MCP uses JSON-RPC to encode messages. JSON-RPC messages **MUST** be UTF-8 encoded.
+
+The protocol currently defines two standard transport mechanisms for client-server
+communication:
+
+1. [stdio](#stdio), communication over standard in and standard out
+2. [Streamable HTTP](#streamable-http)
+
+Clients **SHOULD** support stdio whenever possible.
+
+It is also possible for clients and servers to implement
+[custom transports](#custom-transports) in a pluggable fashion.
+
+## stdio
+
+In the **stdio** transport:
+
+- The client launches the MCP server as a subprocess.
+- The server reads JSON-RPC messages from its standard input (`stdin`) and sends messages
+  to its standard output (`stdout`).
+- Messages are individual JSON-RPC requests, notifications, or responses.
+- Messages are delimited by newlines, and **MUST NOT** contain embedded newlines.
+- The server **MAY** write UTF-8 strings to its standard error (`stderr`) for any
+  logging purposes including informational, debug, and error messages.
+- The client **MAY** capture, forward, or ignore the server's `stderr` output
+  and **SHOULD NOT** assume `stderr` output indicates error conditions.
+- The server **MUST NOT** write anything to its `stdout` that is not a valid MCP message.
+- The client **MUST NOT** write anything to the server's `stdin` that is not a valid MCP
+  message.
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Server Process
+
+    Client->>+Server Process: Launch subprocess
+    loop Message Exchange
+        Client->>Server Process: Write to stdin
+        Server Process->>Client: Write to stdout
+        Server Process--)Client: Optional logs on stderr
+    end
+    Client->>Server Process: Close stdin, terminate subprocess
+    deactivate Server Process
+```
+
+## Streamable HTTP
+
+> **Info:**
+> This replaces the [HTTP+SSE
+> transport](/specification/2024-11-05/basic/transports#http-with-sse) from
+> protocol version 2024-11-05. See the [backwards compatibility](#backwards-compatibility)
+> guide below.
+
+In the **Streamable HTTP** transport, the server operates as an independent process that
+can handle multiple client connections. This transport uses HTTP POST and GET requests.
+Server can optionally make use of
+[Server-Sent Events](https://en.wikipedia.org/wiki/Server-sent_events) (SSE) to stream
+multiple server messages. This permits basic MCP servers, as well as more feature-rich
+servers supporting streaming and server-to-client notifications and requests.
+
+The server **MUST** provide a single HTTP endpoint path (hereafter referred to as the
+**MCP endpoint**) that supports both POST and GET methods. For example, this could be a
+URL like `https://example.com/mcp`.
+
+#### Security Warning
+
+When implementing Streamable HTTP transport:
+
+1. Servers **MUST** validate the `Origin` header on all incoming connections to prevent DNS rebinding attacks
+   - If the `Origin` header is present and invalid, servers **MUST** respond with HTTP 403 Forbidden. The HTTP response
+     body **MAY** comprise a JSON-RPC _error response_ that has no `id`
+2. When running locally, servers **SHOULD** bind only to localhost (127.0.0.1) rather than all network interfaces (0.0.0.0)
+3. Servers **SHOULD** implement proper authentication for all connections
+
+Without these protections, attackers could use DNS rebinding to interact with local MCP servers from remote websites.
+
+### Sending Messages to the Server
+
+Every JSON-RPC message sent from the client **MUST** be a new HTTP POST request to the
+MCP endpoint.
+
+1. The client **MUST** use HTTP POST to send JSON-RPC messages to the MCP endpoint.
+2. The client **MUST** include an `Accept` header, listing both `application/json` and
+   `text/event-stream` as supported content types.
+3. The body of the POST request **MUST** be a single JSON-RPC _request_, _notification_, or _response_.
+4. If the input is a JSON-RPC _response_ or _notification_:
+   - If the server accepts the input, the server **MUST** return HTTP status code 202
+     Accepted with no body.
+   - If the server cannot accept the input, it **MUST** return an HTTP error status code
+     (e.g., 400 Bad Request). The HTTP response body **MAY** comprise a JSON-RPC _error
+     response_ that has no `id`.
+5. If the input is a JSON-RPC _request_, the server **MUST** either
+   return `Content-Type: text/event-stream`, to initiate an SSE stream, or
+   `Content-Type: application/json`, to return one JSON object. The client **MUST**
+   support both these cases.
+6. If the server initiates an SSE stream:
+   - The server **SHOULD** immediately send an SSE event consisting of an event
+     ID and an empty `data` field in order to prime the client to reconnect
+     (using that event ID as `Last-Event-ID`).
+   - After the server has sent an SSE event with an event ID to the client, the
+     server **MAY** close the _connection_ (without terminating the _SSE stream_)
+     at any time in order to avoid holding a long-lived connection. The client
+     **SHOULD** then "poll" the SSE stream by attempting to reconnect.
+   - If the server does close the _connection_ prior to terminating the _SSE stream_,
+     it **SHOULD** send an SSE event with a standard [`retry`](https://html.spec.whatwg.org/multipage/server-sent-events.html#:~:text=field%20name%20is%20%22retry%22) field before
+     closing the connection. The client **MUST** respect the `retry` field,
+     waiting the given number of milliseconds before attempting to reconnect.
+   - The SSE stream **SHOULD** eventually include a JSON-RPC _response_ for the
+     JSON-RPC _request_ sent in the POST body.
+   - The server **MAY** send JSON-RPC _requests_ and _notifications_ before sending the
+     JSON-RPC _response_. These messages **SHOULD** relate to the originating client
+     _request_.
+   - The server **MAY** terminate the SSE stream if the [session](#session-management)
+     expires.
+   - After the JSON-RPC _response_ has been sent, the server **SHOULD** terminate the
+     SSE stream.
+   - Disconnection **MAY** occur at any time (e.g., due to network conditions).
+     Therefore:
+     - Disconnection **SHOULD NOT** be interpreted as the client cancelling its request.
+     - To cancel, the client **SHOULD** explicitly send an MCP `CancelledNotification`.
+     - To avoid message loss due to disconnection, the server **MAY** make the stream
+       [resumable](#resumability-and-redelivery).
+
+### Listening for Messages from the Server
+
+1. The client **MAY** issue an HTTP GET to the MCP endpoint. This can be used to open an
+   SSE stream, allowing the server to communicate to the client, without the client first
+   sending data via HTTP POST.
+2. The client **MUST** include an `Accept` header, listing `text/event-stream` as a
+   supported content type.
+3. The server **MUST** either return `Content-Type: text/event-stream` in response to
+   this HTTP GET, or else return HTTP 405 Method Not Allowed, indicating that the server
+   does not offer an SSE stream at this endpoint.
+4. If the server initiates an SSE stream:
+   - The server **MAY** send JSON-RPC _requests_ and _notifications_ on the stream.
+   - These messages **SHOULD** be unrelated to any concurrently-running JSON-RPC
+     _request_ from the client.
+   - The server **MUST NOT** send a JSON-RPC _response_ on the stream **unless**
+     [resuming](#resumability-and-redelivery) a stream associated with a previous client
+     request.
+   - The server **MAY** close the SSE stream at any time.
+   - If the server closes the _connection_ without terminating the _stream_, it
+     **SHOULD** follow the same polling behavior as described for POST requests:
+     sending a `retry` field and allowing the client to reconnect.
+   - The client **MAY** close the SSE stream at any time.
+
+### Multiple Connections
+
+1. The client **MAY** remain connected to multiple SSE streams simultaneously.
+2. The server **MUST** send each of its JSON-RPC messages on only one of the connected
+   streams; that is, it **MUST NOT** broadcast the same message across multiple streams.
+   - The risk of message loss **MAY** be mitigated by making the stream
+     [resumable](#resumability-and-redelivery).
+
+### Resumability and Redelivery
+
+To support resuming broken connections, and redelivering messages that might otherwise be
+lost:
+
+1. Servers **MAY** attach an `id` field to their SSE events, as described in the
+   [SSE standard](https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation).
+   - If present, the ID **MUST** be globally unique across all streams within that
+     [session](#session-management)—or all streams with that specific client, if session
+     management is not in use.
+   - Event IDs **SHOULD** encode sufficient information to identify the originating
+     stream, enabling the server to correlate a `Last-Event-ID` to the correct stream.
+2. If the client wishes to resume after a disconnection (whether due to network failure
+   or server-initiated closure), it **SHOULD** issue an HTTP GET to the MCP endpoint,
+   and include the
+   [`Last-Event-ID`](https://html.spec.whatwg.org/multipage/server-sent-events.html#the-last-event-id-header)
+   header to indicate the last event ID it received.
+   - The server **MAY** use this header to replay messages that would have been sent
+     after the last event ID, _on the stream that was disconnected_, and to resume the
+     stream from that point.
+   - The server **MUST NOT** replay messages that would have been delivered on a
+     different stream.
+   - This mechanism applies regardless of how the original stream was initiated (via
+     POST or GET). Resumption is always via HTTP GET with `Last-Event-ID`.
+
+In other words, these event IDs should be assigned by servers on a _per-stream_ basis, to
+act as a cursor within that particular stream.
+
+### Session Management
+
+An MCP "session" consists of logically related interactions between a client and a
+server, beginning with the [initialization phase](/specification/2025-11-25/basic/lifecycle). To support
+servers which want to establish stateful sessions:
+
+1. A server using the Streamable HTTP transport **MAY** assign a session ID at
+   initialization time, by including it in an `MCP-Session-Id` header on the HTTP
+   response containing the `InitializeResult`.
+   - The session ID **SHOULD** be globally unique and cryptographically secure (e.g., a
+     securely generated UUID, a JWT, or a cryptographic hash).
+   - The session ID **MUST** only contain visible ASCII characters (ranging from 0x21 to
+     0x7E).
+   - The client **MUST** handle the session ID in a secure manner, see [Session Hijacking mitigations](/specification/2025-11-25/basic/security_best_practices#session-hijacking) for more details.
+2. If an `MCP-Session-Id` is returned by the server during initialization, clients using
+   the Streamable HTTP transport **MUST** include it in the `MCP-Session-Id` header on
+   all of their subsequent HTTP requests.
+   - Servers that require a session ID **SHOULD** respond to requests without an
+     `MCP-Session-Id` header (other than initialization) with HTTP 400 Bad Request.
+3. The server **MAY** terminate the session at any time, after which it **MUST** respond
+   to requests containing that session ID with HTTP 404 Not Found.
+4. When a client receives HTTP 404 in response to a request containing an
+   `MCP-Session-Id`, it **MUST** start a new session by sending a new `InitializeRequest`
+   without a session ID attached.
+5. Clients that no longer need a particular session (e.g., because the user is leaving
+   the client application) **SHOULD** send an HTTP DELETE to the MCP endpoint with the
+   `MCP-Session-Id` header, to explicitly terminate the session.
+   - The server **MAY** respond to this request with HTTP 405 Method Not Allowed,
+     indicating that the server does not allow clients to terminate sessions.
+
+### Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Server
+
+    note over Client, Server: initialization
+
+    Client->>+Server: POST InitializeRequest
+    Server->>-Client: InitializeResponse<br>MCP-Session-Id: 1868a90c...
+
+    Client->>+Server: POST InitializedNotification<br>MCP-Session-Id: 1868a90c...
+    Server->>-Client: 202 Accepted
+
+    note over Client, Server: client requests
+    Client->>+Server: POST ... request ...<br>MCP-Session-Id: 1868a90c...
+
+    alt single HTTP response
+      Server->>Client: ... response ...
+    else server opens SSE stream
+      loop while connection remains open
+          Server-)Client: ... SSE messages from server ...
+      end
+      Server-)Client: SSE event: ... response ...
+    end
+    deactivate Server
+
+    note over Client, Server: client notifications/responses
+    Client->>+Server: POST ... notification/response ...<br>MCP-Session-Id: 1868a90c...
+    Server->>-Client: 202 Accepted
+
+    note over Client, Server: server requests
+    Client->>+Server: GET<br>MCP-Session-Id: 1868a90c...
+    loop while connection remains open
+        Server-)Client: ... SSE messages from server ...
+    end
+    deactivate Server
+
+```
+
+### Protocol Version Header
+
+If using HTTP, the client **MUST** include the `MCP-Protocol-Version:
+<protocol-version>` HTTP header on all subsequent requests to the MCP
+server, allowing the MCP server to respond based on the MCP protocol version.
+
+For example: `MCP-Protocol-Version: 2025-11-25`
+
+The protocol version sent by the client **SHOULD** be the one [negotiated during
+initialization](/specification/2025-11-25/basic/lifecycle#version-negotiation).
+
+For backwards compatibility, if the server does _not_ receive an `MCP-Protocol-Version`
+header, and has no other way to identify the version - for example, by relying on the
+protocol version negotiated during initialization - the server **SHOULD** assume protocol
+version `2025-03-26`.
+
+If the server receives a request with an invalid or unsupported
+`MCP-Protocol-Version`, it **MUST** respond with `400 Bad Request`.
+
+### Backwards Compatibility
+
+Clients and servers can maintain backwards compatibility with the deprecated [HTTP+SSE
+transport](/specification/2024-11-05/basic/transports#http-with-sse) (from
+protocol version 2024-11-05) as follows:
+
+**Servers** wanting to support older clients should:
+
+- Continue to host both the SSE and POST endpoints of the old transport, alongside the
+  new "MCP endpoint" defined for the Streamable HTTP transport.
+  - It is also possible to combine the old POST endpoint and the new MCP endpoint, but
+    this may introduce unneeded complexity.
+
+**Clients** wanting to support older servers should:
+
+1. Accept an MCP server URL from the user, which may point to either a server using the
+   old transport or the new transport.
+2. Attempt to POST an `InitializeRequest` to the server URL, with an `Accept` header as
+   defined above:
+   - If it succeeds, the client can assume this is a server supporting the new Streamable
+     HTTP transport.
+   - If it fails with the following HTTP status codes "400 Bad Request", "404 Not
+     Found" or "405 Method Not Allowed":
+     - Issue a GET request to the server URL, expecting that this will open an SSE stream
+       and return an `endpoint` event as the first event.
+     - When the `endpoint` event arrives, the client can assume this is a server running
+       the old HTTP+SSE transport, and should use that transport for all subsequent
+       communication.
+
+## Custom Transports
+
+Clients and servers **MAY** implement additional custom transport mechanisms to suit
+their specific needs. The protocol is transport-agnostic and can be implemented over any
+communication channel that supports bidirectional message exchange.
+
+Implementers who choose to support custom transports **MUST** ensure they preserve the
+JSON-RPC message format and lifecycle requirements defined by MCP. Custom transports
+**SHOULD** document their specific connection establishment and message exchange patterns
+to aid interoperability.

--- a/.agents/skills/mcp-knowledge/references/rust-sdk/client/elicitation.md
+++ b/.agents/skills/mcp-knowledge/references/rust-sdk/client/elicitation.md
@@ -1,0 +1,205 @@
+# Client: elicitation (`create_elicitation`)
+
+> **Naming note.** As of rmcp 2.0, `CreateElicitationRequestParams` and
+> `CreateElicitationResult` are deprecated aliases — renamed to
+> `ElicitRequestParams` and `ElicitResult`. The old names still compile
+> (with a deprecation warning); this page uses the current names.
+> Unlike sampling/roots/logging, elicitation itself is **not**
+> SEP-2577-deprecated — only these two type names changed.
+
+When a server calls `elicitation/create`, the client is expected to
+prompt the user for input and return their response.
+`ClientHandler::create_elicitation` is the hook.
+
+## When to read this
+
+- Your client should answer the server's elicitation requests with a
+  real UI.
+- Writing a test that needs to accept / decline / cancel an elicitation
+  programmatically.
+- You want to support URL-based elicitation (where the user fills out
+  a form on a web page).
+
+The default behavior — automatic decline — is what
+`crates/mcp-server/tests/elicitation.rs::DecliningClient` relies on.
+
+## Default behavior: auto-decline
+
+`ClientHandler::create_elicitation`'s default returns:
+
+```rust
+ElicitResult {
+    action: ElicitationAction::Decline,
+    content: None,
+    meta: None,
+}
+```
+
+So if you only need a client that declines every elicitation request,
+just enable the capability and you're done:
+
+```rust
+use rmcp::{
+    ClientHandler,
+    model::{ClientCapabilities, ClientInfo, Implementation},
+};
+
+#[derive(Default, Clone)]
+struct DecliningClient;
+
+impl ClientHandler for DecliningClient {
+    fn get_info(&self) -> ClientInfo {
+        ClientInfo::new(
+            ClientCapabilities::builder().enable_elicitation().build(),
+            Implementation::from_build_env(),
+        )
+    }
+}
+```
+
+This is the entire `DecliningClient` in
+`crates/mcp-server/tests/elicitation.rs:27-37` — the elicitation
+regression test relies on the default to produce a decline.
+
+## Accepting input
+
+To actually collect data and return it, override
+`create_elicitation`:
+
+```rust
+use rmcp::{
+    ClientHandler,
+    model::{
+        ClientCapabilities, ClientInfo, ElicitRequestParams,
+        ElicitResult, ElicitationAction, ErrorData, Implementation,
+    },
+    service::{RequestContext, RoleClient},
+};
+
+#[derive(Default, Clone)]
+struct InteractiveClient;
+
+impl ClientHandler for InteractiveClient {
+    fn get_info(&self) -> ClientInfo {
+        ClientInfo::new(
+            ClientCapabilities::builder().enable_elicitation().build(),
+            Implementation::from_build_env(),
+        )
+    }
+
+    async fn create_elicitation(
+        &self,
+        params: ElicitRequestParams,
+        _ctx: RequestContext<RoleClient>,
+    ) -> Result<ElicitResult, ErrorData> {
+        match params {
+            ElicitRequestParams::FormElicitationParams {
+                message,
+                requested_schema,
+                ..
+            } => {
+                let content = collect_form_input(&message, &requested_schema).await;
+                Ok(ElicitResult::new(ElicitationAction::Accept).with_content(content))
+            }
+            ElicitRequestParams::UrlElicitationParams {
+                url,
+                elicitation_id,
+                ..
+            } => {
+                open_url_in_browser(&url).await;
+                // The user will complete the form in the browser; the client
+                // separately receives `on_url_elicitation_notification_complete`.
+                Ok(ElicitResult::new(ElicitationAction::Accept))
+            }
+        }
+    }
+}
+```
+
+`ElicitResult` is `#[non_exhaustive]`, so build it with
+`ElicitResult::new(action)` and, if accepting, `.with_content(value)` —
+a struct literal (`ElicitResult { action, content, meta }`) no longer
+compiles from outside the `rmcp` crate.
+
+`collect_form_input` and `open_url_in_browser` are illustrative —
+they're the parts only your UI knows how to do.
+
+## `ElicitRequestParams` variants
+
+The request is an enum with two flavors (source:
+`submodules/mcp-rust-sdk/crates/rmcp/src/model.rs:2773-2812`):
+
+### `FormElicitationParams`
+
+| Field              | Type                | What it carries                                       |
+| ------------------ | ------------------- | ----------------------------------------------------- |
+| `message`          | `String`            | What to display to the user                           |
+| `requested_schema` | `ElicitationSchema` | JSON Schema for the expected input (object type only) |
+| `meta`             | `Option<Meta>`      | Protocol-level metadata                               |
+
+Render the schema as a form, collect input matching the schema, return
+it as `content`.
+
+### `UrlElicitationParams` (2025-11-25 spec)
+
+| Field            | Type           | What it carries                                                |
+| ---------------- | -------------- | -------------------------------------------------------------- |
+| `message`        | `String`       | What to display to the user                                    |
+| `url`            | `String`       | Where the user completes the elicitation                       |
+| `elicitation_id` | `String`       | The id the server will reference in the follow-up notification |
+| `meta`           | `Option<Meta>` |                                                                |
+
+The user fills out the form at the URL. When they finish, the server
+side surfaces the result via
+`on_url_elicitation_notification_complete` — see
+`references/rust-sdk/client/handler.md` for that callback.
+
+## `ElicitationAction` and `ElicitResult`
+
+| `action`  | Meaning                                                           |
+| --------- | ----------------------------------------------------------------- |
+| `Accept`  | User submitted data. `content` must conform to `requested_schema` |
+| `Decline` | User said no, but allow the operation to continue                 |
+| `Cancel`  | User aborted the whole operation                                  |
+
+`content` is `Option<serde_json::Value>` — for `Accept`, it's the
+object the user produced. For `Decline` and `Cancel`, leave it as
+`None`.
+
+The server's `Peer::elicit::<T>(...)` translates these back into
+`Ok(Some(T)) | Ok(None) | Err(ElicitationError::UserDeclined) |
+Err(ElicitationError::UserCancelled)` — see
+`references/rust-sdk/server/elicitation.md` for the server-side contract that
+your client must hold up.
+
+## Schema validation
+
+The `enable_elicitation_schema_validation()` capability tells the
+server that the client validates `content` against
+`requested_schema` before sending. If the client *doesn't* validate,
+the server may receive malformed data and surface
+`ElicitationError::ParseError`. Always validate at the client edge if
+you can — it's cheaper than a round trip.
+
+## Test client patterns
+
+For tests, the three patterns are:
+
+| Goal                                | How                                                                                                            |
+| ----------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| Always decline                      | Don't override `create_elicitation`. Just enable the capability                                                |
+| Always cancel                       | Override with `Ok(ElicitResult::new(ElicitationAction::Cancel))`                                               |
+| Always accept with a canned payload | Override with `ElicitResult::new(ElicitationAction::Accept).with_content(serde_json::json!({"name": "test"}))` |
+| Decline based on the prompt text    | Match on `params` and return `Decline` for one prompt, `Accept` for another                                    |
+
+## See also
+
+- `references/rust-sdk/server/elicitation.md` — what the server is doing on the
+  other end (`Peer::elicit<T>`, `ElicitationError` variants)
+- `references/rust-sdk/client/handler.md` — the full `ClientHandler` method list
+- `crates/mcp-server/tests/elicitation.rs` — `DecliningClient` in
+  action
+- `submodules/mcp-rust-sdk/crates/rmcp/src/handler/client.rs:114-182`
+  — the default implementation with doc-comment examples
+- `submodules/mcp-rust-sdk/examples/servers/src/elicitation_stdio.rs`
+  — upstream example exercising form elicitation end-to-end

--- a/.agents/skills/mcp-knowledge/references/rust-sdk/client/getting-started.md
+++ b/.agents/skills/mcp-knowledge/references/rust-sdk/client/getting-started.md
@@ -1,0 +1,187 @@
+# Client: getting started
+
+A `rmcp` client is anything that implements the `ClientHandler` trait
+and gets handed to `ServiceExt::serve(transport)`. The trait has a
+default for every method, so the minimum useful client is essentially
+a `struct` with `Default` and `Clone` derives.
+
+## When to read this
+
+- Writing your first `rmcp` client (production or test).
+- A client should drive an existing MCP server (subprocess, local
+  binary, remote HTTP).
+- You're integrating the in-memory `tokio::io::duplex` test harness
+  pattern.
+
+The smallest in-repo example is `crates/mcp-server/tests/tools.rs` —
+a real round-tripped client that sends `ListToolsRequest` and
+`CallToolRequest` to the local server.
+
+## The smallest viable client
+
+```rust
+use rmcp::{ClientHandler, ServiceExt};
+
+#[derive(Default, Clone)]
+struct MyClient;
+
+impl ClientHandler for MyClient {}
+```
+
+That's it. `ClientHandler` has default implementations for every
+method, so an empty `impl` block is enough.
+
+To drive a transport, hand the client to `ServiceExt::serve`:
+
+```rust
+use rmcp::{
+    ClientHandler, ServiceExt,
+    model::{CallToolRequestParams, ClientRequest, Request, ServerResult},
+};
+
+let client_service = MyClient.serve(transport).await?;
+
+let response = client_service
+    .send_request(ClientRequest::CallToolRequest(Request::new(
+        CallToolRequestParams::new("ping"),
+    )))
+    .await?;
+
+let ServerResult::CallToolResult(result) = response else {
+    panic!("expected CallToolResult, got {response:?}");
+};
+```
+
+Then `client_service.cancel().await` cleans up when you're done.
+
+## `ServiceExt::serve` returns `RunningService<RoleClient, _>`
+
+The return type is a `RunningService<RoleClient, MyClient>`. It owns
+the spawned message loop and exposes:
+
+| Method                                        | What it does                                                       |
+| --------------------------------------------- | ------------------------------------------------------------------ |
+| `.send_request(ClientRequest)`                | Send a typed `ClientRequest` and await the matching `ServerResult` |
+| `.send_notification(ClientNotification)`      | Fire-and-forget notification                                       |
+| `.peer()`                                     | Get a `Peer<RoleServer>` for raw outgoing calls                    |
+| `.peer_info()`                                | The `ServerInfo` returned during `initialize`                      |
+| `.waiting()`                                  | Block until the service ends                                       |
+| `.cancel()`                                   | Gracefully stop the service                                        |
+| `.call_tool(...)` / `.list_tools(...)` / etc. | Convenience wrappers that skip the `send_request` boilerplate      |
+| `.list_all_tools()` / `.list_all_resources()` | Drain pagination automatically                                     |
+
+Use the convenience methods (`.call_tool(...)`) when you can — they
+type-thread the response so you don't have to pattern-match
+`ServerResult`. Drop down to `send_request` only when you need a
+request variant that doesn't have a wrapper, or when you want to assert
+on the variant explicitly (as in tests).
+
+## Advertising client capabilities
+
+The default `get_info()` returns `ClientInfo::default()`, which has no
+capabilities set. To declare elicitation, sampling, or roots support,
+override `get_info`:
+
+```rust
+use rmcp::{
+    ClientHandler,
+    model::{ClientCapabilities, ClientInfo, Implementation},
+};
+
+#[derive(Default, Clone)]
+struct MyClient;
+
+impl ClientHandler for MyClient {
+    fn get_info(&self) -> ClientInfo {
+        ClientInfo::new(
+            ClientCapabilities::builder()
+                .enable_sampling()
+                .enable_elicitation()
+                .enable_roots()
+                .build(),
+            Implementation::from_build_env(),
+        )
+    }
+}
+```
+
+Declaring a capability is the gate that lets the server *make* the
+corresponding request. You still need to override the matching
+`ClientHandler` method (`create_message`, `create_elicitation`,
+`list_roots`) to actually answer it. The default behavior:
+
+| Method               | Default behavior                                                    |
+| -------------------- | ------------------------------------------------------------------- |
+| `create_message`     | Returns `method_not_found` — must override if `sampling` is enabled |
+| `create_elicitation` | Returns `ElicitationAction::Decline` with no content                |
+| `list_roots`         | Returns an empty `ListRootsResult`                                  |
+
+So the bare-minimum client that *declines* every elicitation request is
+already correct without an override — the test at
+`crates/mcp-server/tests/elicitation.rs::DecliningClient` relies on
+this exact behavior.
+
+## `ClientHandler` is implemented for `()` and `ClientInfo`
+
+Two convenience impls let you skip the struct entirely:
+
+- **`impl ClientHandler for ()`** — a no-op client with default info.
+  Useful for "just talk to the server" scripts.
+- **`impl ClientHandler for ClientInfo`** — uses the given `ClientInfo`
+  as the value `get_info()` returns. The streamable HTTP client
+  example at
+  `submodules/mcp-rust-sdk/examples/clients/src/streamable_http.rs`
+  uses this:
+
+  ```rust
+  let client_info = ClientInfo::new(
+      ClientCapabilities::default(),
+      Implementation::new("test client", "0.0.1"),
+  );
+  let client = client_info.serve(transport).await?;
+  ```
+
+Reach for the struct pattern when you need to override callbacks (e.g.
+to back a server's sampling/elicitation requests) or when you need
+internal state.
+
+## Transports
+
+The transport is whatever implements `IntoTransport<RoleClient, ...>`:
+
+| Transport                              | Built from                                                                                           |
+| -------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| stdio subprocess (`TokioChildProcess`) | `rmcp::transport::TokioChildProcess::new(Command::new(...).configure(                                |
+| Streamable HTTP                        | `StreamableHttpClientTransport::from_uri("http://...")` (`transport-streamable-http-client-reqwest`) |
+| In-memory duplex (tests)               | `tokio::io::duplex(4096)` — pass one half to the server and the other to the client                  |
+| Custom `(AsyncRead, AsyncWrite)`       | Any pair that implements `AsyncRead + AsyncWrite` (`transport-async-rw`)                             |
+
+See `references/rust-sdk/client/transports.md` for the wiring details of each.
+
+## Lifecycle
+
+```text
+client.serve(transport).await?       // initialize handshake
+client.send_request(...).await?      // run as long as you need
+// ...
+client.cancel().await?               // graceful shutdown
+```
+
+`.serve(...)` runs the JSON-RPC `initialize` handshake. If it succeeds
+you get a live `RunningService`. If the server rejects initialization
+(version mismatch, capability conflict), you get an error.
+
+`.waiting()` blocks until the service ends. Use it in production
+binaries to keep the process alive; use `.cancel()` in tests to tear
+the service down explicitly.
+
+## See also
+
+- `references/rust-sdk/client/handler.md` — every method on `ClientHandler` and
+  what overriding it does
+- `references/rust-sdk/client/requests.md` — sending typed requests and matching
+  on `ServerResult`
+- `references/rust-sdk/client/testing.md` — the in-memory duplex test harness
+- `references/rust-sdk/client/transports.md` — production transports
+- `crates/mcp-server/tests/tools.rs` — smallest runnable in-repo
+  example

--- a/.agents/skills/mcp-knowledge/references/rust-sdk/client/handler.md
+++ b/.agents/skills/mcp-knowledge/references/rust-sdk/client/handler.md
@@ -1,0 +1,141 @@
+# Client: the `ClientHandler` trait
+
+`ClientHandler` is the trait every `rmcp` client implements. Every
+method has a default, so you only override what you actually need to
+answer.
+
+Trait source: `submodules/mcp-rust-sdk/crates/rmcp/src/handler/client.rs`
+(starting at line 89).
+
+## When to read this
+
+- You're overriding a callback and want to know the signature.
+- You need the full list of notification callbacks a client receives.
+- You're debugging "method not found" or "elicitation declined"
+  responses and want to know what the defaults do.
+
+## Method catalog
+
+### Server-to-client *requests* (server asks the client to do something)
+
+These come from `ServerRequest::*` and the client must respond.
+
+| Method                                                                         | Default                           | Capability gate | When to override                           |
+| ------------------------------------------------------------------------------ | --------------------------------- | --------------- | ------------------------------------------ |
+| `ping(ctx) -> Result<(), McpError>`                                            | Returns `Ok(())`                  | none            | Almost never                               |
+| `create_message(params, ctx) -> Result<CreateMessageResult, McpError>`         | Returns `method_not_found`        | `sampling`      | Whenever sampling is enabled               |
+| `list_roots(ctx) -> Result<ListRootsResult, McpError>`                         | Returns empty `ListRootsResult`   | `roots`         | When the client exposes folders            |
+| `create_elicitation(params, ctx) -> Result<ElicitResult, McpError>`            | Returns `Decline` with no content | `elicitation`   | Whenever you want to actually ask the user |
+| `on_custom_request(req, ctx) -> Result<CustomResult, McpError>`                | Returns `method_not_found`        | none            | Handling protocol extensions               |
+
+### Server-to-client *notifications* (server tells the client about something)
+
+These are fire-and-forget — the client doesn't reply. Returning from
+the method is enough.
+
+| Method                                                  | Default | When to override                                                     |
+| ------------------------------------------------------- | ------- | -------------------------------------------------------------------- |
+| `on_cancelled(params, ctx)`                             | no-op   | Surface "operation cancelled" to the user                            |
+| `on_progress(params, ctx)`                              | no-op   | Update a progress bar                                                |
+| `on_logging_message(params, ctx)`                       | no-op   | Forward server logs into your logging system                         |
+| `on_resource_updated(params, ctx)`                      | no-op   | Invalidate a cache, re-fetch a resource                              |
+| `on_resource_list_changed(ctx)`                         | no-op   | Re-list resources                                                    |
+| `on_tool_list_changed(ctx)`                             | no-op   | Re-list tools                                                        |
+| `on_prompt_list_changed(ctx)`                           | no-op   | Re-list prompts                                                      |
+| `on_url_elicitation_notification_complete(params, ctx)` | no-op   | Continue a URL-based elicitation flow once the user finishes the URL |
+| `on_task_status(params, ctx)`                           | no-op   | Track task (SEP-1319) status changes pushed from the server          |
+| `on_custom_notification(notification, ctx)`             | no-op   | Handle protocol extensions                                           |
+
+### Initialization
+
+| Method       | Default                 | When to override                                                  |
+| ------------ | ----------------------- | ----------------------------------------------------------------- |
+| `get_info()` | `ClientInfo::default()` | Always when you want to declare capabilities or identify yourself |
+
+## `ClientInfo` and `ClientCapabilities`
+
+`ClientInfo::new(capabilities, implementation)` builds the value
+returned by `get_info()`. `ClientCapabilities::builder()` lets you
+opt in to client-side features:
+
+```rust
+use rmcp::model::{ClientCapabilities, ClientInfo, Implementation};
+
+ClientInfo::new(
+    ClientCapabilities::builder()
+        .enable_experimental()
+        .enable_roots()
+        .enable_roots_list_changed()
+        .enable_sampling()
+        .enable_elicitation()
+        .build(),
+    Implementation::from_build_env(),
+)
+```
+
+Builder methods (from
+`submodules/mcp-rust-sdk/crates/rmcp/src/model/capabilities.rs`):
+
+| Method                                    | Sets                                                  |
+| ----------------------------------------- | ----------------------------------------------------- |
+| `.enable_experimental()`                  | `experimental` capability marker (no fields)          |
+| `.enable_roots()`                         | `roots: Some(RootsCapabilities::default())`           |
+| `.enable_roots_list_changed()`            | `roots.list_changed = Some(true)`                     |
+| `.enable_sampling()`                      | `sampling: Some(SamplingCapability::default())`       |
+| `.enable_sampling_tools()`                | `sampling.tools = Some(true)` (SEP-1330)              |
+| `.enable_sampling_context()`              | `sampling.context = Some(true)` (SEP-1577)            |
+| `.enable_elicitation()`                   | `elicitation: Some(ElicitationCapability::default())` |
+| `.enable_elicitation_schema_validation()` | `elicitation.schema_validation = Some(true)`          |
+| `.enable_tasks()`                         | `tasks: Some(TasksCapability::default())`             |
+
+`Implementation::from_build_env()` reads `CARGO_PKG_NAME` and
+`CARGO_PKG_VERSION` and uses them as the client identity. For a
+hand-written name/version, use `Implementation::new("my-client", "0.1.0")`.
+
+## `RequestContext<RoleClient>` and `NotificationContext<RoleClient>`
+
+Every request and notification handler takes a context as its last
+parameter. The two most useful fields:
+
+- `ctx.peer` — the `Peer<RoleServer>` you can use to make outgoing
+  calls to the server. Useful inside `create_message` if you want to
+  call a tool before answering.
+- `ctx.request_id` (request contexts) — the JSON-RPC request id, useful
+  for tracing.
+
+## The blanket `Service<RoleClient>` impl
+
+`ClientHandler` is wired into the JSON-RPC machinery via a blanket
+`impl Service<RoleClient> for H: ClientHandler` at the top of
+`handler/client.rs`. You don't need to know about `Service<R>` to write
+a client — the blanket impl pattern-matches `ServerRequest` /
+`ServerNotification` and dispatches to the trait methods.
+
+## Wrapper impls
+
+`ClientHandler` is also implemented for `Box<T: ClientHandler>` and
+`Arc<T: ClientHandler>`, so you can stash clients in collections
+without erasing the type. For full dynamic dispatch use the
+`DynService<R>` trait surfaced via `ServiceExt::into_dyn`.
+
+## Special-case impls
+
+| Type         | `get_info()` returns    | `create_message` returns | `list_roots` returns | `create_elicitation` returns |
+| ------------ | ----------------------- | ------------------------ | -------------------- | ---------------------------- |
+| `()`         | `ClientInfo::default()` | `method_not_found`       | empty                | `Decline`                    |
+| `ClientInfo` | the value itself        | `method_not_found`       | empty                | `Decline`                    |
+
+These are intentional shortcuts for "I just want to talk to a server"
+clients (`()`) and "I just want to advertise capabilities" clients
+(`ClientInfo`).
+
+## See also
+
+- `references/rust-sdk/client/getting-started.md` — full minimum example
+- `references/rust-sdk/client/sampling.md`,
+  `references/rust-sdk/client/elicitation.md`,
+  `references/rust-sdk/client/roots.md` — per-callback deep dives
+- `submodules/mcp-rust-sdk/crates/rmcp/src/handler/client.rs` — full
+  trait source
+- `submodules/mcp-rust-sdk/crates/rmcp/src/model/capabilities.rs` —
+  `ClientCapabilities` builder source

--- a/.agents/skills/mcp-knowledge/references/rust-sdk/client/requests.md
+++ b/.agents/skills/mcp-knowledge/references/rust-sdk/client/requests.md
@@ -1,0 +1,226 @@
+# Client: sending requests
+
+A client drives a server by sending JSON-RPC requests and matching on
+the responses. `rmcp` exposes this via the `RunningService` returned
+from `ServiceExt::serve(transport)`.
+
+## When to read this
+
+- Calling a tool, fetching a resource, listing prompts, etc.
+- Tests that assert on the exact `ServerResult` variant.
+- You hit the `CancelTaskResult` vs `GetTaskResult` deserialization
+  ambiguity.
+
+## Two ways to send requests
+
+### Convenience methods on `RunningService`
+
+The fastest path is the typed convenience methods:
+
+```rust
+// List
+let tools = client.list_tools(Default::default()).await?;
+let resources = client.list_resources(Default::default()).await?;
+let prompts = client.list_prompts(Default::default()).await?;
+
+// Auto-paginate
+let all_tools = client.list_all_tools().await?;
+let all_resources = client.list_all_resources().await?;
+
+// Calls
+use rmcp::model::CallToolRequestParams;
+
+let result = client
+    .call_tool(
+        CallToolRequestParams::new("echo")
+            .with_arguments(rmcp::object!({ "message": "hi" })),
+    )
+    .await?;
+
+let prompt = client
+    .get_prompt(
+        rmcp::model::GetPromptRequestParams::new("echo")
+            .with_arguments(/* serde_json::Map<String, Value> */),
+    )
+    .await?;
+
+let res = client
+    .read_resource(rmcp::model::ReadResourceRequestParams::new("mem://example"))
+    .await?;
+```
+
+These return the typed result directly, so there's no enum
+pattern-matching. Use them in production code.
+
+The `rmcp::object!` macro is a small helper that produces a
+`serde_json::Map<String, Value>` — useful for tool arguments without
+declaring a struct.
+
+### Raw `send_request` for explicit variants
+
+When you need the wire-level enum (most often in tests, where you want
+to assert on the exact variant), build a `ClientRequest` and call
+`send_request`:
+
+```rust
+use rmcp::model::{
+    CallToolRequestParams, ClientRequest, Request, ServerResult,
+};
+
+let response = client
+    .send_request(ClientRequest::CallToolRequest(Request::new(
+        CallToolRequestParams::new("ping"),
+    )))
+    .await?;
+
+let ServerResult::CallToolResult(result) = response else {
+    panic!("expected CallToolResult, got {response:?}");
+};
+```
+
+`Request::new(params)` wraps the params in a `Request<Method, Params>`
+shape carrying the method-name marker type and the params. The convert
+to `ClientRequest::*` is done by the enum variants you choose.
+
+## `ClientRequest` variant map
+
+| Variant                        | Params type                      | Convenience method on `RunningService`         |
+| ------------------------------ | -------------------------------- | ---------------------------------------------- |
+| `InitializeRequest`            | `InitializeRequestParams`        | (auto, during `.serve(...)`)                   |
+| `PingRequest`                  | (no params)                      | `.ping()`                                      |
+| `ListResourcesRequest`         | `Option<PaginatedRequestParams>` | `.list_resources(...)`                         |
+| `ListResourceTemplatesRequest` | `Option<PaginatedRequestParams>` | `.list_resource_templates(...)`                |
+| `ReadResourceRequest`          | `ReadResourceRequestParams`      | `.read_resource(...)`                          |
+| `ListPromptsRequest`           | `Option<PaginatedRequestParams>` | `.list_prompts(...)`                           |
+| `GetPromptRequest`             | `GetPromptRequestParams`         | `.get_prompt(...)`                             |
+| `ListToolsRequest`             | `Option<PaginatedRequestParams>` | `.list_tools(...)`                             |
+| `CallToolRequest`              | `CallToolRequestParams`          | `.call_tool(...)`                              |
+| `CompleteRequest`              | `CompleteRequestParams`          | `.complete(...)`                               |
+| `SetLevelRequest`              | `SetLevelRequestParams`          | `.set_level(...)`                              |
+| `SubscribeRequest`             | `SubscribeRequestParams`         | `.subscribe(...)`                              |
+| `UnsubscribeRequest`           | `UnsubscribeRequestParams`       | `.unsubscribe(...)`                            |
+| `ListTasksRequest`             | `Option<PaginatedRequestParams>` | (raw `send_request`)                           |
+| `GetTaskRequest`               | `GetTaskParams`                  | (raw `send_request`)                           |
+| `GetTaskPayloadRequest`        | `GetTaskPayloadParams`           | (raw `send_request`)                           |
+| `CancelTaskRequest`            | `CancelTaskParams`               | (raw `send_request`)                           |
+| `CustomRequest`                | arbitrary JSON                   | (raw `send_request`)                           |
+
+There's no separate "enqueue task" request variant — invoking a tool as a
+task is `CallToolRequest` (or `.call_tool(...)`) with
+`CallToolRequestParams::with_task(TaskMetadata::new())` set. The server
+replies with `ServerResult::CreateTaskResult` instead of
+`ServerResult::CallToolResult`.
+
+`GetTaskPayloadRequest` / `GetTaskPayloadParams` were named
+`GetTaskResultRequest` / `GetTaskResultParams` before rmcp 2.0; the old
+names are kept as deprecated aliases.
+
+Exact variant names live in `model.rs` — `grep -n "pub enum ClientRequest"
+submodules/mcp-rust-sdk/crates/rmcp/src/model.rs` if you need the
+authoritative list.
+
+## Matching on `ServerResult`
+
+`send_request` returns a `ServerResult` enum (`ServerResult::*`):
+
+```rust
+match response {
+    ServerResult::CallToolResult(r) => { /* r is CallToolResult */ },
+    ServerResult::ListToolsResult(r) => { /* r is ListToolsResult */ },
+    ServerResult::ReadResourceResult(r) => { /* ... */ },
+    /* ... */
+    other => panic!("unexpected: {other:?}"),
+}
+```
+
+In the (rare) cases where the variant doesn't match the request you
+sent, you've likely:
+
+1. Hit the **untagged enum gotcha** (next section), or
+2. Sent a request the server doesn't support — it returned a
+   protocol-level error instead, which `send_request` would have
+   surfaced as `Err(...)`, not `Ok(ServerResult::*)`.
+
+## The untagged-enum gotcha (cancel vs get task)
+
+`ServerResult` deserializes via `#[serde(untagged)]`. Variants are
+tried in declaration order, so when two variants share the same wire
+shape, `serde` picks the first match.
+
+The known case is **`CancelTaskResult` vs `GetTaskResult`**: both
+serialize as `{ task: Task, _meta: Option<Meta> }` (a result shape plus
+a `task` field), and `GetTaskResult` is listed first in the enum. So a
+`tasks/cancel` response *may* deserialize as `ServerResult::GetTaskResult`
+even though the server intended to send `CancelTaskResult`.
+
+The fix: accept either:
+
+```rust
+let response = client
+    .send_request(ClientRequest::CancelTaskRequest(Request::new(
+        CancelTaskParams::new(task_id.clone()),
+    )))
+    .await?;
+
+let task = match response {
+    ServerResult::CancelTaskResult(r) => r.task,
+    ServerResult::GetTaskResult(r) => r.task,
+    other => panic!("expected cancel/get task result, got {other:?}"),
+};
+assert_eq!(task.status, TaskStatus::Cancelled);
+```
+
+`CancelTaskParams` is `#[non_exhaustive]`, so build it with
+`CancelTaskParams::new(task_id)` rather than a struct literal — the
+latter no longer compiles from outside the `rmcp` crate.
+
+`crates/mcp-server/tests/task.rs::list_tasks_reports_cancelled_status_for_cancelled_task`
+shows this in practice. If you see a test failing on
+`expected CancelTaskResult got GetTaskResult`, this is why.
+
+## Cancellation tokens
+
+`send_request` cancels cleanly when the caller's future is dropped —
+the underlying transport receives a `cancelled` notification. For
+explicit cancellation (e.g. timing out a slow tool), wrap the call:
+
+```rust
+let response = tokio::time::timeout(
+    std::time::Duration::from_secs(5),
+    client.send_request(/* ... */),
+)
+.await??;
+```
+
+## Notifications
+
+Send a fire-and-forget notification via `send_notification`:
+
+```rust
+use rmcp::model::{ClientNotification, Notification, ProgressNotificationParam};
+
+client
+    .send_notification(ClientNotification::ProgressNotification(
+        Notification::new(ProgressNotificationParam::new(progress_token, 0.5)),
+    ))
+    .await?;
+```
+
+`ProgressNotificationParam` is `#[non_exhaustive]` — build it with
+`::new(progress_token, progress)` plus `.with_total(...)` /
+`.with_message(...)`, not a struct literal.
+
+There's no response and no `await` for the server's reply.
+
+## See also
+
+- `references/rust-sdk/client/handler.md` — what the server can request from the
+  client
+- `references/rust-sdk/server/tasks.md` — the server side of the
+  `CancelTaskResult` / `GetTaskResult` ambiguity
+- `references/rust-sdk/client/testing.md` — full test-harness pattern using
+  `send_request`
+- `crates/mcp-server/tests/task.rs` — `CancelTaskParams`,
+  `ListTasksRequest`, polling-with-timeout
+- `submodules/mcp-rust-sdk/examples/clients/src/everything_stdio.rs`
+  — convenience methods (`call_tool`, `list_all_tools`, etc.)

--- a/.agents/skills/mcp-knowledge/references/rust-sdk/client/roots.md
+++ b/.agents/skills/mcp-knowledge/references/rust-sdk/client/roots.md
@@ -1,0 +1,147 @@
+# Client: roots (`list_roots`)
+
+> **SEP-2577 deprecation.** As of rmcp 2.0, roots types and methods
+> (`Root`, `ListRootsResult`, `Peer::list_roots`, `ClientHandler::list_roots`,
+> ...) are marked `#[deprecated]`. They still work — it's a compiler
+> warning, not a hard error — and roots remains part of the protocol. Real
+> code that keeps using them (like the examples on this page) should wrap
+> the call site in
+> `#[allow(deprecated, reason = "SEP-2577 deprecates roots; kept as an example")]`,
+> matching the pattern in `crates/mcp-server/src/tools.rs::list_workspace_roots`.
+
+When a server calls `roots/list`, the client returns the
+filesystem/workspace roots it has exposed (IDE open folders, sandbox
+paths, etc.). `ClientHandler::list_roots` is the hook.
+
+## When to read this
+
+- Writing an IDE-integrated client that exposes open folders.
+- Building a sandboxed client that wants to scope server access to
+  specific directories.
+- Implementing live updates so the server is notified when the user
+  opens or closes a folder.
+
+The default behavior — empty list — is fine for clients that don't
+have a filesystem concept (chat UIs, headless scripts).
+
+## Default behavior: empty list
+
+`ClientHandler::list_roots`'s default returns `ListRootsResult::default()`
+— an empty `roots: Vec<Root>`. A server calling `peer.list_roots()`
+will get the empty list back without an error.
+
+If you don't even want the *capability* advertised, leave it off in
+`ClientCapabilities`; the server's `Peer::list_roots()` call then
+fails with a capability-not-supported error, which the server-side
+tool can handle gracefully.
+
+## Returning real roots
+
+```rust
+use rmcp::{
+    ClientHandler,
+    model::{
+        ClientCapabilities, ClientInfo, ErrorData, Implementation,
+        ListRootsResult, Root,
+    },
+    service::{RequestContext, RoleClient},
+};
+
+#[derive(Clone)]
+struct WorkspaceClient {
+    roots: Vec<Root>,
+}
+
+#[allow(deprecated, reason = "SEP-2577 deprecates roots; kept as an example")]
+impl ClientHandler for WorkspaceClient {
+    fn get_info(&self) -> ClientInfo {
+        ClientInfo::new(
+            ClientCapabilities::builder()
+                .enable_roots()
+                .enable_roots_list_changed()
+                .build(),
+            Implementation::from_build_env(),
+        )
+    }
+
+    async fn list_roots(
+        &self,
+        _ctx: RequestContext<RoleClient>,
+    ) -> Result<ListRootsResult, ErrorData> {
+        Ok(ListRootsResult::new(self.roots.clone()))
+    }
+}
+
+fn build_root(uri: &str, name: Option<&str>) -> Root {
+    match name {
+        Some(n) => Root::new(uri).with_name(n),
+        None => Root::new(uri),
+    }
+}
+```
+
+`Root` and `ListRootsResult` are both `#[non_exhaustive]`, so build them
+with `Root::new(uri).with_name(...)` and `ListRootsResult::new(roots)`
+rather than struct literals — the old `Annotated<RawRoot>` wrapper (and
+its `.no_annotation()` constructor) is gone in rmcp 2.0.
+
+## `Root` shape
+
+`Root` is now a flat, `#[deprecated]`, `#[non_exhaustive]` struct — no
+more `Annotated<RawRoot>` wrapper. Its fields:
+
+| Field  | Type             | Meaning                                                                   |
+| ------ | ---------------- | ------------------------------------------------------------------------- |
+| `uri`  | `String`         | The root URI. Use `file:///absolute/path` for filesystem locations        |
+| `name` | `Option<String>` | Display label. If unset, server-side code typically falls back to the URI |
+| `meta` | `Option<Meta>`   | Protocol-level metadata (SEP-1319), set via `.with_meta(...)`             |
+
+URIs should be **absolute** and **normalized**. Servers may compare
+URIs as strings; trailing slashes and `..` segments will cause
+mismatches.
+
+## Capability flavors
+
+| Capability                     | Meaning                                                          |
+| ------------------------------ | ---------------------------------------------------------------- |
+| `.enable_roots()`              | Client supports `roots/list`                                     |
+| `.enable_roots_list_changed()` | Client will additionally send `roots/list_changed` notifications |
+
+If your client mutates its roots at runtime (user opens / closes a
+folder), enable list-changed and emit notifications via
+`client_service.peer().notify_roots_list_changed().await?` whenever the
+list shifts. Servers can subscribe by overriding
+`ServerHandler::on_roots_list_changed`.
+
+## Static vs dynamic
+
+Two common shapes:
+
+| Pattern                               | When                                                                        |
+| ------------------------------------- | --------------------------------------------------------------------------- |
+| Static `Vec<Root>` fixed at startup   | Headless scripts, sandboxes with a single workspace                         |
+| Dynamic, fetched from an IDE callback | VS Code / IntelliJ-style clients where roots change as folders open / close |
+
+For the dynamic case, store the list behind an `Arc<Mutex<...>>` so
+`list_roots` can read it without async blocking, and update from the
+IDE's filesystem-watch callbacks.
+
+## Permission and consent
+
+Like sampling, roots disclose information that the user might not want
+to share. UI clients should:
+
+- Show the user which roots are exposed (and to which server).
+- Default to **no roots** for untrusted servers.
+- Allow per-server overrides.
+
+`rmcp` doesn't enforce any of this — it's policy.
+
+## See also
+
+- `references/rust-sdk/server/roots.md` — the server side that calls
+  `list_roots`
+- `references/rust-sdk/client/handler.md` — the full `ClientHandler` method list
+  including `on_resource_*` notifications (analogous live updates)
+- `submodules/mcp-rust-sdk/crates/rmcp/src/handler/client.rs:107-112`
+  — default implementation of `list_roots`

--- a/.agents/skills/mcp-knowledge/references/rust-sdk/client/sampling.md
+++ b/.agents/skills/mcp-knowledge/references/rust-sdk/client/sampling.md
@@ -1,0 +1,211 @@
+# Client: sampling (`create_message`)
+
+> **SEP-2577 deprecation.** As of rmcp 2.0, sampling types and methods
+> (`CreateMessageRequestParams`, `CreateMessageResult`, `SamplingMessage`,
+> `Peer::create_message`, ...) are marked `#[deprecated]`. They still work —
+> it's a compiler warning, not a hard error — and sampling remains part of
+> the protocol. Real code that keeps using them (like the examples on this
+> page) should wrap the call site in
+> `#[allow(deprecated, reason = "SEP-2577 deprecates sampling; kept as an example")]`,
+> matching the pattern in `crates/mcp-server/src/tools.rs::ask_llm`.
+
+When a server calls `sampling/createMessage`, the client is expected to
+hand the request to an LLM and return the model's response.
+`rmcp` exposes the hook as `ClientHandler::create_message`.
+
+## When to read this
+
+- Your client should back a server that uses sampling (e.g. running
+  `crates/mcp-server/` and exercising the `ask_llm` tool).
+- Writing a desktop / IDE client that integrates a local or remote LLM.
+- Building a mock client for tests.
+
+The upstream mock-LLM example is
+`submodules/mcp-rust-sdk/examples/clients/src/sampling_stdio.rs`.
+
+## The minimum overriding client
+
+```rust
+use rmcp::{
+    ClientHandler,
+    model::{
+        ClientCapabilities, ClientInfo, CreateMessageRequestParams,
+        CreateMessageResult, ErrorData, Implementation, SamplingMessage,
+    },
+    service::{RequestContext, RoleClient},
+};
+
+#[derive(Default, Clone)]
+struct SamplingClient;
+
+#[allow(deprecated, reason = "SEP-2577 deprecates sampling; kept as an example")]
+impl ClientHandler for SamplingClient {
+    fn get_info(&self) -> ClientInfo {
+        ClientInfo::new(
+            ClientCapabilities::builder().enable_sampling().build(),
+            Implementation::from_build_env(),
+        )
+    }
+
+    async fn create_message(
+        &self,
+        params: CreateMessageRequestParams,
+        _ctx: RequestContext<RoleClient>,
+    ) -> Result<CreateMessageResult, ErrorData> {
+        // Forward params.messages, params.system_prompt, params.max_tokens,
+        // and params.temperature to your LLM of choice. Below: mock response.
+        let reply = format!(
+            "(mock) saw {} message(s), max_tokens={}",
+            params.messages.len(),
+            params.max_tokens,
+        );
+
+        Ok(CreateMessageResult::new(
+            SamplingMessage::assistant_text(reply),
+            "mock_model".to_string(),
+        )
+        .with_stop_reason(CreateMessageResult::STOP_REASON_END_TURN))
+    }
+}
+```
+
+Two responsibilities:
+
+1. Advertise the `sampling` capability in `get_info()`. Without this
+   the server's `Peer::create_message` call returns an error.
+2. Override `create_message` and return a `CreateMessageResult`.
+
+## `CreateMessageRequestParams` shape
+
+Useful fields on the params (full list in
+`submodules/mcp-rust-sdk/crates/rmcp/src/model.rs`):
+
+| Field               | Type                                                          |
+| ------------------- | ------------------------------------------------------------- |
+| `messages`          | `Vec<SamplingMessage>` — the conversation so far              |
+| `model_preferences` | `Option<ModelPreferences>` — model hints from the server      |
+| `system_prompt`     | `Option<String>`                                              |
+| `include_context`   | `Option<IncludeContext>` — `None`, `ThisServer`, `AllServers` |
+| `temperature`       | `Option<f32>`                                                 |
+| `max_tokens`        | `u32` — required, server-supplied                             |
+| `stop_sequences`    | `Option<Vec<String>>`                                         |
+| `metadata`          | `Option<Value>`                                               |
+
+`include_context` is the server's way of saying "also feed in context
+from MCP servers when sampling." Most clients ignore it — handling it
+correctly requires inspecting active sessions, which is application-specific.
+
+## `CreateMessageResult` constructor
+
+`CreateMessageResult::new(message, model_name)` is the minimum shape.
+Chain optional builders for stop reason and metadata:
+
+```rust
+CreateMessageResult::new(
+    SamplingMessage::assistant_text("Hello, world."),
+    "gpt-4o-mini".to_string(),
+)
+.with_stop_reason(CreateMessageResult::STOP_REASON_END_TURN)
+```
+
+Known stop-reason constants:
+
+| Constant                                         | Meaning                               |
+| ------------------------------------------------ | ------------------------------------- |
+| `CreateMessageResult::STOP_REASON_END_TURN`      | Model finished naturally              |
+| `CreateMessageResult::STOP_REASON_END_SEQUENCE`  | Hit one of `stop_sequences`           |
+| `CreateMessageResult::STOP_REASON_END_MAX_TOKEN` | Output truncated at `max_tokens`      |
+| `CreateMessageResult::STOP_REASON_TOOL_USE`      | Model produced a tool call (SEP-1577) |
+
+Use the string literal if the constant you want isn't exposed yet.
+
+## Multi-modal responses
+
+`SamplingMessage::user_text` / `assistant_text` produce text turns. For
+images or audio, construct the message manually with the appropriate
+`SamplingMessageContentBlock` variant — the sampling-specific content
+union (text | image | audio | tool_use | tool_result), distinct from the
+general-purpose `ContentBlock` used everywhere else (tool results,
+resources, prompts):
+
+```rust
+use rmcp::model::{ImageContent, Role, SamplingMessage, SamplingMessageContentBlock};
+
+let img = SamplingMessageContentBlock::Image(ImageContent::new(base64_bytes, "image/png"));
+let message = SamplingMessage::new(Role::Assistant, img);
+```
+
+`SamplingMessage` is `#[non_exhaustive]`, so build it with
+`SamplingMessage::new(role, content)` / `::new_multiple(role, contents)`
+rather than a struct literal.
+
+The server side (see `references/rust-sdk/server/sampling.md`) iterates content
+blocks via `as_text()` etc., so non-text content needs explicit
+handling on both sides.
+
+## Forwarding to a real LLM
+
+The mock client just echoes — a real client wires the params through to
+its provider. Sketch:
+
+```rust
+async fn create_message(
+    &self,
+    params: CreateMessageRequestParams,
+    _ctx: RequestContext<RoleClient>,
+) -> Result<CreateMessageResult, ErrorData> {
+    let reply = self
+        .anthropic_client
+        .complete(&params.messages, params.system_prompt.as_deref(), params.max_tokens)
+        .await
+        .map_err(|e| ErrorData::internal_error(format!("LLM error: {e}"), None))?;
+
+    Ok(CreateMessageResult::new(
+        SamplingMessage::assistant_text(reply.text),
+        reply.model_name,
+    )
+    .with_stop_reason(reply.stop_reason))
+}
+```
+
+The `anthropic_client` here is illustrative — `rmcp` doesn't ship an
+LLM client; you bring your own.
+
+## Honoring `model_preferences`
+
+`ModelPreferences` carries the server's hints:
+
+| Field                   | Meaning                                            |
+| ----------------------- | -------------------------------------------------- |
+| `cost_priority`         | 0..=1 — higher means prefer cheaper                |
+| `speed_priority`        | 0..=1 — higher means prefer faster                 |
+| `intelligence_priority` | 0..=1 — higher means prefer more capable           |
+| `hints`                 | `Vec<ModelHint>` — explicit model name suggestions |
+
+If you can route between multiple models, use these to pick. If you
+only have one, ignore them.
+
+## Authorization and abuse
+
+Sampling lets a server request *arbitrary* LLM output via the user's
+LLM budget. UI clients should:
+
+- Show the user what's about to be sampled (the prompt, system prompt,
+  message count).
+- Ask for permission, at least the first time per server.
+- Apply budget limits.
+
+This is policy — `rmcp` doesn't enforce it. But the spec recommends it,
+and production clients should follow.
+
+## See also
+
+- `references/rust-sdk/server/sampling.md` — the server side that calls
+  `create_message`
+- `references/rust-sdk/client/handler.md` — the full `ClientHandler` method list
+- `references/rust-sdk/client/elicitation.md` — sibling client-side request
+  handler
+- `submodules/mcp-rust-sdk/examples/clients/src/sampling_stdio.rs` —
+  upstream mock-LLM client
+- `submodules/mcp-rust-sdk/examples/servers/src/sampling_stdio.rs` —
+  the server it talks to

--- a/.agents/skills/mcp-knowledge/references/rust-sdk/client/testing.md
+++ b/.agents/skills/mcp-knowledge/references/rust-sdk/client/testing.md
@@ -1,0 +1,268 @@
+# Client: testing MCP servers with `tokio::io::duplex`
+
+The canonical way to unit-test an MCP server is to drive it from a
+client inside the same process, with a `tokio::io::duplex(...)` pair
+as the transport. No subprocess, no network — just two `AsyncRead`/
+`AsyncWrite` halves piped between server and client.
+
+Every test in `crates/mcp-server/tests/` uses this pattern. It's *the*
+shape for testing any MCP-related Rust code.
+
+## When to read this
+
+- Writing integration tests for a server.
+- Reproducing a server bug from a known client interaction.
+- Exercising the server's `tools/*`, `prompts/*`, `resources/*`,
+  `tasks/*` flows without setting up subprocesses or HTTP.
+
+## The harness
+
+```rust
+use rmcp::{ClientHandler, ServiceExt};
+
+#[derive(Default, Clone)]
+struct TestClient;
+impl ClientHandler for TestClient {}
+
+#[tokio::test]
+async fn smoke() -> anyhow::Result<()> {
+    let (server_transport, client_transport) = tokio::io::duplex(4096);
+
+    let server_handle = tokio::spawn(async move {
+        let service = MyServer::new().serve(server_transport).await?;
+        service.waiting().await?;
+        anyhow::Ok(())
+    });
+
+    let client = TestClient.serve(client_transport).await?;
+
+    // ... assertions go here ...
+
+    client.cancel().await?;
+    let _ = server_handle.await;
+    Ok(())
+}
+```
+
+Three moving parts:
+
+1. **`tokio::io::duplex(buffer)`** — returns a pair of duplex streams.
+   Whatever the server writes to its half, the client reads on its
+   half, and vice versa.
+2. **`tokio::spawn(...)`** — the server lives on a background task. It
+   does `serve(server_transport).await?` (initialize handshake), then
+   `.waiting().await?` (run the message loop) until the client
+   disconnects.
+3. **`TestClient.serve(client_transport).await?`** — the client
+   initializes against the same in-memory channel. The `.serve` call
+   completes once the JSON-RPC `initialize` handshake succeeds.
+
+When the test is done, `client.cancel()` closes the client end, which
+makes the server's `.waiting()` future complete, which makes the
+spawned task return, which `_ = server_handle.await` joins cleanly.
+
+## A complete worked test
+
+```rust
+use mcp_server::Server;
+use rmcp::{
+    ClientHandler, ServiceExt,
+    model::{
+        CallToolRequestParams, ClientRequest, ContentBlock, ListToolsRequest, Request,
+        ServerResult,
+    },
+};
+
+#[derive(Default, Clone)]
+struct TestClient;
+impl ClientHandler for TestClient {}
+
+#[tokio::test]
+async fn list_tools_returns_the_advertised_set() -> anyhow::Result<()> {
+    let (server_transport, client_transport) = tokio::io::duplex(4096);
+    let server_handle = tokio::spawn(async move {
+        let service = Server::new().serve(server_transport).await?;
+        service.waiting().await?;
+        anyhow::Ok(())
+    });
+    let client = TestClient.serve(client_transport).await?;
+
+    let response = client
+        .send_request(ClientRequest::ListToolsRequest(ListToolsRequest::default()))
+        .await?;
+    let ServerResult::ListToolsResult(listed) = response else {
+        panic!("expected ListToolsResult, got {response:?}");
+    };
+
+    let mut names: Vec<&str> = listed.tools.iter().map(|t| t.name.as_ref()).collect();
+    names.sort();
+    assert_eq!(names, vec!["ping", "slow_count"]);
+
+    client.cancel().await?;
+    let _ = server_handle.await;
+    Ok(())
+}
+```
+
+(Sample taken from `crates/mcp-server/tests/tools.rs`.)
+
+## Helper: extracting text content
+
+`ContentBlock` is a flat, non-generic enum (`Text | Image | Audio |
+Resource | ResourceLink`) — no more `Annotated<RawContent>` wrapper, so
+there's no `.raw` indirection. A tiny helper keeps the test bodies clean:
+
+```rust
+fn first_text(content: &[ContentBlock]) -> Option<&str> {
+    content.iter().find_map(|c| match c {
+        ContentBlock::Text(t) => Some(t.text.as_str()),
+        _ => None,
+    })
+}
+```
+
+This appears verbatim in
+`crates/mcp-server/tests/tools.rs::first_text` and
+`crates/mcp-server/tests/elicitation.rs::first_text`.
+
+## Polling for state
+
+For task tests, the server completes work in the background — you have
+to poll until the desired state appears. Don't `tokio::time::sleep(...)`
+a fixed duration; it's slow and flaky. Use a bounded polling loop:
+
+```rust
+use std::time::Duration;
+use rmcp::{
+    RoleClient,
+    model::{ClientRequest, ListTasksRequest, ServerResult, TaskStatus},
+    service::RunningService,
+};
+
+async fn wait_for_task_status(
+    client: &RunningService<RoleClient, TestClient>,
+    task_id: &str,
+    target: TaskStatus,
+    within: Duration,
+) -> anyhow::Result<()> {
+    tokio::time::timeout(within, async {
+        loop {
+            let tasks = client
+                .send_request(ClientRequest::ListTasksRequest(ListTasksRequest::default()))
+                .await?;
+            let ServerResult::ListTasksResult(listed) = tasks else {
+                anyhow::bail!("expected ListTasksResult, got {tasks:?}");
+            };
+            if listed
+                .tasks
+                .iter()
+                .any(|t| t.task_id == task_id && t.status == target)
+            {
+                return anyhow::Ok(());
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .map_err(|_| anyhow::anyhow!("task {task_id} did not reach {target:?} within {within:?}"))?
+}
+```
+
+(From `crates/mcp-server/tests/task.rs:30-56`.)
+
+Use a 5-second timeout for tests that wait on running tasks. The inner
+poll delay (`20ms`) is short enough that the test reacts almost
+instantly when the state arrives.
+
+## Capability negotiation in tests
+
+If your test exercises a server feature that needs a client capability
+(elicitation, sampling, roots), declare it in the test client's
+`get_info()`. The simplest "always declines" elicitation client is
+literally:
+
+```rust
+#[derive(Default, Clone)]
+struct DecliningClient;
+
+impl ClientHandler for DecliningClient {
+    fn get_info(&self) -> ClientInfo {
+        ClientInfo::new(
+            ClientCapabilities::builder().enable_elicitation().build(),
+            Implementation::from_build_env(),
+        )
+    }
+}
+```
+
+Default `create_elicitation` already returns `Decline`, so the test
+needs no override. See
+`crates/mcp-server/tests/elicitation.rs`.
+
+For a test that needs to *accept* elicitation with canned content,
+override `create_elicitation`:
+
+```rust
+async fn create_elicitation(
+    &self,
+    _params: ElicitRequestParams,
+    _ctx: RequestContext<RoleClient>,
+) -> Result<ElicitResult, ErrorData> {
+    Ok(ElicitResult::new(ElicitationAction::Accept)
+        .with_content(serde_json::json!({ "name": "Test User" })))
+}
+```
+
+## Sending raw `ClientRequest::*` vs convenience methods
+
+Tests typically use `send_request(ClientRequest::*)` rather than
+`client.call_tool(...)` so the test can pattern-match on the *exact*
+`ServerResult` variant. Production code should prefer the convenience
+methods.
+
+When a request can ambiguously deserialize (e.g.
+`CancelTaskResult` vs `GetTaskResult` — see
+`references/rust-sdk/client/requests.md`), accept either variant:
+
+```rust
+let task = match cancel_response {
+    ServerResult::CancelTaskResult(r) => r.task,
+    ServerResult::GetTaskResult(r) => r.task,
+    other => panic!("expected cancel/get task result, got {other:?}"),
+};
+```
+
+## Gotchas
+
+### `cancel().await` doesn't always join the spawned task
+
+The pattern `let _ = server_handle.await;` after `client.cancel()` is
+there to actually wait for the server task to finish, not just to
+trigger its shutdown. Without it, the test may finish before the
+server's logging or drop logic runs — fine in most cases, but it can
+mask resource-leak bugs.
+
+### Buffer too small => stall
+
+`tokio::io::duplex(4096)` gives 4 KB of in-memory buffer per direction.
+That's plenty for normal MCP messages, but if a single response is
+larger (large `tools/list` result, big resource body) and the reader
+isn't draining, you can deadlock. Bump to `64 * 1024` if you see a
+stall on a big response.
+
+### Tests can run in parallel
+
+`cargo test` runs integration tests concurrently by default. Each
+duplex pair is process-local, so there's no cross-test interference —
+no need to serialize tests against a global resource.
+
+## See also
+
+- `references/rust-sdk/client/getting-started.md` — the smallest viable client
+- `references/rust-sdk/client/requests.md` — building `ClientRequest::*`
+- `references/rust-sdk/client/transports.md` — production transport choices
+- `crates/mcp-server/tests/tools.rs` — list / call / typed args
+- `crates/mcp-server/tests/prompts.rs` — `GetPromptRequest`
+- `crates/mcp-server/tests/resources.rs` — list / read / template / error
+- `crates/mcp-server/tests/elicitation.rs` — `DecliningClient` + capability declaration
+- `crates/mcp-server/tests/task.rs` — polling, cancellation, completion

--- a/.agents/skills/mcp-knowledge/references/rust-sdk/client/transports.md
+++ b/.agents/skills/mcp-knowledge/references/rust-sdk/client/transports.md
@@ -1,0 +1,194 @@
+# Client: transports
+
+A client picks a transport based on where the server lives:
+
+| Server location                  | Transport                                                                                         |
+| -------------------------------- | ------------------------------------------------------------------------------------------------- |
+| Subprocess on the same host      | `TokioChildProcess` (`transport-child-process`)                                                   |
+| Remote / network                 | `StreamableHttpClientTransport` (`transport-streamable-http-client-reqwest`)                      |
+| Unix socket on the same host     | `StreamableHttpClientTransport` over Unix socket (`transport-streamable-http-client-unix-socket`) |
+| Inside the same process (tests)  | One half of `tokio::io::duplex(...)`                                                              |
+| Custom `(AsyncRead, AsyncWrite)` | Anything implementing `IntoTransport<RoleClient, ...>` (`transport-async-rw`)                     |
+
+## stdio subprocess (`transport-child-process`)
+
+The most common production client transport: launch a server binary as
+a subprocess and pipe its stdin/stdout. The helper is
+`rmcp::transport::TokioChildProcess`.
+
+```rust
+use rmcp::{
+    ServiceExt,
+    transport::{ConfigureCommandExt, TokioChildProcess},
+};
+use tokio::process::Command;
+
+let client = ()
+    .serve(TokioChildProcess::new(Command::new("npx").configure(
+        |cmd| {
+            cmd.arg("-y").arg("@modelcontextprotocol/server-everything");
+        },
+    ))?)
+    .await?;
+```
+
+`Command::new(bin).configure(|cmd| { cmd.arg(...); })` is sugar from
+the `ConfigureCommandExt` trait — it threads the command builder
+through a closure so you can keep the call site one expression. Plain
+`Command` works too:
+
+```rust
+let mut cmd = Command::new("./target/release/mcp-server-stdio");
+let transport = TokioChildProcess::new(cmd)?;
+let client = ().serve(transport).await?;
+```
+
+### When the binary path isn't known statically
+
+Use `which_command` (gated behind the `which-command` feature) to
+resolve a binary name to a path cross-platform. It returns a
+`tokio::process::Command` pointing at the resolved executable, which you
+then configure and hand to `TokioChildProcess::new`:
+
+```rust
+use rmcp::transport::{which_command, ConfigureCommandExt, TokioChildProcess};
+
+let cmd = which_command("python")?.configure(|cmd| {
+    cmd.arg("-m").arg("my_mcp_server");
+});
+let transport = TokioChildProcess::new(cmd)?;
+```
+
+## Streamable HTTP (`transport-streamable-http-client-reqwest`)
+
+For network servers. The transport is built from a URI:
+
+```rust
+use rmcp::{
+    ServiceExt,
+    model::{ClientCapabilities, ClientInfo, Implementation},
+    transport::StreamableHttpClientTransport,
+};
+
+let transport = StreamableHttpClientTransport::from_uri("http://localhost:8000/mcp");
+
+let client_info = ClientInfo::new(
+    ClientCapabilities::default(),
+    Implementation::new("test-client", "0.0.1"),
+);
+let client = client_info.serve(transport).await?;
+
+let tools = client.list_tools(Default::default()).await?;
+println!("{tools:#?}");
+```
+
+Note that `ClientInfo` implements `ClientHandler` (see
+`references/rust-sdk/client/handler.md`), so you can pass it directly to
+`.serve(...)` for a "just talk to the server" client.
+
+### Picking a TLS strategy
+
+Choose one of `reqwest`, `reqwest-native-tls`, or
+`reqwest-tls-no-provider` in your `Cargo.toml`. They're mutually
+exclusive — see `references/rust-sdk/feature-flags.md`.
+
+### Custom headers / auth
+
+`StreamableHttpClientTransport` accepts a configured `reqwest::Client`
+via `StreamableHttpClientTransport::from_client(reqwest_client, "...")`.
+Use this to inject `Authorization`, `User-Agent`, custom timeouts, or
+cookie support. Production clients almost always want this rather than
+`from_uri`.
+
+## Unix socket (`transport-streamable-http-client-unix-socket`)
+
+For talking to a server bound to a Unix domain socket on the same
+host. Uses `hyper` rather than `reqwest`:
+
+```rust
+use rmcp::transport::UnixSocketHttpClient;
+
+let transport = UnixSocketHttpClient::new("/run/myserver.sock", "/mcp");
+let client = ().serve(transport).await?;
+```
+
+Mostly relevant for daemon-style deployments where the server runs as
+a system service.
+
+## In-memory duplex (tests)
+
+Skip the network entirely:
+
+```rust
+let (server_transport, client_transport) = tokio::io::duplex(4096);
+let server_handle = tokio::spawn(async move {
+    let service = MyServer::new().serve(server_transport).await?;
+    service.waiting().await?;
+    anyhow::Ok(())
+});
+let client = TestClient.serve(client_transport).await?;
+// ... drive the server ...
+client.cancel().await?;
+let _ = server_handle.await;
+```
+
+This is *the* canonical test harness — every test in
+`crates/mcp-server/tests/` uses it. The buffer (`4096`) is just the
+backpressure threshold; it's not a message-size limit. See
+`references/rust-sdk/client/testing.md` for more.
+
+## `IntoTransport` and BYO transport
+
+Any `(impl AsyncRead, impl AsyncWrite)` pair implements
+`IntoTransport<RoleClient, ...>` when the `transport-async-rw` feature
+is on (which is the default for `client`). So you can plug in:
+
+- A TCP socket — `tokio::net::TcpStream::split()` gives you the two
+  halves.
+- A web-socket library that produces `AsyncRead`/`AsyncWrite` adapters.
+- A test mock — any pair you wire up by hand.
+
+The `Sink` / `Stream` variant is also supported via
+`IntoTransport<RoleClient, _, Sink + Stream>` — used by the streamable
+HTTP transport internally.
+
+## Choosing in one line
+
+| Goal                                 | Reach for                                                               |
+| ------------------------------------ | ----------------------------------------------------------------------- |
+| Drive a local MCP server binary      | `TokioChildProcess` (`transport-child-process`)                         |
+| Drive a remote MCP server over HTTPS | `StreamableHttpClientTransport` with `reqwest` TLS feature              |
+| Drive a system-daemon MCP server     | `UnixSocketHttpClient` (`transport-streamable-http-client-unix-socket`) |
+| Unit-test a local server             | `tokio::io::duplex(4096)`                                               |
+
+## Gotchas
+
+### Subprocess stderr is *your* problem
+
+`TokioChildProcess` only pipes stdin/stdout. The child's stderr
+inherits from the parent by default. If your subprocess logs to stderr,
+that output will appear interleaved with your client's logs unless you
+explicitly redirect it (`.stderr(Stdio::piped())` and consume it).
+
+### HTTPS to `localhost` needs care
+
+`localhost` doesn't have a public certificate. For development, point
+at `http://localhost:...` (no TLS) or use a self-signed cert with
+`reqwest::ClientBuilder::danger_accept_invalid_certs(true)` — set
+that on the client you pass to `from_client`.
+
+### Don't `serve` twice
+
+`ServiceExt::serve(transport)` consumes the transport. If you need to
+reconnect after a failure, build a new transport and call `.serve(...)`
+again.
+
+## See also
+
+- `references/rust-sdk/feature-flags.md` — exact feature flags for each transport
+- `references/rust-sdk/server/transports.md` — corresponding server-side wiring
+- `references/rust-sdk/client/testing.md` — duplex transport in detail
+- `submodules/mcp-rust-sdk/examples/clients/src/everything_stdio.rs`
+  — subprocess client driving the JS reference server
+- `submodules/mcp-rust-sdk/examples/clients/src/streamable_http.rs`
+  — HTTP client

--- a/.agents/skills/mcp-knowledge/references/rust-sdk/doc-index.md
+++ b/.agents/skills/mcp-knowledge/references/rust-sdk/doc-index.md
@@ -1,0 +1,99 @@
+# rmcp (Rust SDK) documentation index
+
+One-line summary of every reference file shipped under the Rust SDK section
+of the `mcp-knowledge` skill. Paths in the tables below are relative to
+`skills/mcp-knowledge/references/rust-sdk/`. Code citations target either
+the local example crate (`crates/mcp-server/`) or the pinned upstream
+submodule (`submodules/mcp-rust-sdk/`).
+
+## Shared
+
+| Path               | Topic                                                                                                                              |
+| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `feature-flags.md` | Every Cargo feature on the `rmcp` crate, what it enables, common starter sets, the `reqwest` TLS choice, and common compile errors |
+
+## Server features (`server/`)
+
+### Composition
+
+| Path                        | Topic                                                                                                                                                                                           |
+| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `server/getting-started.md` | Wiring `ToolRouter` / `PromptRouter` / `OperationProcessor` into a single `Server`; the stacked-handler-macros rule; resource handlers as free functions; `get_info` / capability advertisement |
+
+### Primitives
+
+| Path                  | Topic                                                                                                                                                                                                     |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `server/tools.md`     | `#[tool_router]`, `#[tool(description = ...)]`, `Parameters<T>` with `schemars::JsonSchema`, `CallToolResult` shape, `execution(task_support = ...)`, `annotations(...)` and the default-destructive trap |
+| `server/prompts.md`   | `#[prompt_router]`, no-arg + single-arg + multi-arg prompts, `Role`, `GetPromptResult::with_description`                                                                                                  |
+| `server/resources.md` | Why there is no macro router for resources; `list_resources` / `read_resource` / `list_resource_templates`; URI scheme dispatch with `strip_prefix`; `Resource` / `ResourceTemplate` builders             |
+| `server/tasks.md`     | SEP-1686 lifecycle, `OperationProcessor`, `#[task_handler]` macro contract, the canonical `list_tasks` override, cancellation string-matching, timestamp limitation                                       |
+
+### Server-to-client requests
+
+| Path                    | Topic                                                                                                                                                                               |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `server/sampling.md`    | `ctx.peer.create_message(...)`, `CreateMessageRequestParams` builder methods, multimodal content extraction with `as_text()`, `tracing::warn!` fallback pattern                     |
+| `server/elicitation.md` | `rmcp::elicit_safe!`, `ctx.peer.elicit::<T>(...)`, the `ElicitationError` must-handle variants (`UserDeclined`, `UserCancelled`, `CapabilityNotSupported`), form vs URL elicitation |
+| `server/roots.md`       | `ctx.peer.list_roots()`, `Root` shape, empty-roots fallback                                                                                                                         |
+
+### Transports
+
+| Path                   | Topic                                                                                                                                                                              |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `server/transports.md` | stdio (`rmcp::transport::stdio`) with stderr-only logging; Streamable HTTP via `StreamableHttpService` + `LocalSessionManager` + axum; graceful shutdown; in-memory duplex pointer |
+
+## Client features (`client/`)
+
+### Composition
+
+| Path                        | Topic                                                                                                                                     |
+| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `client/getting-started.md` | Smallest viable `ClientHandler`, `ServiceExt::serve(transport)`, `RunningService<RoleClient, _>`, the `()` and `ClientInfo` blanket impls |
+| `client/handler.md`         | Every method on `ClientHandler` (requests + notifications + `get_info`), defaults, the `ClientCapabilities::builder` toggle list          |
+
+### Driving servers
+
+| Path                 | Topic                                                                                                                                                      |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `client/requests.md` | `ClientRequest::*` variant map, convenience wrappers (`.call_tool`, `.list_all_tools`), the untagged-enum gotcha for `CancelTaskResult` vs `GetTaskResult` |
+
+### Answering server-to-client requests
+
+| Path                    | Topic                                                                                                                                   |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `client/sampling.md`    | Overriding `create_message`, `CreateMessageRequestParams` fields, stop-reason constants, forwarding to a real LLM                       |
+| `client/elicitation.md` | Overriding `create_elicitation`, `ElicitationAction` (`Accept` / `Decline` / `Cancel`), form vs URL variants, default-decline behavior  |
+| `client/roots.md`       | Overriding `list_roots`, `Root::new(...).with_name(...)`, list-changed notifications, static vs dynamic roots                           |
+
+### Transports and testing
+
+| Path                   | Topic                                                                                                                 |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `client/transports.md` | `TokioChildProcess`, `StreamableHttpClientTransport`, Unix socket, `tokio::io::duplex`, custom `IntoTransport`        |
+| `client/testing.md`    | The `tokio::io::duplex` harness pattern, bounded polling helpers, in-test capability negotiation, `first_text` helper |
+
+## Cross-references in this skill
+
+| Topic                                | Server file               | Client file                       |
+| ------------------------------------ | ------------------------- | --------------------------------- |
+| Sampling                             | `server/sampling.md`      | `client/sampling.md`              |
+| Elicitation                          | `server/elicitation.md`   | `client/elicitation.md`           |
+| Roots                                | `server/roots.md`         | `client/roots.md`                 |
+| Transports                           | `server/transports.md`    | `client/transports.md`            |
+| Untagged-enum result deserialization | `server/tasks.md` (cause) | `client/requests.md` (mitigation) |
+
+## External pointers
+
+- **Local working example** — `crates/mcp-server/` (server only). Every
+  server reference file cites specific files and lines.
+- **Upstream rmcp source** — `submodules/mcp-rust-sdk/crates/rmcp/src/`
+  is the source of truth when these reference files conflict with reality.
+- **Upstream examples** — `submodules/mcp-rust-sdk/examples/servers/`
+  and `submodules/mcp-rust-sdk/examples/clients/` cover scenarios these
+  files mention but the local example doesn't ship (OAuth flows,
+  completion, structured output, sampling-tools, URL elicitation).
+- **MCP spec / protocol questions** — see the per-spec-version reference
+  files in sibling directories (`references/2024-11-05/`,
+  `references/2025-03-26/`, `references/2025-06-18/`,
+  `references/2025-11-25/`). This section stays Rust-specific.

--- a/.agents/skills/mcp-knowledge/references/rust-sdk/feature-flags.md
+++ b/.agents/skills/mcp-knowledge/references/rust-sdk/feature-flags.md
@@ -1,0 +1,114 @@
+# Cargo feature flags
+
+Source of truth: `submodules/mcp-rust-sdk/crates/rmcp/Cargo.toml`
+(`[features]` section starting at line 115).
+
+The `rmcp` crate is heavily feature-gated because it covers two roles
+(client and server), several transports, and optional integrations
+(OAuth, TLS, schemars). Defaults give you a server with macros and
+base64 image support but **no transports** — you almost always have to
+opt in to one.
+
+```toml
+# Defaults (line 116 of rmcp/Cargo.toml)
+default = ["base64", "macros", "server"]
+```
+
+## Quick reference table
+
+The columns are: feature name → what it pulls in → when to enable it.
+
+### Roles
+
+| Feature            | Implies                                            | Enable when                                                                                 |
+| ------------------ | -------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `server` (default) | `transport-async-rw`, `dep:schemars`, `dep:pastey` | Writing a server. Re-exports `ServerHandler`, `serve_server`, `RoleServer`                  |
+| `client`           | `dep:tokio-stream`                                 | Writing or testing a client. Re-exports `ClientHandler`, `serve_client`, `RoleClient`       |
+| `macros` (default) | `dep:rmcp-macros`, `dep:pastey`                    | Using `#[tool]`, `#[tool_router]`, `#[prompt]`, `#[prompt_router]`, `#[task_handler]`, etc. |
+| `base64` (default) | —                                                  | Encoding image/binary content in tool results                                               |
+| `schemars`         | `dep:schemars`                                     | Stand-alone JSON Schema generation. Implied by `server`                                     |
+| `elicitation`      | `dep:url`                                          | Server-side typed elicitation via `Peer::elicit<T>(...)` and the `elicit_safe!` macro       |
+
+### Transports
+
+| Feature                                        | Implies                                                                             | Enable when                                                                    |
+| ---------------------------------------------- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| `transport-async-rw`                           | `tokio/io-util`, `tokio-util/codec`                                                 | Generic `AsyncRead + AsyncWrite` transport. Implied by `server`                |
+| `transport-io`                                 | `transport-async-rw`, `tokio/io-std`                                                | stdio transport (`rmcp::transport::stdio()`)                                   |
+| `transport-child-process`                      | `transport-async-rw`, `tokio/process`, `dep:process-wrap`                           | Spawn an MCP server as a subprocess and talk to it over stdio                  |
+| `which-command`                                | `transport-child-process`, `dep:which`                                              | Resolve a server binary by name (cross-platform `which`)                       |
+| `transport-streamable-http-server-session`     | `transport-async-rw`, `dep:tokio-stream`                                            | Lower-level building block; usually pulled in by the next flag                 |
+| `transport-streamable-http-server`             | `transport-streamable-http-server-session`, `server-side-http`, `transport-worker`  | Streamable HTTP server (`StreamableHttpService` + axum / tower)                |
+| `transport-streamable-http-client`             | `client-side-sse`, `transport-worker`                                               | Base for the streamable HTTP client                                            |
+| `transport-streamable-http-client-reqwest`     | `transport-streamable-http-client`, `__reqwest`                                     | Streamable HTTP client with the `reqwest` backend                              |
+| `transport-streamable-http-client-unix-socket` | `transport-streamable-http-client`, hyper + bytes + `tokio/net`                     | Streamable HTTP client over a Unix domain socket                               |
+| `transport-worker`                             | `dep:tokio-stream`                                                                  | Helper transport that coordinates a worker task                                |
+| `client-side-sse`                              | `dep:sse-stream`, `dep:http`                                                        | Parsing SSE responses on the client                                            |
+| `server-side-http`                             | `uuid`, `rand`, `tokio-stream`, `http`, `http-body`, `bytes`, `sse-stream`, `tower` | Lower-level HTTP server primitives (implied by the streamable HTTP server)     |
+| `tower`                                        | `dep:tower-service`                                                                 | Expose `StreamableHttpService` as a `tower::Service` to plug into axum / hyper |
+
+### HTTP backends — pick exactly one
+
+`reqwest`, `reqwest-native-tls`, and `reqwest-tls-no-provider` are
+**mutually exclusive**. They all enable the internal `__reqwest`
+feature, but each picks a different TLS strategy:
+
+| Feature                   | TLS strategy                                                    | Use when                                                                                           |
+| ------------------------- | --------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `reqwest`                 | `reqwest/rustls` — pure-Rust TLS via rustls                     | **Default recommendation.** Portable, no system OpenSSL dependency                                 |
+| `reqwest-native-tls`      | `reqwest/native-tls` — OS-native TLS                            | You need to honor platform certificate stores (Windows SChannel, macOS Keychain, OpenSSL on Linux) |
+| `reqwest-tls-no-provider` | `reqwest/rustls-no-provider` — rustls without baked-in provider | You're providing your own `CryptoProvider` (FIPS, OpenSSL-backed rustls, etc.)                     |
+
+Picking more than one is a compile error. Picking none gives you
+`reqwest` without TLS, which only works for `http://` URLs.
+
+### Auth
+
+| Feature                       | Implies                              | Enable when                                            |
+| ----------------------------- | ------------------------------------ | ------------------------------------------------------ |
+| `auth`                        | `dep:oauth2`, `__reqwest`, `dep:url` | OAuth 2.0 client-credentials flows                     |
+| `auth-client-credentials-jwt` | `auth`, `dep:jsonwebtoken`, `uuid`   | OAuth 2.0 with `private_key_jwt` client authentication |
+
+### Miscellaneous
+
+| Feature | Implies              | Enable when                                                                          |
+| ------- | -------------------- | ------------------------------------------------------------------------------------ |
+| `uuid`  | `uuid` crate (v4)    | Generating session IDs. Auto-on with `server-side-http`                              |
+| `local` | `rmcp-macros?/local` | Targeting environments without `Send` futures (e.g. WASM). Switches the trait bounds |
+
+## Choosing a starter set
+
+| You're building...                                           | Recommended features                                                                                                                                                        |
+| ------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| A simple stdio server                                        | `["server", "macros", "transport-io"]`                                                                                                                                      |
+| A stdio + Streamable HTTP server (like `crates/mcp-server/`) | `["server", "client", "macros", "transport-io", "transport-streamable-http-server", "schemars", "elicitation"]`                                                             |
+| A subprocess client (driving an existing MCP server)         | `["client", "transport-child-process"]`                                                                                                                                     |
+| A Streamable HTTP client                                     | `["client", "transport-streamable-http-client-reqwest", "reqwest"]`                                                                                                         |
+| A test crate that drives a server over in-memory duplex      | `["server", "client", "macros"]` — duplex transport needs no extra features (it's just `AsyncRead + AsyncWrite` and goes through `transport-async-rw`, implied by `server`) |
+| An OAuth-protected HTTP server                               | `["server", "macros", "transport-streamable-http-server", "auth"]` plus a `reqwest*` flag                                                                                   |
+
+## Common compile errors and what they mean
+
+- **`cannot find macro #[tool_router] in this scope`** — you didn't
+  enable `macros` (or you enabled `client` only, since `macros` is gated
+  behind `feature = "macros"` plus `feature = "server"` in the re-export
+  at `crates/rmcp/src/lib.rs:33`).
+- **`unresolved import rmcp::transport::stdio`** — you didn't enable
+  `transport-io`. The function is gated behind that feature.
+- **`unresolved import rmcp::transport::StreamableHttpService`** — you
+  didn't enable `transport-streamable-http-server`.
+- **`cannot find macro elicit_safe! in scope`** — you didn't enable
+  `elicitation`. The macro and the `ElicitationError` enum are both
+  gated behind that feature flag (see
+  `submodules/mcp-rust-sdk/crates/rmcp/src/service/server.rs:451`).
+- **`expected struct rmcp::model::ClientCapabilities, found ...`** when
+  building a `ClientInfo` from `ClientCapabilities::builder().build()`
+  — the builder state encodes which `enable_*` methods were called via
+  const generics. Just call `.build()` immediately; you do not need to
+  store the intermediate builder type.
+
+## Workspace example
+
+The local workspace at `crates/mcp-server/Cargo.toml` consumes `rmcp`
+via the workspace dependency at `Cargo.toml:50-58`. That set is a good
+starting point for any server that needs more than just stdio.

--- a/.agents/skills/mcp-knowledge/references/rust-sdk/overview.md
+++ b/.agents/skills/mcp-knowledge/references/rust-sdk/overview.md
@@ -1,0 +1,283 @@
+# rmcp (Rust SDK for MCP)
+
+Expert guidance on [`rmcp`](https://docs.rs/rmcp), the official Rust SDK
+for the [Model Context Protocol](https://modelcontextprotocol.io/). Goal:
+help users write correct, idiomatic `rmcp` code — servers, clients, tools,
+prompts, resources, tasks, transports, and test harnesses — without
+re-discovering the same macro contracts and trait shapes every time.
+
+`rmcp` is **fast-moving and lightly documented**. The repository at
+`submodules/mcp-rust-sdk/` is the source of truth: when a signature in
+these reference files conflicts with what's in the pinned submodule, trust
+the submodule and update the files. The reference set intentionally cites
+specific source paths so they stay grepable as the crate evolves.
+
+For protocol-level questions (the JSON-RPC wire format, spec versions,
+what a `tools/call` request looks like across implementations), use the
+per-spec-version reference files in sibling directories
+(`references/2024-11-05/`, `references/2025-03-26/`, `references/2025-06-18/`,
+`references/2025-11-25/`). This section stays Rust-specific.
+
+## Workspace orientation
+
+The `rmcp` workspace ships two crates plus a large set of examples:
+
+| Crate / directory                               | What it is                                                                                                                                                                                          |
+| ----------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `submodules/mcp-rust-sdk/crates/rmcp/`          | The main `rmcp` crate. Re-exports everything the user sees: `ServerHandler`, `ClientHandler`, `ServiceExt`, `model::*`, `transport::*`, `task_manager::*`                                           |
+| `submodules/mcp-rust-sdk/crates/rmcp-macros/`   | The procedural-macros crate behind `#[tool_router]`, `#[tool_handler]`, `#[prompt_router]`, `#[prompt_handler]`, `#[task_handler]`. Re-exported by `rmcp` when the `macros` feature is on           |
+| `submodules/mcp-rust-sdk/examples/servers/src/` | One example server per primitive (calculator, counter, prompt, task, sampling, elicitation, completion, memory, structured output, OAuth)                                                           |
+| `submodules/mcp-rust-sdk/examples/clients/src/` | Example clients (stdio subprocess, streamable HTTP, sampling, task polling, progress, OAuth flows)                                                                                                  |
+| `crates/mcp-server/`                            | **Local** working server example built against `rmcp` 2.0. Covers every server-side primitive and ships an integration test per feature. This is the canonical reference cited throughout this set  |
+
+Application code depends on `rmcp` (plus whichever transport feature it
+needs). `rmcp-macros` is pulled in transitively by the `macros` feature
+— never depend on it directly.
+
+## Version and stability note
+
+This material targets **`rmcp` 2.x** (the workspace pins 2.0 at
+`Cargo.toml:50`). Version 2.0.0 was a breaking release
+(`feat!: align model types with MCP 2025-11-25 spec`, upstream PR #927):
+most model types moved from public-field struct literals to
+`::new(...)` constructors plus `.with_*(...)` builder methods, and the
+`Content` / `Resource` / `ResourceTemplate` types are no longer
+`Annotated<Raw*>` wrappers — `annotations` and `_meta` are now inline
+fields on flat, `#[non_exhaustive]` structs. See
+`references/rust-sdk/server/tools.md` and
+`references/rust-sdk/server/resources.md` for the exact shapes. The SDK
+is officially Tier 2 conformance — most of the 2025-11-25 MCP spec
+works, but pieces like prompt argument substitution, embedded resources
+in prompts, DNS-rebinding protection, and full SEP-1330 enum inference
+are still in motion. Specific known limitations:
+
+- Sampling, Logging, and Roots are `#[deprecated]` as of 2.0.0 per
+  SEP-2577 (the types and methods still work — they emit a compiler
+  warning, not a hard error). `crates/mcp-server/src/tools.rs` still
+  demonstrates `ask_llm` (sampling) and `list_workspace_roots` (roots)
+  behind `#[allow(deprecated)]`, since both remain part of the protocol
+  today. Expect them to be removed in a future major version.
+- `OperationProcessor` does not yet expose per-task `created_at` /
+  `last_updated_at` — `tasks/list` overrides have to fake the
+  timestamps. See `references/rust-sdk/server/tasks.md`.
+- The macro-generated `list_tasks` only surfaces _running_ tasks; the
+  canonical pattern (in `crates/mcp-server/src/tasks.rs`) is to override
+  it and merge in `peek_completed()`.
+- Some `ServerResult::*` variants share wire shape after `serde`
+  flattening (most prominently `CancelTaskResult` vs `GetTaskResult`),
+  so the untagged enum may pick the wrong variant when deserializing.
+  Callers must accept either. See `references/rust-sdk/client/requests.md`.
+- `Peer::elicit` returns `Err(ElicitationError::UserDeclined)` etc. for
+  _user actions_, which are not service failures. Tools must
+  pattern-match on `ElicitationError` and return
+  `CallToolResult::success` for the user-action variants. See
+  `references/rust-sdk/server/elicitation.md`.
+
+When you hit something that looks broken, check the submodule first —
+`grep` for the symbol in `submodules/mcp-rust-sdk/crates/rmcp/src/`
+before guessing.
+
+## Feature flags at a glance
+
+Defaults (from `submodules/mcp-rust-sdk/crates/rmcp/Cargo.toml:116`):
+`default = ["base64", "macros", "server"]`. So `cargo add rmcp` gives
+you a server crate with macros and base64 image support. You still need
+to **opt in** to the transports and to client-side support.
+
+| Flag                                                         | When to enable                                                                      |
+| ------------------------------------------------------------ | ----------------------------------------------------------------------------------- |
+| `server`                                                     | Authoring a server. Pulls in `ServerHandler`, `schemars`, `transport-async-rw`      |
+| `client`                                                     | Authoring or testing a client. Adds `ClientHandler`, `tokio-stream`                 |
+| `macros`                                                     | `#[tool_router]` / `#[tool]` / `#[prompt_router]` / `#[prompt]` / `#[task_handler]` |
+| `transport-io`                                               | stdio transport (`rmcp::transport::stdio()`)                                        |
+| `transport-streamable-http-server`                           | Streamable HTTP server (`StreamableHttpService`, axum / tower integration)          |
+| `transport-streamable-http-client-reqwest`                   | Streamable HTTP client with reqwest backend                                         |
+| `transport-child-process`                                    | Spawn a server as a subprocess and talk to it over stdio                            |
+| `elicitation`                                                | `rmcp::elicit_safe!`, `ElicitationError`, typed `Peer::elicit<T>()`                 |
+| `schemars`                                                   | JSON Schema generation for tool/prompt argument types (auto-on with `server`)       |
+| `auth` / `auth-client-credentials-jwt`                       | OAuth 2.0 client-credentials and JWT-signed assertions                              |
+| `reqwest` / `reqwest-native-tls` / `reqwest-tls-no-provider` | Pick exactly one TLS strategy for the reqwest backend                               |
+
+A common starter set for a server with stdio + HTTP + tasks +
+elicitation is what `crates/mcp-server/` uses:
+
+```toml
+rmcp = { version = "2.0", features = [
+    "server", "client", "macros",
+    "transport-io",
+    "transport-streamable-http-server",
+    "schemars",
+    "elicitation",
+] }
+```
+
+See `references/rust-sdk/feature-flags.md` for the full list and the
+`reqwest` TLS choice (which is easy to get wrong).
+
+## Minimum-you-need-to-know — server
+
+The smallest viable server is a struct with a `tool_router` field, one
+`#[tool]` method in a `#[tool_router]` block, and a `#[tool_handler]
+impl ServerHandler`:
+
+```rust
+use rmcp::{
+    ErrorData as McpError, ServerHandler, ServiceExt,
+    handler::server::router::tool::ToolRouter,
+    model::{CallToolResult, ContentBlock},
+    tool, tool_handler, tool_router,
+    transport::stdio,
+};
+
+#[derive(Clone)]
+struct Hello {
+    tool_router: ToolRouter<Hello>,
+}
+
+#[tool_router]
+impl Hello {
+    fn new() -> Self {
+        Self { tool_router: Self::tool_router() }
+    }
+
+    #[tool(description = "Health check.")]
+    async fn ping(&self) -> Result<CallToolResult, McpError> {
+        Ok(CallToolResult::success(vec![ContentBlock::text("pong")]))
+    }
+}
+
+#[tool_handler]
+impl ServerHandler for Hello {}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    Hello::new().serve(stdio()).await?.waiting().await?;
+    Ok(())
+}
+```
+
+The router field name (`tool_router`) is the **macro default**; rename
+it and you'll need to pass the new name to both `#[tool_router]` and
+`#[tool_handler]`. The same applies to `prompt_router` and the
+`processor` field that `#[task_handler]` reads.
+
+When you add prompts, resources, or tasks, all the handler attributes
+**must target the same `impl ServerHandler` block**:
+
+```rust
+#[tool_handler]
+#[prompt_handler]
+#[task_handler]
+impl ServerHandler for Server { /* ... */ }
+```
+
+Splitting them across multiple `impl` blocks is a compile error because
+each macro synthesizes a different subset of `ServerHandler`'s methods.
+The full annotated form is in `crates/mcp-server/src/lib.rs:62-93` —
+read it. `references/rust-sdk/server/getting-started.md` walks through
+the composition step by step.
+
+## Minimum-you-need-to-know — client
+
+The smallest viable client is even shorter — `ClientHandler` has a
+default implementation for `()` and `ClientInfo`, so the stub is one
+line:
+
+```rust
+use rmcp::{ClientHandler, ServiceExt, model::CallToolRequestParams};
+use rmcp::model::{ClientRequest, Request, ServerResult};
+
+#[derive(Default, Clone)]
+struct MyClient;
+impl ClientHandler for MyClient {}
+
+// Connect to any transport — for tests this is `tokio::io::duplex`,
+// for production it's a subprocess or `StreamableHttpClientTransport`.
+let client = MyClient.serve(transport).await?;
+
+let response = client
+    .send_request(ClientRequest::CallToolRequest(Request::new(
+        CallToolRequestParams::new("ping"),
+    )))
+    .await?;
+
+let ServerResult::CallToolResult(result) = response else {
+    panic!("expected CallToolResult, got {response:?}");
+};
+```
+
+The reason this matters: every test in `crates/mcp-server/tests/` uses
+this exact harness pattern (with `tokio::io::duplex` as the transport)
+to drive the server from inside the same process. It's the cheapest way
+to write integration tests for any MCP server. See
+`references/rust-sdk/client/testing.md`.
+
+If you need to advertise client capabilities (so the server can ask the
+user to elicit input, or sample the LLM, or list roots), override
+`get_info()`:
+
+```rust
+use rmcp::model::{ClientCapabilities, ClientInfo, Implementation};
+
+impl ClientHandler for MyClient {
+    fn get_info(&self) -> ClientInfo {
+        ClientInfo::new(
+            ClientCapabilities::builder().enable_elicitation().build(),
+            Implementation::from_build_env(),
+        )
+    }
+}
+```
+
+And override the corresponding callback (`create_elicitation`,
+`create_message`, `list_roots`) to respond to those requests. The default
+`create_elicitation` automatically declines, which is what
+`crates/mcp-server/tests/elicitation.rs` relies on.
+
+## Reference files
+
+The reference set is split into shared topics, server features, and
+client features. Read the index at `references/rust-sdk/doc-index.md`
+for a one-line summary of every file. Quick map below:
+
+### Shared
+
+| File                                   | Read when                                                                                                  |
+| -------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `references/rust-sdk/feature-flags.md` | Picking Cargo features, debugging missing-feature compile errors, choosing the right `reqwest` TLS variant |
+
+### Server features
+
+| File                                            | Read when                                                                                                                               |
+| ----------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `references/rust-sdk/server/getting-started.md` | Composing `Server` with multiple routers; the stacked-handler-macros rule                                                               |
+| `references/rust-sdk/server/tools.md`           | Authoring `#[tool]` methods, `Parameters<T>`, `CallToolResult`, `task_support`, `annotations(...)` (declare or get default-destructive) |
+| `references/rust-sdk/server/prompts.md`         | `#[prompt_router]`, multi-arg prompt examples, `Role`                                                                                   |
+| `references/rust-sdk/server/resources.md`       | Static resources, URI templates, why there's no macro router for resources                                                              |
+| `references/rust-sdk/server/tasks.md`           | SEP-1686 task lifecycle, `OperationProcessor`, the `list_tasks` override pattern                                                        |
+| `references/rust-sdk/server/sampling.md`        | `ctx.peer.create_message(...)`, multimodal content handling                                                                             |
+| `references/rust-sdk/server/elicitation.md`     | `ctx.peer.elicit::<T>(...)`, `elicit_safe!`, the `ElicitationError` variants                                                            |
+| `references/rust-sdk/server/roots.md`           | `ctx.peer.list_roots()` for workspace-aware servers                                                                                     |
+| `references/rust-sdk/server/transports.md`      | stdio and Streamable HTTP wiring, `StreamableHttpService` + `LocalSessionManager`                                                       |
+
+### Client features
+
+| File                                            | Read when                                                                                |
+| ----------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `references/rust-sdk/client/getting-started.md` | Smallest viable `ClientHandler`, the `ServiceExt::serve` lifecycle                       |
+| `references/rust-sdk/client/handler.md`         | Full `ClientHandler` method list, `ClientCapabilities` builder, notification callbacks   |
+| `references/rust-sdk/client/requests.md`        | Sending `ClientRequest::*`, pattern-matching `ServerResult::*`, the untagged-enum gotcha |
+| `references/rust-sdk/client/sampling.md`        | Overriding `create_message` to satisfy a server's sampling request                       |
+| `references/rust-sdk/client/elicitation.md`     | Overriding `create_elicitation`, `ElicitationAction`, form vs URL elicitation            |
+| `references/rust-sdk/client/roots.md`           | Overriding `list_roots` to expose workspace/filesystem roots                             |
+| `references/rust-sdk/client/transports.md`      | Child-process transport, Streamable HTTP client (reqwest), in-memory duplex              |
+| `references/rust-sdk/client/testing.md`         | The `tokio::io::duplex` harness — the standard way to unit-test an MCP server            |
+
+## Going further than this section
+
+For end-to-end runnable examples beyond what `crates/mcp-server/` covers
+(OAuth servers, completion, structured output, progress notifications,
+subprocess-launching clients, OAuth client-credentials flows), browse
+`submodules/mcp-rust-sdk/examples/`. Each subcrate's `Cargo.toml`
+declares exactly the feature set it needs, which is itself a useful
+reference when you're not sure what to enable.

--- a/.agents/skills/mcp-knowledge/references/rust-sdk/server/elicitation.md
+++ b/.agents/skills/mcp-knowledge/references/rust-sdk/server/elicitation.md
@@ -1,0 +1,204 @@
+# Server: elicitation
+
+**Elicitation** is the server-to-client request `elicitation/create`:
+the server asks the user (via the client) for typed input mid-tool.
+`rmcp` exposes a typed wrapper via `Peer::elicit<T>(...)` plus the
+`rmcp::elicit_safe!` macro to mark input types as schema-safe.
+
+The `elicitation` Cargo feature must be enabled for both the macro and
+the `ElicitationError` enum to be in scope.
+
+## When to read this
+
+- Writing a tool that needs a piece of user info (name, choice,
+  confirmation) that isn't already in the tool's arguments.
+- A tool you wrote is surfacing user-decline as `internal_error` — see
+  the gotcha below; this is the most common elicitation bug.
+- You want to register a custom struct for elicitation.
+
+The canonical local example is `greet_user` in
+`crates/mcp-server/src/tools.rs:130-177`, with the regression test at
+`crates/mcp-server/tests/elicitation.rs`.
+
+## The minimum elicitation tool
+
+```rust
+use rmcp::{
+    ErrorData as McpError, RoleServer,
+    model::{CallToolResult, ContentBlock},
+    service::{ElicitationError, RequestContext},
+    tool, schemars,
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct UserNameInput {
+    /// The user's preferred display name.
+    pub name: String,
+}
+
+rmcp::elicit_safe!(UserNameInput);
+
+#[tool(description = "Ask the user for their name, then greet them.")]
+async fn greet_user(
+    &self,
+    ctx: RequestContext<RoleServer>,
+) -> Result<CallToolResult, McpError> {
+    match ctx
+        .peer
+        .elicit::<UserNameInput>("Please enter your name")
+        .await
+    {
+        Ok(Some(input)) => Ok(CallToolResult::success(vec![ContentBlock::text(format!(
+            "Hello, {}!",
+            input.name
+        ))])),
+        Ok(None) => Ok(CallToolResult::success(vec![ContentBlock::text(
+            "Greeting skipped — no name was provided.",
+        )])),
+        Err(ElicitationError::UserDeclined) => Ok(CallToolResult::success(vec![
+            ContentBlock::text("Greeting skipped — the user declined to share their name."),
+        ])),
+        Err(ElicitationError::UserCancelled) => Ok(CallToolResult::success(vec![
+            ContentBlock::text("Greeting cancelled — the user dismissed the prompt."),
+        ])),
+        Err(ElicitationError::CapabilityNotSupported) => Ok(CallToolResult::success(vec![
+            ContentBlock::text(
+                "This client does not support elicitation, so the user could not be \
+                 prompted for a name.",
+            ),
+        ])),
+        Err(e) => Err(McpError::internal_error(
+            format!("elicitation failed: {e}"),
+            None,
+        )),
+    }
+}
+```
+
+## `elicit_safe!` and why it exists
+
+`Peer::elicit<T>(...)` requires `T: ElicitationSafe` (and `JsonSchema +
+DeserializeOwned`). The `ElicitationSafe` marker trait exists so that
+the input type compiles to a JSON Schema **of type `"object"`** — MCP
+clients expect structured form data, not bare primitives or arrays.
+
+`rmcp::elicit_safe!(MyStruct);` is the canonical way to opt your type
+in. Don't `impl ElicitationSafe for MyStruct` by hand; the macro is
+short for that and intentionally makes the gate visible:
+
+```rust
+#[derive(Serialize, Deserialize, schemars::JsonSchema)]
+pub struct ConfirmInput {
+    pub confirmed: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+rmcp::elicit_safe!(ConfirmInput);
+```
+
+Calling `elicit::<String>("Name?")` will not compile — it's a primitive,
+not an object.
+
+## The `ElicitationError` variants — the must-handle list
+
+`ctx.peer.elicit::<T>(prompt)` returns
+`Result<Option<T>, ElicitationError>`. The full variant list (from
+`submodules/mcp-rust-sdk/crates/rmcp/src/service/server.rs:495-530`):
+
+| Variant                           | Cause                                                                          | Surface as                                                        |
+| --------------------------------- | ------------------------------------------------------------------------------ | ----------------------------------------------------------------- |
+| `Ok(Some(input))`                 | User submitted valid data matching `T`                                         | `CallToolResult::success(...)` happy path                         |
+| `Ok(None)`                        | The client returned `Accept` with no content                                   | `CallToolResult::success(...)` skipped path                       |
+| `Err(UserDeclined)`               | User explicitly clicked "Reject" / "Decline" / "No"                            | `CallToolResult::success(...)` — user action, not failure         |
+| `Err(UserCancelled)`              | User dismissed the dialog (Escape, close, click outside)                       | `CallToolResult::success(...)` — user action, not failure         |
+| `Err(CapabilityNotSupported)`     | Client did not declare `elicitation` in its `ClientCapabilities`               | `CallToolResult::success(...)` — capability mismatch, not failure |
+| `Err(NoContent)`                  | Client sent `Accept` but content was missing (protocol bug on the client side) | `Err(McpError::internal_error(...))`                              |
+| `Err(ParseError { error, data })` | The user's input didn't deserialize to `T`                                     | `Err(McpError::internal_error(...))` or retry                     |
+| `Err(Service(_))`                 | Underlying JSON-RPC / transport failure                                        | `Err(McpError::internal_error(...))`                              |
+
+**The most common bug is treating `UserDeclined` / `UserCancelled` /
+`CapabilityNotSupported` as service failures and bubbling them up as
+`internal_error`.** Those are user actions or capability mismatches —
+the *tool ran successfully and the user said no*. Return
+`CallToolResult::success(...)` with an informative message so the client
+can render it naturally. The regression test at
+`crates/mcp-server/tests/elicitation.rs` locks this contract in.
+
+## Required client capability
+
+The client must advertise `elicitation` during `initialize`. If it
+didn't, `ctx.peer.elicit(...)` returns
+`Err(ElicitationError::CapabilityNotSupported)`.
+
+For a client *test* harness that needs to back the server's elicitation
+calls, override `ClientHandler::create_elicitation` and declare the
+capability via `ClientCapabilities::builder().enable_elicitation()` —
+see `references/rust-sdk/client/elicitation.md`.
+
+## Form vs URL elicitation
+
+The 2025-11-25 MCP spec adds URL-based elicitation: instead of
+collecting fields inline, the server tells the client to open a URL.
+`rmcp` represents this as the `UrlElicitationParams` variant of
+`ElicitRequestParams` (see
+`submodules/mcp-rust-sdk/crates/rmcp/src/model.rs:2743-2809`).
+`CreateElicitationRequestParams` is now a deprecated type alias for
+`ElicitRequestParams` — update any code still importing the old name.
+
+The typed `Peer::elicit<T>` helper covers the form path. For URL
+elicitation, construct the lower-level `ElicitRequest`
+(`CreateElicitationRequest` is now a deprecated alias for it) and send
+it via `ctx.peer.send_request(...)` directly. The upstream example
+`submodules/mcp-rust-sdk/examples/servers/src/elicitation_stdio.rs`
+demonstrates both flavors.
+
+## Multi-step elicitation
+
+If you need to gather a sequence of inputs (e.g. confirm, then provide
+details), make multiple `elicit` calls in sequence. Each one is a
+separate `elicitation/create` round trip; the client may render them
+back-to-back or merge them in its UI.
+
+## Capability declaration on the server side
+
+You do **not** need to advertise anything special in
+`ServerCapabilities` for the server to *make* elicitation requests —
+the gate is the client's `ClientCapabilities::elicitation` field. The
+server side only needs the `elicitation` Cargo feature enabled (so the
+macro and error enum compile).
+
+## Gotchas
+
+### `ParseError` happens when the client returns malformed JSON
+
+The client is supposed to validate the form input against
+`requested_schema` before sending it back. Some clients don't, or
+validate weakly. If you start seeing `ParseError`, either tighten
+schema validation on the client end or accept a more permissive `T` and
+re-validate inside the tool.
+
+### `elicit_safe!` is not auto-derived
+
+You must call the macro on every type you want to elicit. There's no
+`#[derive(ElicitationSafe)]`.
+
+### Don't pre-fill sensitive fields in the schema
+
+`JsonSchema` doc-comments end up in the schema and are shown to the
+user. Don't put secrets, tokens, or PII in field doc-comments.
+
+## See also
+
+- `references/rust-sdk/server/tools.md` — `RequestContext<RoleServer>` as a tool
+  parameter
+- `references/rust-sdk/server/sampling.md` — the sibling server-to-client
+  request for LLM output
+- `references/rust-sdk/server/roots.md` — the sibling server-to-client request
+  for workspace listing
+- `references/rust-sdk/client/elicitation.md` — implementing the client side
+- `crates/mcp-server/src/tools.rs:130-177` — `greet_user` worked example
+- `crates/mcp-server/tests/elicitation.rs` — regression test locking
+  in the "decline is graceful" contract
+- `submodules/mcp-rust-sdk/examples/servers/src/elicitation_stdio.rs`
+  and `elicitation_enum_inference.rs` — upstream examples

--- a/.agents/skills/mcp-knowledge/references/rust-sdk/server/getting-started.md
+++ b/.agents/skills/mcp-knowledge/references/rust-sdk/server/getting-started.md
@@ -1,0 +1,201 @@
+# Server: getting started
+
+Compose a `Server` struct from one or more routers, wire them together
+on a single `impl ServerHandler` block, and serve over a transport.
+
+## When to read this
+
+- You're building your first `rmcp` server.
+- You added a second router (prompts after tools, tasks after prompts)
+  and ran into a macro / `impl` conflict.
+- You renamed `tool_router` / `prompt_router` / `processor` and the
+  macro now can't find the field.
+
+The canonical local example is `crates/mcp-server/src/lib.rs`. Read it
+end-to-end before this file if you prefer code-first orientation.
+
+## The minimum server
+
+```rust
+use rmcp::{
+    ErrorData as McpError, ServerHandler, ServiceExt,
+    handler::server::router::tool::ToolRouter,
+    model::{CallToolResult, ContentBlock},
+    tool, tool_handler, tool_router,
+    transport::stdio,
+};
+
+#[derive(Clone)]
+struct Hello {
+    tool_router: ToolRouter<Hello>,
+}
+
+#[tool_router]
+impl Hello {
+    fn new() -> Self {
+        Self { tool_router: Self::tool_router() }
+    }
+
+    #[tool(description = "Health check.")]
+    async fn ping(&self) -> Result<CallToolResult, McpError> {
+        Ok(CallToolResult::success(vec![ContentBlock::text("pong")]))
+    }
+}
+
+#[tool_handler]
+impl ServerHandler for Hello {}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    Hello::new().serve(stdio()).await?.waiting().await?;
+    Ok(())
+}
+```
+
+`#[tool_router]` on an `impl` block:
+
+1. Scans the block for methods marked `#[tool(...)]`.
+2. Generates `fn tool_router() -> ToolRouter<Self>` so you can
+   initialize the field.
+3. Generates the `ToolRouter<Self>` value that wires those methods to
+   the JSON-RPC dispatcher.
+
+`#[tool_handler]` on `impl ServerHandler` reads `self.tool_router` and
+auto-implements `ServerHandler::list_tools` and `call_tool`.
+
+## Adding more routers
+
+When you go beyond tools — prompts, resources, tasks — the structure
+grows but the rules stay the same. The full shape from
+`crates/mcp-server/src/lib.rs:34-61`:
+
+```rust
+use std::sync::Arc;
+use rmcp::{
+    handler::server::router::{prompt::PromptRouter, tool::ToolRouter},
+    task_manager::OperationProcessor,
+};
+use tokio::sync::Mutex;
+
+#[derive(Clone)]
+pub struct Server {
+    #[allow(dead_code, reason = "read by the #[tool_handler] macro")]
+    tool_router: ToolRouter<Server>,
+    #[allow(dead_code, reason = "read by the #[prompt_handler] macro")]
+    prompt_router: PromptRouter<Server>,
+    pub(crate) processor: Arc<Mutex<OperationProcessor>>,
+}
+
+impl Server {
+    pub fn new() -> Self {
+        Self {
+            tool_router: Self::tool_router(),
+            prompt_router: Self::prompt_router(),
+            processor: Arc::new(Mutex::new(OperationProcessor::new())),
+        }
+    }
+}
+```
+
+The field names are the **macro defaults**:
+
+| Macro               | Default field it reads | Override                                      |
+| ------------------- | ---------------------- | --------------------------------------------- |
+| `#[tool_handler]`   | `tool_router`          | `#[tool_handler(router = self.my_tools)]`     |
+| `#[prompt_handler]` | `prompt_router`        | `#[prompt_handler(router = self.my_prompts)]` |
+| `#[task_handler]`   | `processor`            | `#[task_handler(processor = self.task_proc)]` |
+
+The `Clone` bound is required by `#[task_handler]` — it captures
+`self` into spawned futures. Make sure any internal state lives behind
+`Arc` / `Mutex` so cloning is cheap.
+
+## The stacked-handler rule
+
+This is the one thing that bites every newcomer. All three handler
+attributes must target the **same** `impl ServerHandler` block:
+
+```rust
+#[tool_handler]
+#[prompt_handler]
+#[task_handler]
+impl ServerHandler for Server {
+    // any manual overrides go here
+}
+```
+
+Why: each macro synthesizes a different subset of `ServerHandler`'s
+methods. Putting them on separate `impl ServerHandler for Server`
+blocks would mean re-implementing the trait multiple times for the same
+type, which Rust forbids.
+
+If you need to manually override one of the methods a macro synthesizes
+(e.g. `list_tasks` to merge in completed tasks), add the override to
+the same `impl` block. The macro skips methods you've defined yourself.
+See `crates/mcp-server/src/lib.rs:120-129` for the `list_tasks`
+override.
+
+## Resources are different
+
+Resources are **not** macro-routed. `rmcp` doesn't ship a
+`#[resource_router]`. The path is to implement `list_resources`,
+`read_resource`, and `list_resource_templates` directly on the
+`ServerHandler` impl, typically by delegating to free functions:
+
+```rust
+async fn list_resources(
+    &self,
+    _request: Option<PaginatedRequestParams>,
+    _ctx: RequestContext<RoleServer>,
+) -> Result<ListResourcesResult, McpError> {
+    Ok(resources::list_resources(self))
+}
+```
+
+See `references/rust-sdk/server/resources.md` for the full pattern.
+
+## Serving the result
+
+`ServiceExt::serve(transport)` wraps your `Server` in a
+`RunningService<RoleServer, Server>` and starts the message loop.
+`.waiting()` blocks until the transport closes or the service is
+cancelled. For the streamable HTTP transport, the equivalent is the
+axum integration shown in `crates/mcp-server/src/bin/http.rs:32-47` —
+see `references/rust-sdk/server/transports.md`.
+
+## Capability advertisement and instructions
+
+The default `get_info()` returns a minimal `ServerInfo`. Override it to
+declare capabilities, set a protocol version, or include human-readable
+instructions:
+
+```rust
+fn get_info(&self) -> ServerInfo {
+    ServerInfo::new(
+        ServerCapabilities::builder()
+            .enable_tools()
+            .enable_prompts()
+            .enable_resources()
+            .enable_tasks()
+            .build(),
+    )
+    .with_server_info(Implementation::from_build_env())
+    .with_protocol_version(ProtocolVersion::LATEST)
+    .with_instructions("Replace these example handlers with real ones.")
+}
+```
+
+`Implementation::from_build_env()` picks up `CARGO_PKG_NAME` and
+`CARGO_PKG_VERSION`. The `ServerCapabilities::builder()` toggles are
+typestate — each `enable_*` returns a builder with a different
+const-generic flag set; just call `.build()` when you're done.
+
+## See also
+
+- `references/rust-sdk/server/tools.md` — `#[tool]`, `Parameters<T>`,
+  `CallToolResult` shape
+- `references/rust-sdk/server/prompts.md` — `#[prompt]`, message roles
+- `references/rust-sdk/server/resources.md` — free-function dispatch, templates
+- `references/rust-sdk/server/tasks.md` — `#[task_handler]`, the
+  `OperationProcessor` and the `list_tasks` override
+- `references/rust-sdk/server/transports.md` — stdio and Streamable HTTP wiring
+- `crates/mcp-server/src/lib.rs` — full canonical example

--- a/.agents/skills/mcp-knowledge/references/rust-sdk/server/prompts.md
+++ b/.agents/skills/mcp-knowledge/references/rust-sdk/server/prompts.md
@@ -1,0 +1,188 @@
+# Server: prompts
+
+MCP **prompts** are user-triggered prompt templates with optional
+arguments. `rmcp` exposes them through `#[prompt]` on methods inside a
+`#[prompt_router] impl` block — the same shape as tools, with a
+different macro pair.
+
+## When to read this
+
+- Authoring or modifying a `#[prompt]` method.
+- You need a prompt with typed arguments or optional fields.
+- You want to mix user-role and assistant-role messages.
+
+The canonical local example is `crates/mcp-server/src/prompts.rs`.
+
+## The minimum prompt
+
+```rust
+use rmcp::{
+    ErrorData as McpError,
+    handler::server::router::prompt::PromptRouter,
+    model::{GetPromptResult, PromptMessage, Role},
+    prompt, prompt_router,
+};
+
+#[prompt_router]
+impl Server {
+    #[prompt(name = "greeting", description = "Say hello.")]
+    async fn greeting(&self) -> Result<GetPromptResult, McpError> {
+        let messages = vec![
+            PromptMessage::new_text(Role::User, "Please greet me."),
+            PromptMessage::new_text(Role::Assistant, "Hello! How can I help you today?"),
+        ];
+        Ok(GetPromptResult::new(messages))
+    }
+}
+```
+
+Wire it into `Server` exactly like the tool router:
+
+```rust
+pub struct Server {
+    tool_router: ToolRouter<Server>,
+    prompt_router: PromptRouter<Server>,
+    /* ... */
+}
+
+impl Server {
+    pub fn new() -> Self {
+        Self {
+            tool_router: Self::tool_router(),
+            prompt_router: Self::prompt_router(),
+            /* ... */
+        }
+    }
+}
+
+#[tool_handler]
+#[prompt_handler]
+impl ServerHandler for Server {}
+```
+
+## Typed prompt arguments
+
+`Parameters<T>` works the same as for tools. The arg struct derives
+`Deserialize` and `JsonSchema`:
+
+```rust
+use rmcp::handler::server::wrapper::Parameters;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct EchoArgs {
+    /// The message to echo back.
+    pub message: String,
+}
+
+#[prompt_router]
+impl Server {
+    #[prompt(name = "echo", description = "Echo a message back.")]
+    async fn echo(
+        &self,
+        Parameters(args): Parameters<EchoArgs>,
+    ) -> Result<GetPromptResult, McpError> {
+        let messages = vec![PromptMessage::new_text(
+            Role::User,
+            args.message,
+        )];
+        Ok(GetPromptResult::new(messages))
+    }
+}
+```
+
+The argument schema appears in `prompts/list` so the client can render
+a form. Doc-comments on fields become per-argument descriptions.
+
+## Multi-argument prompts with optionals
+
+Optional arguments use `Option<T>` with
+`#[serde(skip_serializing_if = "Option::is_none")]`:
+
+```rust
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct SummarizeArgs {
+    /// The topic to summarize.
+    pub topic: String,
+    /// How many bullets to produce (must be > 0).
+    pub bullet_count: u8,
+    /// Optional tone: "neutral", "casual", "formal".
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tone: Option<String>,
+}
+```
+
+If you need to validate values *beyond* what the schema captures (e.g.
+`bullet_count > 0`), check inside the prompt method and return
+`Err(McpError::invalid_params(...))` for bad input.
+
+## Message roles
+
+`Role` (the same enum used by sampling messages) has two variants:
+`User` and `Assistant`. A canned exchange typically alternates them so
+the model sees a complete turn. There's no `System` role at the prompt
+level — system prompts belong to sampling requests
+(`CreateMessageRequestParams::with_system_prompt`).
+
+```rust
+PromptMessage::new_text(Role::User, "Summarize the topic.")
+PromptMessage::new_text(Role::Assistant, "Here's a summary: ...")
+```
+
+## Result shape
+
+`GetPromptResult::new(messages)` is enough for most cases.
+`.with_description(s)` attaches a human-readable description that
+clients may surface in their prompt picker.
+
+## Capability declaration
+
+`#[prompt_handler]` auto-implements `list_prompts` and `get_prompt`,
+but the server still has to **advertise** prompt support in its
+capabilities:
+
+```rust
+fn get_info(&self) -> ServerInfo {
+    ServerInfo::new(
+        ServerCapabilities::builder()
+            .enable_tools()
+            .enable_prompts()  // <-- this
+            /* ... */
+            .build(),
+    )
+    /* ... */
+}
+```
+
+Without `enable_prompts`, clients may skip the `prompts/list` call
+entirely.
+
+## Gotchas
+
+### Prompt arguments are typed as JSON, not Rust enums
+
+Even if you declare a field as a Rust enum with `JsonSchema`, the wire
+representation is a JSON string. Clients won't know which values are
+allowed unless you put them in the schema (use
+`#[schemars(extend = "value")]` or `#[serde(rename_all = ...)]` on the
+enum variants) or document them in the doc-comment.
+
+### Avoid stuffing too much into a single prompt
+
+If a prompt needs a lot of conditional logic, consider splitting it into
+multiple prompts the client can choose between, or using a tool that
+returns a prompt-shaped response. Prompts are mostly for static-template
+expansion.
+
+### Macros generate associated items
+
+Like `#[tool_router]`, `#[prompt_router]` generates an associated
+function with the same visibility as the `impl` block. Pass `vis` if
+you want it more or less visible.
+
+## See also
+
+- `references/rust-sdk/server/getting-started.md` — composing routers
+- `references/rust-sdk/server/tools.md` — same macro shape, different primitive
+- `crates/mcp-server/src/prompts.rs` — three worked examples
+- `crates/mcp-server/tests/prompts.rs` — round-trip integration test

--- a/.agents/skills/mcp-knowledge/references/rust-sdk/server/resources.md
+++ b/.agents/skills/mcp-knowledge/references/rust-sdk/server/resources.md
@@ -1,0 +1,246 @@
+# Server: resources
+
+MCP **resources** are URI-addressed pieces of context (files, DB rows,
+in-memory text). They come in two flavors:
+
+- **Static resources** — fixed URIs returned by `resources/list`,
+  fetched by exact match.
+- **Resource templates** — URI patterns like `echo://{message}` or
+  `greet://{language}/{name}` returned by `resources/templates/list`,
+  fetched by filling in the variables.
+
+## When to read this
+
+- Exposing files / generated text / DB records as MCP resources.
+- A client is failing to read a URI you advertised.
+- You want URI templates and aren't sure how to dispatch by scheme.
+
+The canonical local example is `crates/mcp-server/src/resources.rs`.
+
+## Why there's no `#[resource_router]`
+
+`rmcp` doesn't ship a procedural macro for resources. Two reasons:
+
+1. Resources are URI-addressed, not name-addressed. The dispatch
+   function depends on your URI scheme and parsing rules — there's no
+   one-size-fits-all router.
+2. Resource lookup is often dynamic (filesystem scan, DB query) rather
+   than statically declared at the type level.
+
+The path is to **implement the three trait methods directly** on
+`ServerHandler` and delegate to free functions you control:
+
+```rust
+#[tool_handler]
+#[prompt_handler]
+impl ServerHandler for Server {
+    async fn list_resources(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _ctx: RequestContext<RoleServer>,
+    ) -> Result<ListResourcesResult, McpError> {
+        Ok(resources::list_resources(self))
+    }
+
+    async fn read_resource(
+        &self,
+        request: ReadResourceRequestParams,
+        _ctx: RequestContext<RoleServer>,
+    ) -> Result<ReadResourceResult, McpError> {
+        resources::read_resource(self, request)
+    }
+
+    async fn list_resource_templates(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _ctx: RequestContext<RoleServer>,
+    ) -> Result<ListResourceTemplatesResult, McpError> {
+        Ok(resources::list_resource_templates(self))
+    }
+}
+```
+
+The free functions live in their own module so the `impl ServerHandler`
+block stays compact.
+
+## Listing static resources
+
+```rust
+use rmcp::model::{ListResourcesResult, Resource};
+
+const EXAMPLE_RESOURCE_URI: &str = "mem://example";
+const EXAMPLE_RESOURCE_NAME: &str = "example";
+
+pub fn list_resources(_server: &Server) -> ListResourcesResult {
+    let resource: Resource = Resource::new(
+        EXAMPLE_RESOURCE_URI,
+        EXAMPLE_RESOURCE_NAME.to_string(),
+    );
+    ListResourcesResult {
+        resources: vec![resource],
+        next_cursor: None,
+        meta: None,
+    }
+}
+```
+
+`Resource` is a flat, `#[non_exhaustive]` struct (no more `Annotated<RawResource>`
+wrapper). `Resource::new(uri, name)` builds it directly; chain
+`.with_title(...)`, `.with_description(...)`, `.with_mime_type(...)`,
+`.with_size(...)`, `.with_icons(...)`, or `.with_annotations(...)` to attach
+optional fields like audience or priority hints.
+
+## Reading resources — dispatch by scheme
+
+`read_resource` receives a `ReadResourceRequestParams { uri, .. }`.
+Match on the URI scheme:
+
+```rust
+use rmcp::model::{ReadResourceRequestParams, ReadResourceResult, ResourceContents};
+use serde_json::json;
+
+const ECHO_RESOURCE_SCHEME: &str = "echo://";
+const GREET_RESOURCE_SCHEME: &str = "greet://";
+
+pub fn read_resource(
+    _server: &Server,
+    request: ReadResourceRequestParams,
+) -> Result<ReadResourceResult, McpError> {
+    if request.uri == EXAMPLE_RESOURCE_URI {
+        return Ok(ReadResourceResult::new(vec![ResourceContents::text(
+            "Static body.",
+            request.uri.clone(),
+        )]));
+    }
+
+    if let Some(message) = request.uri.strip_prefix(ECHO_RESOURCE_SCHEME) {
+        if message.is_empty() {
+            return Err(McpError::invalid_params(
+                "echo:// requires a non-empty message segment",
+                Some(json!({ "uri": request.uri })),
+            ));
+        }
+        return Ok(ReadResourceResult::new(vec![ResourceContents::text(
+            message,
+            request.uri.clone(),
+        )]));
+    }
+
+    if let Some(rest) = request.uri.strip_prefix(GREET_RESOURCE_SCHEME) {
+        let mut parts = rest.splitn(2, '/');
+        let language = parts.next().filter(|s| !s.is_empty());
+        let name = parts.next().filter(|s| !s.is_empty());
+        return match (language, name) {
+            (Some(language), Some(name)) => Ok(ReadResourceResult::new(vec![
+                ResourceContents::text(render_greeting(language, name), request.uri.clone()),
+            ])),
+            _ => Err(McpError::invalid_params(
+                "greet:// requires both a language and a name segment",
+                Some(json!({ "uri": request.uri })),
+            )),
+        };
+    }
+
+    Err(McpError::resource_not_found(
+        "resource_not_found",
+        Some(json!({ "uri": request.uri })),
+    ))
+}
+```
+
+Two things to notice:
+
+1. `strip_prefix` returns `None` if the URI doesn't have the expected
+   prefix — the `if let` short-circuits.
+2. The two templates handle empty segments differently. `echo://` is
+   permissive (anything after the scheme is echoed, including slashes
+   like `echo://a/b`), while `greet://` enforces a fixed
+   `{language}/{name}` shape. The skeleton makes this asymmetry
+   deliberate; see the comment at
+   `crates/mcp-server/src/resources.rs:47-50`.
+
+## Advertising templates
+
+`resources/templates/list` returns the parameterized URI patterns the
+client can fill in:
+
+```rust
+use rmcp::model::{ListResourceTemplatesResult, ResourceTemplate};
+
+const ECHO_RESOURCE_TEMPLATE: &str = "echo://{message}";
+const GREET_RESOURCE_TEMPLATE: &str = "greet://{language}/{name}";
+
+pub fn list_resource_templates(_server: &Server) -> ListResourceTemplatesResult {
+    let echo: ResourceTemplate = ResourceTemplate::new(ECHO_RESOURCE_TEMPLATE, "echo")
+        .with_description("Reads back whatever appears after `echo://`.")
+        .with_mime_type("text/plain");
+    let greet: ResourceTemplate = ResourceTemplate::new(GREET_RESOURCE_TEMPLATE, "greet")
+        .with_description("Localized greeting. Supported languages: en, ja, es, fr.")
+        .with_mime_type("text/plain");
+    ListResourceTemplatesResult {
+        resource_templates: vec![echo, greet],
+        next_cursor: None,
+        meta: None,
+    }
+}
+```
+
+Templates use RFC 6570 URI Template syntax (`{name}`), and `rmcp`
+itself doesn't enforce a parser — your `read_resource` is responsible
+for matching them.
+
+## `ResourceContents` shape
+
+Two main variants:
+
+| Variant                                               | Use for                             |
+| ----------------------------------------------------- | ----------------------------------- |
+| `ResourceContents::text(text, uri)`                   | UTF-8 text                          |
+| `ResourceContents::blob(base64_data, uri, mime_type)` | Binary content (images, PDFs, etc.) |
+
+For binary content you encode the bytes as base64 before constructing
+the variant — `rmcp` enables the `base64` feature by default.
+
+## Capability declaration
+
+Advertise resource support in `get_info`:
+
+```rust
+ServerCapabilities::builder()
+    .enable_resources()
+    /* ... */
+    .build()
+```
+
+`.enable_resources_list_changed()` and `.enable_resources_subscribe()`
+toggle the corresponding optional capabilities (live notifications when
+the list changes, per-resource update subscriptions).
+
+## Gotchas
+
+### URI template `mimeType` is advisory
+
+Setting `.with_mime_type("text/plain")` tells the client what to
+*expect*, but each `ResourceContents::text(...)` or `::blob(...)` you
+return carries its own MIME info. Keep the two consistent.
+
+### Empty `read_resource` returns 404
+
+If `read_resource` returns
+`Err(McpError::resource_not_found(...))`, the client sees a JSON-RPC
+error. Return `invalid_params` for parse errors and `resource_not_found`
+for genuine "not in my registry" cases.
+
+### Pagination is supported
+
+Both `list_resources` and `list_resource_templates` accept
+`PaginatedRequestParams` and return `next_cursor`. For small registries
+the simplest thing is to ignore both. For large registries paginate the
+internal store and surface a cursor.
+
+## See also
+
+- `references/rust-sdk/server/getting-started.md` — the `impl ServerHandler`
+  block that delegates here
+- `crates/mcp-server/src/resources.rs` — full canonical example
+- `crates/mcp-server/tests/resources.rs` — round-trip integration tests

--- a/.agents/skills/mcp-knowledge/references/rust-sdk/server/roots.md
+++ b/.agents/skills/mcp-knowledge/references/rust-sdk/server/roots.md
@@ -1,0 +1,125 @@
+# Server: roots
+
+**Roots** are the server-to-client request `roots/list`: the server
+asks the client what filesystem/workspace roots it has exposed (IDE
+project paths, sandbox directories, etc.). Servers use roots to scope
+file lookups, restrict search, or render context-aware UIs.
+
+> **Deprecated by SEP-2577.** As of rmcp 2.0, roots' types and methods
+> (`Root`, `ListRootsResult`, `Peer::list_roots`, etc.) carry
+> `#[deprecated]` — a compiler warning, not a hard error. They remain
+> fully functional and are still part of the protocol. Call sites that
+> keep using them (like `list_workspace_roots` below) wrap the call in
+> `#[allow(deprecated, reason = "...")]`; mirror that pattern in your
+> own code.
+
+## When to read this
+
+- Writing a tool that needs to know where the user's project lives.
+- Working with an IDE-integrated MCP client and want to surface its
+  open folders.
+
+The canonical local example is `list_workspace_roots` in
+`crates/mcp-server/src/tools.rs:179-209`.
+
+## The minimum roots-using tool
+
+```rust
+use rmcp::{
+    ErrorData as McpError, RoleServer,
+    model::{CallToolResult, ContentBlock},
+    service::RequestContext,
+    tool,
+};
+
+#[allow(deprecated, reason = "SEP-2577 deprecates roots; kept as an example")]
+#[tool(description = "List the workspace roots the client has exposed.")]
+async fn list_workspace_roots(
+    &self,
+    ctx: RequestContext<RoleServer>,
+) -> Result<CallToolResult, McpError> {
+    let result = ctx.peer.list_roots().await.map_err(|e| {
+        McpError::internal_error(format!("roots/list request failed: {e}"), None)
+    })?;
+
+    let text = if result.roots.is_empty() {
+        "Client exposed no roots.".to_string()
+    } else {
+        result
+            .roots
+            .iter()
+            .map(|root| match &root.name {
+                Some(name) => format!("- {} ({})", name, root.uri),
+                None => format!("- {}", root.uri),
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+    Ok(CallToolResult::success(vec![ContentBlock::text(text)]))
+}
+```
+
+## `Root` shape
+
+A `Root` has two fields:
+
+| Field  | Type             | Meaning                                                 |
+| ------ | ---------------- | ------------------------------------------------------- |
+| `uri`  | `String`         | The root URI, typically `file:///path/to/dir`           |
+| `name` | `Option<String>` | Human-readable label (often the folder name in the IDE) |
+
+Don't assume `name` is set. Always fall back to `uri` if it's not.
+
+## Required client capability
+
+The client must advertise `roots` in its `ClientCapabilities`. If it
+hasn't, `ctx.peer.list_roots()` returns an error. As with
+elicitation/sampling, you can either:
+
+- bubble the error up as `internal_error`, or
+- check the error and degrade gracefully (e.g. "no roots — please open
+  a folder in your IDE").
+
+The capability is two-tiered:
+
+| Capability                                     | Meaning                                                  |
+| ---------------------------------------------- | -------------------------------------------------------- |
+| `ClientCapabilities::builder().enable_roots()` | Client supports `roots/list`                             |
+| `.enable_roots_list_changed()`                 | Client will also send `roots/list_changed` notifications |
+
+If your server cares about live changes (e.g. you want to re-scan when
+the user opens a new folder), implement
+`ServerHandler::on_roots_list_changed` *or* handle the equivalent on
+the client → server notification path.
+
+## Empty roots is normal
+
+A client may legitimately expose zero roots:
+
+- The user hasn't opened a folder yet (IDE).
+- The client is a chat UI that doesn't have a filesystem concept.
+- The user revoked permissions.
+
+The `list_workspace_roots` example handles this explicitly by emitting
+`"Client exposed no roots."` rather than failing.
+
+## Pagination
+
+`roots/list` does not support pagination in the current spec — the
+client returns everything in one response. Don't assume you can iterate.
+
+## Capability declaration on the server side
+
+Like sampling and elicitation, the server doesn't need to advertise
+anything special to *make* `roots/list` requests. The gate is the
+client's `ClientCapabilities::roots` field.
+
+## See also
+
+- `references/rust-sdk/server/tools.md` — `RequestContext<RoleServer>` as a tool
+  parameter
+- `references/rust-sdk/server/sampling.md`,
+  `references/rust-sdk/server/elicitation.md` — sibling server-to-client requests
+- `references/rust-sdk/client/roots.md` — implementing the client side
+- `crates/mcp-server/src/tools.rs:179-209` — `list_workspace_roots`
+  worked example

--- a/.agents/skills/mcp-knowledge/references/rust-sdk/server/sampling.md
+++ b/.agents/skills/mcp-knowledge/references/rust-sdk/server/sampling.md
@@ -1,0 +1,225 @@
+# Server: sampling
+
+**Sampling** is the server-to-client request `sampling/createMessage`:
+the server asks the client's LLM to produce a response. It's the
+mechanism that lets MCP servers do model-mediated work (summaries,
+translation, decisions) without bundling an LLM themselves.
+
+> **Deprecated by SEP-2577.** As of rmcp 2.0, sampling's types and
+> methods (`CreateMessageRequestParams`, `SamplingMessage`,
+> `Peer::create_message`, etc.) carry `#[deprecated]` — a compiler
+> warning, not a hard error. They remain fully functional and are still
+> part of the protocol. Call sites that keep using them (like `ask_llm`
+> below) wrap the call in `#[allow(deprecated, reason = "...")]`; mirror
+> that pattern in your own code.
+
+## When to read this
+
+- Writing a tool that delegates a reasoning step to the client's LLM.
+- A sampling-using tool is returning empty text and you're not sure
+  why.
+- A client that didn't advertise the `sampling` capability is rejecting
+  your request.
+
+The canonical local example is `ask_llm` in
+`crates/mcp-server/src/tools.rs:82-128`.
+
+## The minimum sampling tool
+
+```rust
+use rmcp::{
+    ErrorData as McpError, RoleServer,
+    handler::server::wrapper::Parameters,
+    model::{CallToolResult, ContentBlock, CreateMessageRequestParams, SamplingMessage},
+    service::RequestContext,
+    tool,
+};
+
+#[allow(deprecated, reason = "SEP-2577 deprecates sampling; kept as an example")]
+#[tool(description = "Ask the client's LLM a question via sampling.")]
+async fn ask_llm(
+    &self,
+    Parameters(args): Parameters<AskLlmArgs>,
+    ctx: RequestContext<RoleServer>,
+) -> Result<CallToolResult, McpError> {
+    let response = ctx
+        .peer
+        .create_message(
+            CreateMessageRequestParams::new(
+                vec![SamplingMessage::user_text(&args.question)],
+                512,
+            )
+            .with_system_prompt("You are a concise assistant.")
+            .with_temperature(0.7),
+        )
+        .await
+        .map_err(|e| McpError::internal_error(format!("sampling request failed: {e}"), None))?;
+
+    let text = response
+        .message
+        .content
+        .iter()
+        .find_map(|c| c.as_text())
+        .map(|t| t.text.clone())
+        .unwrap_or_else(|| "(no text response)".to_string());
+
+    Ok(CallToolResult::success(vec![ContentBlock::text(text)]))
+}
+```
+
+The pattern:
+
+1. Take `ctx: RequestContext<RoleServer>` as a parameter on the tool
+   method — that's how you reach the peer.
+2. Build `CreateMessageRequestParams::new(messages, max_tokens)`.
+3. Add optional knobs: `.with_system_prompt(...)`, `.with_temperature(...)`,
+   `.with_model_preferences(...)`, `.with_stop_sequences(...)`.
+4. Call `ctx.peer.create_message(...).await`.
+5. Pull text out of the response.
+
+## `SamplingMessage` constructors
+
+| Constructor                                      | What it makes                                                |
+| ------------------------------------------------ | ------------------------------------------------------------ |
+| `SamplingMessage::user_text("...")`              | User-role text turn                                          |
+| `SamplingMessage::assistant_text("...")`         | Assistant-role text turn                                     |
+| `SamplingMessage::new(role, content)`            | Any single `SamplingMessageContentBlock` (image, audio, ...) |
+| `SamplingMessage::new_multiple(role, vec![...])` | Several content blocks in one turn                           |
+
+`SamplingMessage` is `#[non_exhaustive]`, so struct-literal construction
+(`SamplingMessage { role, content, .. }`) no longer compiles outside the
+`rmcp` crate — use the constructors above.
+
+For multi-turn sampling, pass a `Vec<SamplingMessage>`. The model sees
+the messages in order.
+
+## Iterating response content
+
+`CreateMessageResult.message.content` is a
+`SamplingContent<SamplingMessageContentBlock>` enum that can carry one
+(`Single`) or many (`Multiple`) content blocks. Each block is a
+`SamplingMessageContentBlock` (the old name `SamplingMessageContent` is
+now a deprecated type alias) — a flat, `#[non_exhaustive]` enum with
+`Text(TextContent)`, `Image(ImageContent)`, `Audio(AudioContent)`,
+`ToolUse(ToolUseContent)`, and `ToolResult(ToolResultContent)`
+variants.
+
+The canonical extraction pattern is:
+
+```rust
+let text = response
+    .message
+    .content
+    .iter()
+    .find_map(|c| c.as_text())
+    .map(|t| t.text.clone())
+    .unwrap_or_else(|| "(no text response)".to_string());
+```
+
+`SamplingMessageContentBlock::as_text()` returns `Option<&TextContent>`.
+If you need a specific non-text variant, pattern-match directly on the
+block:
+
+```rust
+use rmcp::model::SamplingMessageContentBlock;
+
+for block in response.message.content.iter() {
+    match block {
+        SamplingMessageContentBlock::Text(t) => /* t.text */,
+        SamplingMessageContentBlock::Image(img) => /* img.data, img.mime_type */,
+        SamplingMessageContentBlock::Audio(_) => /* ... */,
+        SamplingMessageContentBlock::ToolUse(_) | SamplingMessageContentBlock::ToolResult(_) => {
+            /* SEP-1577 tool-use extensions to sampling */
+        }
+        _ => /* future variants — the enum is #[non_exhaustive] */,
+    }
+}
+```
+
+## Non-text fallback — surface a warning
+
+If your tool only handles text, log when a model returns something
+unexpected so future you (or whoever copies the tool) sees there's a
+gap:
+
+```rust
+let text = match response.message.content.iter().find_map(|c| c.as_text()) {
+    Some(t) => t.text.clone(),
+    None => {
+        tracing::warn!(
+            model = %response.model,
+            "ask_llm: sampling response contained no text content; \
+             non-text content blocks are not handled by this skeleton",
+        );
+        "(no text response)".to_string()
+    }
+};
+```
+
+That's how `crates/mcp-server/src/tools.rs:113-126` does it.
+
+## Required client capability
+
+The client must advertise `sampling` during `initialize` for the server
+to make sampling requests. If the client didn't declare it, the
+`create_message` call returns an error.
+
+For a client *test* harness that needs to back the server's sampling
+calls, override `ClientHandler::create_message` and declare the
+capability — see `references/rust-sdk/client/sampling.md`.
+
+## Common patterns
+
+### Forwarding the user's question
+
+Stuff the user-supplied query into a `SamplingMessage::user_text` turn
+and use `with_system_prompt` to set the role / tone:
+
+```rust
+CreateMessageRequestParams::new(
+    vec![SamplingMessage::user_text(question)],
+    512,
+)
+.with_system_prompt("You are a helpful assistant. Answer concisely.")
+.with_temperature(0.4)
+```
+
+### Chained reasoning
+
+For a multi-step plan, accumulate `SamplingMessage` turns and feed the
+whole transcript back in on each step. There's no built-in conversation
+state — your tool owns it.
+
+### Streaming
+
+`create_message` returns the full `CreateMessageResult` once the model
+has finished. There is no server-side streaming API in `rmcp` 2.x. If
+you need streaming, you'd have to layer your own protocol on top.
+
+## Error handling
+
+Wrap the `create_message` call in `.map_err(...)` to convert
+`ServiceError` into `McpError`:
+
+```rust
+.await
+.map_err(|e| McpError::internal_error(format!("sampling request failed: {e}"), None))?
+```
+
+Returning `Err(...)` here surfaces a JSON-RPC error to the client — the
+caller sees the tool failed. If you'd rather degrade gracefully (e.g.
+return a default text response when the client doesn't support
+sampling), check the error string and substitute a fallback.
+
+## See also
+
+- `references/rust-sdk/server/tools.md` — `RequestContext<RoleServer>` as a tool
+  parameter
+- `references/rust-sdk/server/elicitation.md` — the sibling server-to-client
+  request for user input
+- `references/rust-sdk/server/roots.md` — the sibling server-to-client request
+  for workspace listing
+- `references/rust-sdk/client/sampling.md` — implementing the client side
+- `crates/mcp-server/src/tools.rs:82-128` — the `ask_llm` worked example
+- `submodules/mcp-rust-sdk/examples/servers/src/sampling_stdio.rs` —
+  upstream example with multi-turn sampling

--- a/.agents/skills/mcp-knowledge/references/rust-sdk/server/tasks.md
+++ b/.agents/skills/mcp-knowledge/references/rust-sdk/server/tasks.md
@@ -1,0 +1,259 @@
+# Server: tasks (SEP-1686)
+
+MCP **tasks** are async, server-side operations: a client calls a tool
+with `task` metadata, the server kicks off the work, returns a task
+handle immediately, and the client polls `tasks/list`, `tasks/get`,
+`tasks/result`, or `tasks/cancel` to drive the lifecycle.
+
+`rmcp` 2.x ships task support behind the `#[task_handler]` macro plus
+the `OperationProcessor` runtime in `rmcp::task_manager`.
+
+## When to read this
+
+- A tool genuinely takes more than a few seconds and you want the
+  client to be able to walk away and check back.
+- You want to support cancellation.
+- You're surprised that the default `tasks/list` doesn't show
+  completed tasks (it doesn't — see "list_tasks override" below).
+
+The canonical local example is `crates/mcp-server/src/tasks.rs` plus
+the `slow_count` tool in `crates/mcp-server/src/tools.rs`.
+
+## Lifecycle in 30 seconds
+
+1. **Server marks a tool task-capable** — `#[tool(..., execution(task_support = "optional" | "required"))]`.
+2. **Client calls the tool with `task` metadata** — for an `"optional"`
+   tool it can also omit `task` and run synchronously.
+3. **Server enqueues the operation** — `#[task_handler]`-synthesized
+   `enqueue_task` spawns the tool body via `OperationProcessor` and
+   returns a `CreateTaskResult` carrying the new task id.
+4. **Client polls** — `tasks/list`, `tasks/get`, `tasks/result`,
+   or `tasks/cancel` (also synthesized by `#[task_handler]`).
+5. **Task finishes / fails / is cancelled / times out** — result lands
+   in the processor's completed queue.
+
+## Wiring the processor into `Server`
+
+```rust
+use std::sync::Arc;
+use rmcp::task_manager::OperationProcessor;
+use tokio::sync::Mutex;
+
+#[derive(Clone)]
+pub struct Server {
+    tool_router: ToolRouter<Server>,
+    prompt_router: PromptRouter<Server>,
+    pub(crate) processor: Arc<Mutex<OperationProcessor>>,
+}
+
+impl Server {
+    pub fn new() -> Self {
+        Self {
+            tool_router: Self::tool_router(),
+            prompt_router: Self::prompt_router(),
+            processor: Arc::new(Mutex::new(OperationProcessor::new())),
+        }
+    }
+}
+
+#[tool_handler]
+#[prompt_handler]
+#[task_handler]
+impl ServerHandler for Server { /* ... */ }
+```
+
+`#[task_handler]` reads `self.processor` by default. To use a different
+field name, pass it: `#[task_handler(processor = self.my_task_proc)]`.
+
+The processor lives behind `Arc<Mutex<...>>` because
+`#[task_handler]` clones `Server` into each spawned task and the
+processor has interior mutability (`list_running`, `peek_completed`,
+`submit_operation` all take `&mut self`).
+
+## Marking a tool task-capable
+
+```rust
+#[tool(
+    description = "Count up to `target` slowly. Supports task-based invocation.",
+    execution(task_support = "optional")
+)]
+async fn slow_count(
+    &self,
+    Parameters(args): Parameters<SlowCountArgs>,
+) -> Result<CallToolResult, McpError> {
+    for i in 1..=args.target {
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        tracing::debug!(tick = i, target = args.target, "slow_count tick");
+    }
+    Ok(CallToolResult::success(vec![ContentBlock::text(
+        args.target.to_string(),
+    )]))
+}
+```
+
+`task_support` values:
+
+| Value        | Behavior                                                                                                                   |
+| ------------ | -------------------------------------------------------------------------------------------------------------------------- |
+| `"optional"` | Client may opt in to the task path by sending `task` metadata, or run sync. Synchronous calls still block until completion |
+| `"required"` | Client must send `task` metadata. Synchronous calls are rejected                                                           |
+| (omitted)    | Synchronous only. Task metadata is rejected                                                                                |
+
+## What `#[task_handler]` synthesizes
+
+The macro auto-implements these `ServerHandler` methods (one
+synthesized method per `tasks/*` JSON-RPC method):
+
+- `enqueue_task` — spawns the tool body onto the processor and returns
+  `CreateTaskResult { task_id, ... }`.
+- `list_tasks` — returns currently *running* tasks via
+  `OperationProcessor::list_running()`.
+- `get_task_info` — returns metadata for one task.
+- `get_task_result` — drains the completed result for a task id.
+- `cancel_task` — signals cancellation via the processor.
+
+Each method validates the underlying tool's `task_support` declaration
+and rejects mismatches (sync call to a `"required"` tool, etc.).
+
+## The `list_tasks` gotcha
+
+By default, `tasks/list` only returns *running* tasks. Short tools
+vanish from the list as soon as they finish. The canonical fix at
+`crates/mcp-server/src/tasks.rs` overrides `list_tasks` to merge in
+`peek_completed()`:
+
+```rust
+use rmcp::{
+    ErrorData as McpError,
+    model::{ListTasksResult, Task, TaskStatus},
+    task_manager::current_timestamp,
+};
+
+pub async fn list_tasks(server: &Server) -> Result<ListTasksResult, McpError> {
+    let mut processor = server.processor.lock().await;
+    let now = current_timestamp();
+
+    let mut tasks: Vec<Task> = processor
+        .list_running()
+        .into_iter()
+        .map(|task_id| Task::new(task_id, TaskStatus::Working, now.clone(), now.clone()))
+        .collect();
+
+    for result in processor.peek_completed() {
+        let status = match &result.result {
+            Ok(_) => TaskStatus::Completed,
+            Err(e) if e.to_string().to_lowercase().contains("cancelled") => {
+                TaskStatus::Cancelled
+            }
+            Err(_) => TaskStatus::Failed,
+        };
+        tasks.push(Task::new(
+            result.descriptor.operation_id.clone(),
+            status,
+            now.clone(),
+            now.clone(),
+        ));
+    }
+
+    Ok(ListTasksResult::new(tasks))
+}
+```
+
+Put the override on the same `impl ServerHandler` block as the macros;
+the macros skip methods you've defined yourself.
+
+## Distinguishing cancellation from failure
+
+`OperationProcessor::cancel_task` pushes the cancelled result as
+`Err(Error::TaskError("Operation cancelled"))`. Timeouts produce
+`Err(Error::TaskError("Operation timed out"))`. `TaskResult` does not
+yet expose a structured discriminator, so the canonical pattern is to
+string-match on the rendered error message:
+
+```rust
+let status = match &result.result {
+    Ok(_) => TaskStatus::Completed,
+    Err(e) if e.to_string().to_lowercase().contains("cancelled") => {
+        TaskStatus::Cancelled
+    }
+    Err(_) => TaskStatus::Failed,
+};
+```
+
+Timeouts fall through to `Failed`, which matches user intuition. Swap
+to a typed discriminator once upstream exposes one.
+
+## Timestamps
+
+`OperationProcessor` does not yet expose per-task `created_at` /
+`last_updated_at`. Today the cheapest path is to set both timestamps
+to `current_timestamp()` at list time, which makes every task look like
+it was just created. This is acknowledged with a doc comment on the
+override at `crates/mcp-server/src/tasks.rs:18-24` — keep that comment
+in sync with whatever upstream lands.
+
+## Cancellation flow
+
+A client sends `tasks/cancel { task_id }`. The macro-synthesized
+`cancel_task` calls `OperationProcessor::cancel_task(...)`, which sets
+the task's cancellation flag. The spawned future is expected to be
+**cooperative** — it must check the cancellation signal at `.await`
+points. `tokio::time::sleep` and `tokio::select!` interact correctly,
+but a tight CPU loop will not.
+
+## Result enum ambiguity on the client side
+
+Heads up: `ServerResult::CancelTaskResult` and `ServerResult::GetTaskResult`
+share the same wire shape after `serde` flattening, and the untagged
+enum may pick the wrong variant when deserializing. Test code that
+handles cancellation must accept either:
+
+```rust
+let task = match response {
+    ServerResult::CancelTaskResult(r) => r.task,
+    ServerResult::GetTaskResult(r) => r.task,
+    other => panic!("expected cancel/get task result, got {other:?}"),
+};
+```
+
+See `crates/mcp-server/tests/task.rs::list_tasks_reports_cancelled_status_for_cancelled_task`
+for the worked example, and `references/rust-sdk/client/requests.md` for more
+on this pattern.
+
+## Capability declaration
+
+Advertise task support:
+
+```rust
+ServerCapabilities::builder()
+    .enable_tools()
+    .enable_tasks()
+    /* ... */
+    .build()
+```
+
+Without `.enable_tasks()`, clients may skip the `tasks/*` methods
+entirely.
+
+## Inspector / MCP-spec-incompatible clients
+
+Many clients (including MCP Inspector at the time of writing) do not
+opt in to the task path. They will call an `"optional"` task tool
+synchronously and wait for the full result, which may hit a request
+timeout (`-32001`) if the tool is genuinely slow.
+
+Pick the strategy that matches your tool:
+
+| Tool runtime | Recommended `task_support`                                                   |
+| ------------ | ---------------------------------------------------------------------------- |
+| < 1 second   | omit — keep it synchronous                                                   |
+| 1-10 seconds | `"optional"` — sync clients see "slow but works", task clients see better UX |
+| > 10 seconds | `"required"` — sync clients are rejected, forces clients to use tasks        |
+
+## See also
+
+- `references/rust-sdk/server/tools.md` — `execution(task_support = ...)` shape
+- `references/rust-sdk/client/requests.md` — the `CancelTaskResult` /
+  `GetTaskResult` ambiguity, polling patterns
+- `crates/mcp-server/src/tasks.rs` — the `list_tasks` override
+- `crates/mcp-server/tests/task.rs` — full lifecycle integration test

--- a/.agents/skills/mcp-knowledge/references/rust-sdk/server/tools.md
+++ b/.agents/skills/mcp-knowledge/references/rust-sdk/server/tools.md
@@ -1,0 +1,258 @@
+# Server: tools
+
+Tools are the most common MCP primitive. `rmcp` exposes them through
+the `#[tool]` attribute on async methods inside a `#[tool_router]
+impl` block. The macros handle JSON-RPC dispatch, argument
+deserialization, and JSON Schema generation.
+
+## When to read this
+
+- Authoring or modifying a `#[tool]` method.
+- A tool needs typed arguments and you're not sure how `Parameters<T>`
+  wires in.
+- A tool needs to make a server-to-client request (sampling,
+  elicitation, roots) and you need `RequestContext<RoleServer>`.
+- You want a tool that can run synchronously *or* as an async task
+  (SEP-1686).
+
+The canonical local example is `crates/mcp-server/src/tools.rs`.
+
+## The minimum tool
+
+```rust
+#[tool_router]
+impl Server {
+    #[tool(description = "Health-check tool. Returns 'pong'.")]
+    async fn ping(&self) -> Result<CallToolResult, McpError> {
+        Ok(CallToolResult::success(vec![ContentBlock::text("pong")]))
+    }
+}
+```
+
+`description` shows up in `tools/list` and in MCP Inspector's tool
+listing. Keep it short, action-oriented, and self-contained — a model
+may pick which tool to call based on this string alone.
+
+Tool methods take `&self` and return `Result<CallToolResult, McpError>`.
+The macros take care of marshaling them to JSON-RPC. `CallToolResult`
+shape:
+
+| Field                        | Constructor                                                               |
+| ---------------------------- | ------------------------------------------------------------------------- |
+| Successful text reply        | `CallToolResult::success(vec![ContentBlock::text("...")])`                |
+| Successful image reply       | `CallToolResult::success(vec![ContentBlock::image(base64, "image/png")])` |
+| Error returned to the client | `CallToolResult::error(vec![ContentBlock::text("...")])`                  |
+
+Returning `Err(McpError::...)` from the method bubbles up as a JSON-RPC
+error — usually you want `CallToolResult::error(...)` instead so the
+client sees a structured error result (`is_error: true`) rather than a
+protocol-level failure.
+
+## Typed arguments with `Parameters<T>`
+
+Wrap the argument struct in `Parameters<T>` and the macros take care of
+the rest. `T` must derive `Deserialize` and `JsonSchema`:
+
+```rust
+use rmcp::{handler::server::wrapper::Parameters, schemars};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct SlowCountArgs {
+    /// How high to count. Each tick sleeps for SLOW_COUNT_TICK_MS.
+    pub target: u8,
+}
+
+#[tool_router]
+impl Server {
+    #[tool(description = "Count up to `target` slowly.")]
+    async fn slow_count(
+        &self,
+        Parameters(args): Parameters<SlowCountArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        for _ in 1..=args.target {
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+        Ok(CallToolResult::success(vec![ContentBlock::text(args.target.to_string())]))
+    }
+}
+```
+
+The macro emits a JSON Schema for `SlowCountArgs` and registers it as
+the tool's `inputSchema`. Doc-comments on the struct fields surface as
+`description` entries in the schema, which clients (and LLMs) use to
+understand how to call the tool. **Write them.**
+
+Default values, optional fields, and nullable strings work the standard
+serde way:
+
+```rust
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct SummarizeArgs {
+    pub topic: String,
+    pub bullet_count: u8,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tone: Option<String>,
+}
+```
+
+## `RequestContext<RoleServer>` and server-to-client requests
+
+Add `ctx: RequestContext<RoleServer>` as a method parameter to get
+access to:
+
+- `ctx.peer` — the `Peer<RoleServer>` that can make outgoing requests
+  to the client (sampling, elicitation, roots).
+- `ctx.request_id` — for correlating progress notifications.
+- `ctx.meta` / `ctx.extensions` — request metadata.
+
+The three server-to-client request types each get their own dedicated
+reference file:
+
+- **Sampling** — `ctx.peer.create_message(...)` — see
+  `references/rust-sdk/server/sampling.md`.
+- **Elicitation** — `ctx.peer.elicit::<T>(...)` — see
+  `references/rust-sdk/server/elicitation.md`.
+- **Roots** — `ctx.peer.list_roots()` — see
+  `references/rust-sdk/server/roots.md`.
+
+The pattern in `crates/mcp-server/src/tools.rs` (`ask_llm`,
+`greet_user`, `list_workspace_roots`) is the canonical reference for
+each.
+
+## Task-capable tools (SEP-1686)
+
+A tool can opt in to async-task invocation by adding
+`execution(task_support = "optional"|"required")` to the `#[tool]`
+attribute:
+
+```rust
+#[tool(
+    description = "Count up to `target` slowly (100ms per tick). Supports task-based invocation.",
+    execution(task_support = "optional")
+)]
+async fn slow_count(/* ... */) -> Result<CallToolResult, McpError> { /* ... */ }
+```
+
+| Value        | Behavior                                                                                                  |
+| ------------ | --------------------------------------------------------------------------------------------------------- |
+| `"optional"` | Client *may* request task-based execution by passing `task` metadata on `tools/call`. Otherwise runs sync |
+| `"required"` | Client *must* request task-based execution. Synchronous calls are rejected                                |
+| (omitted)    | Synchronous only. Task-based calls are rejected                                                           |
+
+For `"optional"` tools, the synchronous path still runs the whole tool
+to completion, so clients that don't opt in to tasks (including MCP
+Inspector at the time of writing) will hold the JSON-RPC request open
+until the tool finishes. Keep the sync path short, or mark the tool
+`"required"` so clients have to use the task path.
+
+See `references/rust-sdk/server/tasks.md` for the `OperationProcessor` and the
+`list_tasks` override pattern.
+
+## Calling `tools/list` programmatically
+
+`#[tool_handler]` auto-implements `ServerHandler::list_tools`. Clients
+fetch the registry via `ListToolsRequest` — there's no need to
+implement it yourself. The test at
+`crates/mcp-server/tests/tools.rs::list_tools_returns_the_advertised_set`
+shows the round trip.
+
+## Common patterns and gotchas
+
+### `CallToolResult::error` vs `Err(McpError)`
+
+Use `CallToolResult::error(vec![ContentBlock::text("...")])` for problems
+the tool itself surfaces (validation failures, downstream API errors).
+The client sees a successful JSON-RPC response with `is_error: true`,
+which is what most MCP UIs render as "the tool ran and reported a
+problem."
+
+Use `Err(McpError::internal_error(...))` only for protocol-level
+failures the client can't recover from. The client sees a JSON-RPC
+error response, which most UIs render as a hard failure.
+
+### Visibility of the router function
+
+`#[tool_router]` generates `fn tool_router()` with the same visibility
+as the `impl` block by default. If your `Server` is `pub` and you want
+the router to stay `pub(crate)`, pass `vis`:
+
+```rust
+#[tool_router(vis = "pub(crate)")]
+impl Server { /* ... */ }
+```
+
+The local example uses this at `crates/mcp-server/src/tools.rs:53`.
+
+### Renaming the router field
+
+Pass the field name to both macros if you don't want the default
+`tool_router`:
+
+```rust
+#[tool_router(router = my_tools)]
+impl Server { /* ... */ }
+
+#[tool_handler(router = self.my_tools)]
+impl ServerHandler for Server {}
+```
+
+### Tool annotations
+
+Beyond `description`, `#[tool(...)]` accepts `name = "..."` (override
+the auto-derived snake_case name), `input_schema = ...` (provide a
+hand-rolled schema), and `annotations(...)` (declare behavioral hints
+the client surfaces in its UI). The full attribute syntax lives in
+`submodules/mcp-rust-sdk/crates/rmcp-macros/src/tool.rs`.
+
+**Declare annotations for every tool — especially read-only ones.**
+When you omit `annotations(...)`, the client falls back to the MCP
+spec defaults, which are:
+
+| Hint               | Spec default | Meaning when true                         |
+| ------------------ | ------------ | ----------------------------------------- |
+| `read_only_hint`   | `false`      | Tool performs no state changes            |
+| `destructive_hint` | `true`       | Tool may make irreversible changes        |
+| `idempotent_hint`  | `false`      | Repeat calls with same args are safe      |
+| `open_world_hint`  | `true`       | Tool may interact with external systems   |
+
+The defaults are calibrated for the worst case — a stateful,
+destructive, non-idempotent, open-world tool. So a read-only
+HTTP-GET tool that forgets to declare anything shows up in clients
+(MCP Inspector, Claude Code's tool-permission prompts, etc.) as
+"destructive" and "not idempotent". Users may be asked to confirm
+every call, or the host may downrank the tool when picking which to
+invoke. The fix is one block per tool:
+
+```rust
+#[tool(
+    description = "Fetch a docs.rs page and return Markdown.",
+    annotations(
+        read_only_hint = true,
+        destructive_hint = false,
+        idempotent_hint = true,
+        open_world_hint = true,
+    )
+)]
+async fn get_crate_docs(/* ... */) -> Result<CallToolResult, McpError> { /* ... */ }
+```
+
+Per the spec, `destructive_hint` is only meaningful when
+`read_only_hint = false`, but declaring it explicitly costs nothing
+and removes any ambiguity in the client UI. Keep `open_world_hint =
+true` for anything that talks to the network — that's exactly what
+the hint is for, not a mark of shame.
+
+## See also
+
+- `references/rust-sdk/server/getting-started.md` — composing `Server` with
+  multiple routers
+- `references/rust-sdk/server/tasks.md` — `execution(task_support = ...)` and
+  the task processor
+- `references/rust-sdk/server/sampling.md`,
+  `references/rust-sdk/server/elicitation.md`,
+  `references/rust-sdk/server/roots.md` — the three server-to-client request
+  patterns
+- `crates/mcp-server/src/tools.rs` — five worked examples
+  (`ping`, `slow_count`, `ask_llm`, `greet_user`, `list_workspace_roots`)
+- `crates/mcp-server/tests/tools.rs` — integration tests for the same

--- a/.agents/skills/mcp-knowledge/references/rust-sdk/server/transports.md
+++ b/.agents/skills/mcp-knowledge/references/rust-sdk/server/transports.md
@@ -1,0 +1,198 @@
+# Server: transports
+
+A server only needs one transport to be useful, but `rmcp` supports
+several and the wiring differs significantly between them. This file
+covers stdio and Streamable HTTP — the two production transports — and
+points at the in-memory `tokio::io::duplex` pattern used by every test
+in `crates/mcp-server/tests/`.
+
+## When to read this
+
+- Picking how a server should talk to its client.
+- Wiring a Streamable HTTP server (axum, tower) for the first time.
+- Setting up graceful shutdown.
+
+The canonical local examples are `crates/mcp-server/src/bin/stdio.rs`
+and `crates/mcp-server/src/bin/http.rs`.
+
+## stdio (`transport-io` feature)
+
+`rmcp::transport::stdio()` returns a `(Stdin, Stdout)` tuple, which
+implements `IntoTransport<RoleServer, ...>`. Pass it to
+`ServiceExt::serve(...)`:
+
+```rust
+use rmcp::{ServiceExt, transport::stdio};
+use tracing_subscriber::EnvFilter;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+        )
+        .with_writer(std::io::stderr)
+        .with_ansi(false)
+        .init();
+
+    tracing::info!("starting MCP server over stdio");
+
+    let service = Server::new().serve(stdio()).await.inspect_err(|e| {
+        tracing::error!(error = ?e, "failed to start MCP server");
+    })?;
+
+    service.waiting().await?;
+    Ok(())
+}
+```
+
+Key points:
+
+- **Log to stderr, not stdout.** JSON-RPC frames go on stdout; any
+  byte that isn't a valid frame corrupts the stream. The
+  `tracing_subscriber::fmt().with_writer(std::io::stderr)` line above
+  is load-bearing.
+- **Disable ANSI escapes** (`.with_ansi(false)`). Many MCP clients
+  capture stderr too and won't render ANSI codes.
+- **`service.waiting().await`** blocks until the transport closes
+  (client disconnects) or the service is cancelled. Without it, `main`
+  exits immediately.
+
+## Streamable HTTP (`transport-streamable-http-server` feature)
+
+`StreamableHttpService` is a `tower::Service` that handles a single
+HTTP endpoint (typically `/mcp`). Compose it into an `axum::Router`:
+
+```rust
+use rmcp::transport::streamable_http_server::{
+    StreamableHttpServerConfig, StreamableHttpService,
+    session::local::LocalSessionManager,
+};
+use tracing_subscriber::EnvFilter;
+
+const DEFAULT_BIND_ADDRESS: &str = "127.0.0.1:8000";
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+        )
+        .init();
+
+    let bind_address =
+        std::env::var("MCP_BIND_ADDRESS").unwrap_or_else(|_| DEFAULT_BIND_ADDRESS.to_string());
+
+    let cancellation = tokio_util::sync::CancellationToken::new();
+
+    let service = StreamableHttpService::new(
+        || Ok(Server::new()),
+        LocalSessionManager::default().into(),
+        StreamableHttpServerConfig::default()
+            .with_cancellation_token(cancellation.child_token()),
+    );
+
+    let router = axum::Router::new().nest_service("/mcp", service);
+    let listener = tokio::net::TcpListener::bind(&bind_address).await?;
+    tracing::info!(%bind_address, "MCP server listening at /mcp");
+
+    axum::serve(listener, router)
+        .with_graceful_shutdown(async move {
+            let _ = tokio::signal::ctrl_c().await;
+            cancellation.cancel();
+        })
+        .await?;
+
+    Ok(())
+}
+```
+
+Anatomy:
+
+1. **Factory closure** — `|| Ok(Server::new())` is called once per
+   session. If you need per-session state (a session-scoped cache,
+   per-user auth context), construct it here.
+2. **`LocalSessionManager`** — in-memory session store. For multi-node
+   deployments you'd implement the `SessionManager` trait against an
+   external store (Redis, DB).
+3. **`StreamableHttpServerConfig`** — knobs for streaming, JSON
+   responses, cancellation. The defaults are sensible.
+4. **Routing** — `nest_service("/mcp", service)` mounts the MCP
+   endpoint. The exact path is up to you; clients are configured with
+   the full URL.
+5. **Graceful shutdown** — Wire a `CancellationToken` from the config
+   into axum's `with_graceful_shutdown`. On `Ctrl+C`, cancel the token
+   so in-flight requests can drain.
+
+## When to use which
+
+| Transport                | Use when                                                           |
+| ------------------------ | ------------------------------------------------------------------ |
+| stdio                    | Local subprocess clients (Claude Desktop, MCP Inspector via stdio) |
+| Streamable HTTP          | Remote / network-accessible servers; multiple concurrent clients   |
+| Both (separate binaries) | Want development-time stdio (cheap, no port) plus production HTTP  |
+
+The canonical example ships both as separate binaries —
+`mcp-server-stdio` and `mcp-server-http` — sharing one `Server`
+implementation. Match that pattern when you need transport flexibility.
+
+## In-memory duplex (for tests)
+
+For integration tests, skip the real transport and pipe two ends of a
+`tokio::io::duplex` between server and client:
+
+```rust
+let (server_transport, client_transport) = tokio::io::duplex(4096);
+let server_handle = tokio::spawn(async move {
+    let service = Server::new().serve(server_transport).await?;
+    service.waiting().await?;
+    anyhow::Ok(())
+});
+let client_service = TestClient.serve(client_transport).await?;
+// ... drive the server via client_service.send_request(...).await ...
+client_service.cancel().await?;
+let _ = server_handle.await;
+```
+
+The buffer size (`4096`) only matters for backpressure — it's not the
+message size limit. See `references/rust-sdk/client/testing.md` for the full
+test-harness pattern.
+
+## Other transports
+
+| Transport                                 | Feature flag                                   | Notes                                                                  |
+| ----------------------------------------- | ---------------------------------------------- | ---------------------------------------------------------------------- |
+| HTTP+SSE (legacy)                         | `server-side-http`                             | Deprecated by the spec in favor of Streamable HTTP; avoid for new code |
+| Unix socket Streamable HTTP (client only) | `transport-streamable-http-client-unix-socket` | Client-side only; for talking to a Unix-domain HTTP server             |
+
+## Gotchas
+
+### Forgetting `with_writer(stderr)` on stdio
+
+Symptoms: client hangs at `initialize` or returns parse errors. Cause:
+a stray `println!` or default tracing output is corrupting the JSON-RPC
+stream on stdout.
+
+### Cancellation tokens vs Ctrl+C
+
+The pattern above wires a child cancellation token into the
+`StreamableHttpServerConfig`. Cancelling the parent token also cancels
+the child — that's what makes graceful shutdown work. If you forget to
+pass `with_cancellation_token`, the server will keep running after
+axum stops accepting connections.
+
+### Session lifetime
+
+`LocalSessionManager` stores sessions in memory. They live as long as
+the process does, which means stale sessions accumulate if clients
+disconnect without sending a proper close. For long-running servers,
+either configure session timeouts via `StreamableHttpServerConfig` or
+implement a custom `SessionManager` with TTL.
+
+## See also
+
+- `references/rust-sdk/feature-flags.md` — the transport-* feature matrix
+- `references/rust-sdk/client/transports.md` — corresponding client-side wiring
+- `references/rust-sdk/client/testing.md` — duplex-transport test pattern
+- `crates/mcp-server/src/bin/stdio.rs` — stdio binary
+- `crates/mcp-server/src/bin/http.rs` — Streamable HTTP binary

--- a/.agents/skills/mcp-knowledge/references/typescript-sdk/pkce-challenge.md
+++ b/.agents/skills/mcp-knowledge/references/typescript-sdk/pkce-challenge.md
@@ -1,0 +1,94 @@
+# `pkce-challenge` breaks Vite/bundler resolution
+
+A real-world quirk of the official **TypeScript** MCP SDK
+(`@modelcontextprotocol/sdk` npm package) and its transitive dependency
+`pkce-challenge` — not part of the MCP spec itself and not applicable to
+other-language SDKs (Python, Rust, etc.), but reliably encountered when
+shipping the TypeScript SDK in browser-targeted builds.
+
+## Symptom
+
+Building an app that depends on `@modelcontextprotocol/sdk` (directly or
+transitively, e.g. via `@elmethis/qwik`'s `ag-ui-client`) fails during the
+client/SSR build with a resolver error for `pkce-challenge`, even when the app
+never reaches any OAuth code path at runtime.
+
+## Why it happens
+
+```text
+your-app
+  └─ await import('@modelcontextprotocol/sdk/client/streamableHttp.js')   ← dynamic
+       └─ import { auth, … } from './auth.js'                              ← static
+            └─ import pkceChallenge from 'pkce-challenge'                  ← static
+```
+
+- The MCP SDK's `streamableHttp.js` (any version supporting OAuth) statically
+  imports `./auth.js`, which statically imports `pkce-challenge`. Wrapping the
+  SDK in a dynamic `import()` only puts it in a separate chunk — Vite still
+  walks the full static graph of that chunk at build time.
+- `pkce-challenge`'s `package.json` (≤5.0.1) has an `exports` field with
+  `browser`, `node.import`, and `node.require` conditions but **no `default`
+  condition.** Under Vite's SSR/Qwik client builds where neither the `browser`
+  nor `node` conditions resolve cleanly, the resolver fails the whole build.
+
+## Fix (consumer app)
+
+Alias `pkce-challenge` to a local stub in `vite.config.ts`:
+
+```ts
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "pkce-challenge": fileURLToPath(
+        new URL("./src/stubs/pkce-challenge.ts", import.meta.url),
+      ),
+    },
+  },
+});
+```
+
+```ts
+// src/stubs/pkce-challenge.ts
+export default async function pkceChallenge(): Promise<{
+  code_verifier: string;
+  code_challenge: string;
+}> {
+  throw new Error("pkce-challenge is stubbed in this build");
+}
+export async function verifyChallenge(): Promise<boolean> {
+  throw new Error("pkce-challenge is stubbed in this build");
+}
+```
+
+The `throw` is deliberate. If the OAuth code path is ever reached at runtime
+you want a loud error, not silent broken crypto. If the app actually needs
+OAuth, drop the alias and ship a real implementation instead — don't quietly
+make the stub return fake values.
+
+## What *not* to do
+
+- Don't try to lazy-import the SDK to escape this — Vite resolves the static
+  graph behind every dynamic chunk, so it can't be sidestepped at the call
+  site.
+- Don't suggest the upstream library (`@elmethis/qwik`, etc.) "fix it" purely
+  in its own source — it can document the alias or ship a Vite plugin that
+  injects the alias, but it cannot remove the static import from the SDK.
+
+## Upstream fix
+
+The proper resolution is a one-line `"default": "./dist/index.node.js"` (or
+equivalent) added to `pkce-challenge`'s `exports` field, or a PR against the
+MCP SDK to lazy-import `pkce-challenge` only when an `authProvider` is
+configured. Until either lands, the consumer-side alias is the standard
+workaround.
+
+## Identifying this issue
+
+If a user reports a Vite/Rollup/Webpack resolver error mentioning
+`pkce-challenge` while building an app that uses `@modelcontextprotocol/sdk`
+(or any library that does — `ag-ui-client`, custom MCP clients, etc.), this
+is almost certainly the cause. The fix is the alias above, not a code change
+to their app or the consuming library.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -23,10 +23,5 @@
         ]
       }
     ]
-  },
-  "enabledPlugins": {
-    "web-view-transition@46ki75-plugins": true,
-    "frontend-design@claude-plugins-official": true,
-    "playwright@claude-plugins-official": true
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,4 @@
 {
-  "enabledPlugins": {
-    "web-view-transition@46ki75-plugins": true
-  },
   "hooks": {
     "PostToolUse": [
       {
@@ -26,5 +23,10 @@
         ]
       }
     ]
+  },
+  "enabledPlugins": {
+    "web-view-transition@46ki75-plugins": true,
+    "frontend-design@claude-plugins-official": true,
+    "playwright@claude-plugins-official": true
   }
 }

--- a/.claude/skills/a2ui-knowledge
+++ b/.claude/skills/a2ui-knowledge
@@ -1,0 +1,1 @@
+../../.agents/skills/a2ui-knowledge

--- a/.claude/skills/ag-ui-knowledge
+++ b/.claude/skills/ag-ui-knowledge
@@ -1,0 +1,1 @@
+../../.agents/skills/ag-ui-knowledge

--- a/.claude/skills/mcp-knowledge
+++ b/.claude/skills/mcp-knowledge
@@ -1,0 +1,1 @@
+../../.agents/skills/mcp-knowledge

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "playwright": {
+      "type": "stdio",
+      "command": "pnpx",
+      "args": [
+        "@playwright/mcp@latest"
+      ],
+      "env": {}
+    }
+  }
+}

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "playwright": {
+      "type": "local",
+      "command": ["pnpx", "@playwright/mcp@latest"],
+      "enabled": true
+    }
+  }
+}

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,23 @@
+{
+  "version": 1,
+  "skills": {
+    "a2ui-knowledge": {
+      "source": "46ki75/yaarr",
+      "sourceType": "github",
+      "skillPath": "skills/a2ui-knowledge/SKILL.md",
+      "computedHash": "c420f05d0de840a474ca0a16db3d1a64dee2b1ae00a6339cb8a7e62485725330"
+    },
+    "ag-ui-knowledge": {
+      "source": "46ki75/yaarr",
+      "sourceType": "github",
+      "skillPath": "skills/ag-ui-knowledge/SKILL.md",
+      "computedHash": "b436e348766b76c8854b23d9618ed0b62368d3e0714d862519d8cd8417878bbe"
+    },
+    "mcp-knowledge": {
+      "source": "46ki75/yaarr",
+      "sourceType": "github",
+      "skillPath": "skills/mcp-knowledge/SKILL.md",
+      "computedHash": "9a0fe387c5ea89506c857a6e8aae10907f4f77a263527dc28fda6f77a2d094d3"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Install three knowledge skills from `46ki75/yaarr` under `.agents/skills/`, pinned via `skills-lock.json`:
  - **a2ui-knowledge** — A2UI protocol reference (v0.8 / v0.9 / v1.0)
  - **ag-ui-knowledge** — AG-UI protocol reference (concepts, quickstarts, SDKs)
  - **mcp-knowledge** — MCP spec reference (2024-11-05 through 2025-11-25) plus Rust/TypeScript SDK guides
- Symlink each skill into `.claude/skills/` so Claude Code picks them up.
- Enable the `frontend-design` and `playwright` official plugins in `.claude/settings.json`.

These skills back the ongoing A2UI / AG-UI / CopilotKit work across the component libraries and the planned Rust MCP server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)