### PR TITLE
fix: preserve inline rich text in A2UI block quotes

### DIFF
--- a/packages/qwik/package.json
+++ b/packages/qwik/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elmethis/qwik",
-  "version": "1.0.0-alpha.41",
+  "version": "1.0.0-alpha.42",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/qwik/src/components/a2ui/catalog/notion-block-catalog.stories.tsx
+++ b/packages/qwik/src/components/a2ui/catalog/notion-block-catalog.stories.tsx
@@ -311,6 +311,62 @@ export const BlockQuote: Story = {
   },
 };
 
+export const BlockQuoteInlineRichText: Story = {
+  args: {
+    messages: [
+      {
+        version: "v0.9",
+        createSurface: {
+          surfaceId: "blockquote-inline-rich-text",
+          catalogId: CATALOG_ID,
+        },
+      },
+      {
+        version: "v0.9",
+        updateComponents: {
+          surfaceId: "blockquote-inline-rich-text",
+          components: [
+            {
+              component: "BlockQuote",
+              id: "root",
+              children: ["t1", "t2", "t3", "t4", "t5", "t6", "t7"],
+            },
+            { component: "RichText", id: "t1", text: "Could you " },
+            {
+              component: "RichText",
+              id: "t2",
+              text: "look",
+              color: "#b8a36e",
+              decoration: ["bold", "underline"],
+            },
+            { component: "RichText", id: "t3", text: " " },
+            {
+              component: "RichText",
+              id: "t4",
+              text: "into",
+              color: "#b8a36e",
+              decoration: ["bold", "underline"],
+            },
+            {
+              component: "RichText",
+              id: "t5",
+              text: " whether there's any way to make this ",
+            },
+            {
+              component: "RichText",
+              id: "t6",
+              text: "happen",
+              color: "#b8a36e",
+              decoration: ["bold", "underline"],
+            },
+            { component: "RichText", id: "t7", text: "?" },
+          ],
+        },
+      },
+    ],
+  },
+};
+
 // ---------------------------------------------------------------------------
 // Callout
 // ---------------------------------------------------------------------------

--- a/packages/qwik/src/components/typography/elm-block-quote.module.css
+++ b/packages/qwik/src/components/typography/elm-block-quote.module.css
@@ -18,10 +18,11 @@
 
 .body {
   box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  gap: var(--elmethis-stack-gap);
   padding: 2rem 1.5rem;
+
+  > * + * {
+    margin-block-start: var(--elmethis-stack-gap);
+  }
 }
 
 .icon {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elmethis/react",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "React component library for elmethis.",
   "publishConfig": {
     "access": "public"

--- a/packages/react/src/components/a2ui/catalog/notion-block-catalog.browser.spec.tsx
+++ b/packages/react/src/components/a2ui/catalog/notion-block-catalog.browser.spec.tsx
@@ -1,0 +1,76 @@
+import { render } from "vitest-browser-react";
+import { describe, expect, test, vi } from "vitest";
+
+import { ElmA2ui } from "../elm-a2ui";
+
+const CATALOG_ID = "https://a2ui.org/specification/v0_9/basic_catalog.json";
+
+const inlineRichTextBlockQuoteSurface = [
+  {
+    version: "v0.9",
+    createSurface: { surfaceId: "blockquote", catalogId: CATALOG_ID },
+  },
+  {
+    version: "v0.9",
+    updateComponents: {
+      surfaceId: "blockquote",
+      components: [
+        {
+          component: "BlockQuote",
+          id: "root",
+          children: ["t1", "t2", "t3", "t4", "t5", "t6", "t7"],
+        },
+        { component: "RichText", id: "t1", text: "Could you " },
+        {
+          component: "RichText",
+          id: "t2",
+          text: "look",
+          color: "#b8a36e",
+          decoration: ["bold", "underline"],
+        },
+        { component: "RichText", id: "t3", text: " " },
+        {
+          component: "RichText",
+          id: "t4",
+          text: "into",
+          color: "#b8a36e",
+          decoration: ["bold", "underline"],
+        },
+        {
+          component: "RichText",
+          id: "t5",
+          text: " whether there's any way to make this ",
+        },
+        {
+          component: "RichText",
+          id: "t6",
+          text: "happen",
+          color: "#b8a36e",
+          decoration: ["bold", "underline"],
+        },
+        { component: "RichText", id: "t7", text: "?" },
+      ],
+    },
+  },
+] as object[];
+
+describe("[CSR] notionBlockCatalog BlockQuote", () => {
+  test("keeps direct RichText children in normal inline flow", async () => {
+    const screen = await render(
+      <ElmA2ui messages={inlineRichTextBlockQuoteSurface} />,
+    );
+
+    await vi.waitFor(() => {
+      expect(screen.container.textContent).toContain(
+        "Could you look into whether there's any way to make this happen?",
+      );
+    });
+
+    const body = screen.container.querySelector(
+      "blockquote > div:nth-of-type(2)",
+    );
+    expect(body).not.toBeNull();
+    expect(body?.children).toHaveLength(7);
+    expect(getComputedStyle(body!).display).toBe("block");
+  });
+});

--- a/packages/react/src/components/a2ui/catalog/notion-block-catalog.stories.tsx
+++ b/packages/react/src/components/a2ui/catalog/notion-block-catalog.stories.tsx
@@ -300,6 +300,62 @@ export const BlockQuote: Story = {
   },
 };
 
+export const BlockQuoteInlineRichText: Story = {
+  args: {
+    messages: [
+      {
+        version: "v0.9",
+        createSurface: {
+          surfaceId: "blockquote-inline-rich-text",
+          catalogId: CATALOG_ID,
+        },
+      },
+      {
+        version: "v0.9",
+        updateComponents: {
+          surfaceId: "blockquote-inline-rich-text",
+          components: [
+            {
+              component: "BlockQuote",
+              id: "root",
+              children: ["t1", "t2", "t3", "t4", "t5", "t6", "t7"],
+            },
+            { component: "RichText", id: "t1", text: "Could you " },
+            {
+              component: "RichText",
+              id: "t2",
+              text: "look",
+              color: "#b8a36e",
+              decoration: ["bold", "underline"],
+            },
+            { component: "RichText", id: "t3", text: " " },
+            {
+              component: "RichText",
+              id: "t4",
+              text: "into",
+              color: "#b8a36e",
+              decoration: ["bold", "underline"],
+            },
+            {
+              component: "RichText",
+              id: "t5",
+              text: " whether there's any way to make this ",
+            },
+            {
+              component: "RichText",
+              id: "t6",
+              text: "happen",
+              color: "#b8a36e",
+              decoration: ["bold", "underline"],
+            },
+            { component: "RichText", id: "t7", text: "?" },
+          ],
+        },
+      },
+    ],
+  },
+};
+
 // ---------------------------------------------------------------------------
 // Callout
 // ---------------------------------------------------------------------------

--- a/packages/react/src/components/typography/elm-block-quote.module.css
+++ b/packages/react/src/components/typography/elm-block-quote.module.css
@@ -18,10 +18,11 @@
 
 .body {
   box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  gap: var(--elmethis-stack-gap);
   padding: 2rem 1.5rem;
+
+  > * + * {
+    margin-block-start: var(--elmethis-stack-gap);
+  }
 }
 
 .icon {

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elmethis/vue",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Vue 3 component library for elmethis.",
   "publishConfig": {
     "access": "public"

--- a/packages/vue/src/components/a2ui/catalog/notion-block-catalog.stories.tsx
+++ b/packages/vue/src/components/a2ui/catalog/notion-block-catalog.stories.tsx
@@ -245,6 +245,47 @@ export const BlockQuote: Story = {
   },
 };
 
+export const BlockQuoteInlineRichText: Story = {
+  args: {
+    messages: surface([
+      {
+        component: "BlockQuote",
+        id: "root",
+        children: ["t1", "t2", "t3", "t4", "t5", "t6", "t7"],
+      },
+      { component: "RichText", id: "t1", text: "Could you " },
+      {
+        component: "RichText",
+        id: "t2",
+        text: "look",
+        color: "#b8a36e",
+        decoration: ["bold", "underline"],
+      },
+      { component: "RichText", id: "t3", text: " " },
+      {
+        component: "RichText",
+        id: "t4",
+        text: "into",
+        color: "#b8a36e",
+        decoration: ["bold", "underline"],
+      },
+      {
+        component: "RichText",
+        id: "t5",
+        text: " whether there's any way to make this ",
+      },
+      {
+        component: "RichText",
+        id: "t6",
+        text: "happen",
+        color: "#b8a36e",
+        decoration: ["bold", "underline"],
+      },
+      { component: "RichText", id: "t7", text: "?" },
+    ]),
+  },
+};
+
 // ---------------------------------------------------------------------------
 // Callout
 // ---------------------------------------------------------------------------

--- a/packages/vue/src/components/typography/elm-block-quote.module.css
+++ b/packages/vue/src/components/typography/elm-block-quote.module.css
@@ -18,10 +18,11 @@
 
 .body {
   box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  gap: var(--elmethis-stack-gap);
   padding: 2rem 1.5rem;
+
+  > * + * {
+    margin-block-start: var(--elmethis-stack-gap);
+  }
 }
 
 .icon {


### PR DESCRIPTION
## Summary
- render direct A2UI `RichText` children in block quotes as inline text
- add matching Notion catalog stories for React, Qwik, and Vue
- add a React Chromium regression test and bump framework package versions

## Validation
- `pnpm exec vitest run src/components/a2ui/catalog/notion-block-catalog.spec.tsx` (React, Vue)
- `pnpm exec vitest run --config vitest.browser.config.ts src/components/a2ui/catalog/notion-block-catalog.browser.spec.tsx` (React)
- `pnpm run lint.css` and `pnpm run build.types` (React, Qwik, Vue)