### PR TITLE
feat: add OpenCode Ikuma theme

### DIFF
--- a/packages/ikuma-theme/README.md
+++ b/packages/ikuma-theme/README.md
@@ -1,7 +1,6 @@
 # Ikuma Theme
 
-Ikuma Theme provides dark and light themes for VS Code plus matching Shiki
-syntax themes.
+Ikuma Theme provides dark and light themes for VS Code, OpenCode, and Shiki.
 
 ## VS Code
 
@@ -15,8 +14,24 @@ import ikumaDark from "@46ki75/ikuma-theme/dark";
 import ikumaLight from "@46ki75/ikuma-theme/light";
 ```
 
+## OpenCode
+
+OpenCode detects the package's included `oc-themes` entry. Add it to your
+`~/.config/opencode/tui.json`:
+
+```json
+{
+  "$schema": "https://opencode.ai/tui.json",
+  "plugin": ["@46ki75/ikuma-theme"],
+  "theme": "ikuma"
+}
+```
+
+Restart OpenCode after changing TUI configuration.
+
 ## Development
 
-`pnpm --filter ikuma-theme run build` generates the VS Code theme, Shiki
-package, Windows Terminal scheme, and VSIX. Edit `scripts/colors.ts` to change
-the shared palette and semantic color assignments.
+`pnpm --filter ikuma-theme run build` generates the VS Code theme, OpenCode
+theme, Shiki package, Windows Terminal scheme, and VSIX. Edit
+`scripts/colors.ts` to change the shared palette and semantic color
+assignments.

--- a/packages/ikuma-theme/package.json
+++ b/packages/ikuma-theme/package.json
@@ -3,7 +3,7 @@
   "displayName": "ikuma-theme",
   "description": "VS Code theme for personal use.",
   "publisher": "46ki75",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "repository": {
     "type": "git",
     "url": "https://github.com/46ki75/elmethis.git"
@@ -16,7 +16,9 @@
   "engines": {
     "vscode": "^1.120.0"
   },
-  "categories": ["Themes"],
+  "categories": [
+    "Themes"
+  ],
   "scripts": {
     "prebuild": "rimraf dist && mkdir -p dist",
     "build": "pnpm build:theme && pnpm build:npm && pnpm build:vsix",

--- a/packages/ikuma-theme/scripts/build-npm.ts
+++ b/packages/ikuma-theme/scripts/build-npm.ts
@@ -1,6 +1,7 @@
 import { mkdir, copyFile, writeFile, rm, readFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import { format, resolveConfig } from "prettier";
+import { getOpenCodeTheme } from "./opencode.ts";
 import { getShikiTheme, type GetThemeOptions } from "./theme.ts";
 
 const OUT = "dist/npm";
@@ -26,20 +27,35 @@ const targets: GetThemeOptions[] = [
 const pkg = {
   name: "@46ki75/ikuma-theme",
   version: root.version,
-  description: "Shiki syntax-highlighting themes from ikuma-theme.",
+  description:
+    "Shiki syntax-highlighting and OpenCode TUI themes from ikuma-theme.",
   license: "Apache-2.0",
   author: root.publisher,
   repository: root.repository,
   homepage: root.homepage,
   bugs: root.bugs,
-  keywords: ["shiki", "theme", "syntax-highlighting", "ikuma-theme"],
+  keywords: [
+    "shiki",
+    "opencode",
+    "theme",
+    "syntax-highlighting",
+    "ikuma-theme",
+  ],
   type: "module",
   exports: {
     "./dark": "./ikuma-dark.json",
     "./light": "./ikuma-light.json",
+    "./opencode": "./opencode/ikuma.json",
     "./package.json": "./package.json",
   },
-  files: ["ikuma-dark.json", "ikuma-light.json", "README.md", "LICENSE"],
+  "oc-themes": ["./opencode/ikuma.json"],
+  files: [
+    "ikuma-dark.json",
+    "ikuma-light.json",
+    "opencode/ikuma.json",
+    "README.md",
+    "LICENSE",
+  ],
   publishConfig: {
     access: "public",
   },
@@ -53,6 +69,7 @@ await Promise.all([
   ...targets.map((target) =>
     writeJson(`${OUT}/ikuma-${target.color}.json`, getShikiTheme(target)),
   ),
+  writeJson(`${OUT}/opencode/ikuma.json`, getOpenCodeTheme()),
   copyFile("README.md", `${OUT}/README.md`),
   copyFile("LICENSE", `${OUT}/LICENSE`),
 ]);

--- a/packages/ikuma-theme/scripts/index.ts
+++ b/packages/ikuma-theme/scripts/index.ts
@@ -2,6 +2,7 @@ import { writeFile, mkdir } from "node:fs/promises";
 import { dirname } from "node:path";
 import { format, resolveConfig } from "prettier";
 import { buildWindowsTerminal, createTheme } from "./helper.ts";
+import { getOpenCodeTheme } from "./opencode.ts";
 import { getTheme, type GetThemeOptions } from "./theme.ts";
 
 async function writeJson(file: string, data: unknown) {
@@ -37,4 +38,7 @@ await Promise.all([
 
   // Windows Terminal: both schemes in one fragment for settings.json
   writeJson("dist/windows-terminal/ikuma.json", windowsTerminal),
+
+  // OpenCode TUI theme
+  writeJson("dist/opencode-theme/ikuma.json", getOpenCodeTheme()),
 ]);

--- a/packages/ikuma-theme/scripts/opencode.ts
+++ b/packages/ikuma-theme/scripts/opencode.ts
@@ -1,0 +1,120 @@
+import { palette } from "./colors.ts";
+
+type PaletteColor = keyof typeof palette;
+
+function opaque(value: string) {
+  return value.slice(0, 7);
+}
+
+function color(name: PaletteColor) {
+  return {
+    dark: opaque(palette[name][0]),
+    light: opaque(palette[name][1]),
+  };
+}
+
+function colorPair(dark: PaletteColor, light: PaletteColor) {
+  return {
+    dark: opaque(palette[dark][0]),
+    light: opaque(palette[light][1]),
+  };
+}
+
+function blend(background: string, foreground: string, alpha: number) {
+  const rgb = (value: string) =>
+    [1, 3, 5].map((offset) =>
+      Number.parseInt(value.slice(offset, offset + 2), 16),
+    );
+  const [backgroundRed, backgroundGreen, backgroundBlue] = rgb(background);
+  const [foregroundRed, foregroundGreen, foregroundBlue] = rgb(foreground);
+  const channel = (backgroundChannel: number, foregroundChannel: number) =>
+    Math.round(
+      backgroundChannel + (foregroundChannel - backgroundChannel) * alpha,
+    )
+      .toString(16)
+      .padStart(2, "0");
+
+  return `#${channel(backgroundRed, foregroundRed)}${channel(backgroundGreen, foregroundGreen)}${channel(backgroundBlue, foregroundBlue)}`;
+}
+
+function diffBackground(name: PaletteColor) {
+  const alpha = 0x30 / 0xff;
+  return {
+    dark: blend(opaque(palette.base00[0]), opaque(palette[name][0]), alpha),
+    light: blend(opaque(palette.base00[1]), opaque(palette[name][1]), alpha),
+  };
+}
+
+export function getOpenCodeTheme() {
+  const background = color("base00");
+  const panel = color("base01");
+  const element = color("bgBrightest");
+  const text = color("base05");
+  const activeText = color("primaryBright");
+  const muted = color("base04");
+  const comment = color("base03");
+  const primary = color("primary");
+  const primaryDim = color("primaryDim");
+  const primaryDimDim = color("primaryDimDim");
+  const secondary = color("secondaryDim");
+  const success = color("emerald");
+  const error = color("crimson");
+  const addedBackground = diffBackground("emerald");
+  const removedBackground = diffBackground("crimson");
+
+  return {
+    $schema: "https://opencode.ai/theme.json",
+    theme: {
+      primary,
+      secondary,
+      accent: activeText,
+      error,
+      warning: colorPair("base0E", "primaryBright"),
+      success,
+      info: primary,
+      text,
+      textMuted: muted,
+      background,
+      backgroundPanel: panel,
+      backgroundElement: element,
+      border: primaryDimDim,
+      borderActive: primary,
+      borderSubtle: primaryDim,
+      diffAdded: success,
+      diffRemoved: error,
+      diffContext: muted,
+      diffHunkHeader: primary,
+      diffHighlightAdded: success,
+      diffHighlightRemoved: error,
+      diffAddedBg: addedBackground,
+      diffRemovedBg: removedBackground,
+      diffContextBg: background,
+      diffLineNumber: primaryDim,
+      diffAddedLineNumberBg: addedBackground,
+      diffRemovedLineNumberBg: removedBackground,
+      markdownText: text,
+      markdownHeading: activeText,
+      markdownLink: primary,
+      markdownLinkText: activeText,
+      markdownCode: color("base0D"),
+      markdownBlockQuote: comment,
+      markdownEmph: color("base0E"),
+      markdownStrong: activeText,
+      markdownHorizontalRule: primaryDim,
+      markdownListItem: primary,
+      markdownListEnumeration: activeText,
+      markdownImage: primary,
+      markdownImageText: activeText,
+      markdownCodeBlock: text,
+      syntaxComment: comment,
+      syntaxKeyword: color("base0E"),
+      syntaxFunction: color("base0D"),
+      syntaxVariable: text,
+      syntaxString: color("base0B"),
+      syntaxNumber: color("base09"),
+      syntaxType: color("base0A"),
+      syntaxOperator: text,
+      syntaxPunctuation: comment,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- generate an OpenCode TUI theme from the shared Ikuma palette
- publish the theme through the npm package's OpenCode theme metadata
- document OpenCode setup and bump ikuma-theme to 0.0.11

## Testing
- pnpm --filter ikuma-theme run check
- npm pack --dry-run