### PR TITLE
fix(qwik/media): stop ElmBlockImage opacity getting stuck at 0.01

### DIFF
--- a/packages/qwik/package.json
+++ b/packages/qwik/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elmethis/qwik",
-  "version": "1.0.0-alpha.42",
+  "version": "1.0.0-alpha.43",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/qwik/src/components/media/elm-block-image.browser.spec.tsx
+++ b/packages/qwik/src/components/media/elm-block-image.browser.spec.tsx
@@ -70,3 +70,23 @@ describe("[CSR] ElmBlockImage lightbox lifecycle", () => {
     await vi.waitFor(() => expect(dialog.open).toBe(false));
   });
 });
+
+describe("[CSR] ElmBlockImage — decode failure recovery", () => {
+  // A broken image never fires `load` (only `error`), so the `onLoad$`
+  // backup never kicks in — this isolates the `useVisibleTask$` path.
+  // `decode()` rejects for real on a corrupt image. Regression for a bug
+  // where an unhandled `decode()` rejection left `isLoading` (and the
+  // `0.01` opacity applied while loading) stuck forever in SSR output.
+  const BrokenHarness = component$(() => (
+    <ElmBlockImage src="data:image/png;base64,AAAA" alt="broken" />
+  ));
+
+  test("clears the loading state instead of hanging when the image fails to decode", async () => {
+    const screen = await render(<BrokenHarness />);
+    const img = innerImg(screen);
+
+    await vi.waitFor(() =>
+      expect(img.style.getPropertyValue("--elmethis-scoped-opacity")).toBe("1"),
+    );
+  });
+});

--- a/packages/qwik/src/components/media/elm-block-image.tsx
+++ b/packages/qwik/src/components/media/elm-block-image.tsx
@@ -82,12 +82,27 @@ export const ElmBlockImage = component$<ElmBlockImageProps>((props) => {
 
   /**
    * @see {@link https://qwik.dev/docs/cookbook/detect-img-tag-onload/}
+   *
+   * `complete` is checked up front because cache-served images can already
+   * be done by the time this task runs. `decode()` is also given a
+   * rejection handler: some browsers hang or reject that promise for
+   * cached images, which would otherwise leave `isLoading` stuck forever.
    */
   // eslint-disable-next-line qwik/no-use-visible-task
   useVisibleTask$(() => {
-    imgRef.value!.decode().then(() => {
+    const img = imgRef.value!;
+    if (img.complete) {
       isLoading.value = false;
-    });
+      return;
+    }
+    img.decode().then(
+      () => {
+        isLoading.value = false;
+      },
+      () => {
+        isLoading.value = false;
+      },
+    );
   });
 
   const ImageComponent = (isModal: boolean) => (


### PR DESCRIPTION
## Summary
- `ElmBlockImage`'s `useVisibleTask$` only cleared the loading state (`isLoading` → `opacity: 0.01`) on `decode()` success; some browsers reject or never settle `decode()` for cache-served images, leaving an unhandled rejection and the image permanently stuck at `opacity: 0.01` in SSR/SSG output.
- Short-circuit on `img.complete` (cache-served images can already be done by the time the task runs) and give `decode()` a rejection handler so `isLoading` always settles either way.
- Bumps `@elmethis/qwik` to `1.0.0-alpha.43`.

## Test plan
- [x] Added a browser-layer regression test (`elm-block-image.browser.spec.tsx`) using a broken image src, which never fires `load` and whose `decode()` genuinely rejects — isolates the `useVisibleTask$` path from the `onLoad$` backup.
- [x] Verified the new test fails against the pre-fix code (times out with the opacity stuck at `0.01`, surfacing the unhandled `EncodingError` rejection) and passes against the fix.
- [x] `pnpm --filter @elmethis/qwik run test.browser` / `test.unit` for the touched spec files pass.
- [x] `pnpm --filter @elmethis/qwik run fmt.check` and `run lint` pass.