### PR TITLE
fix(media): remove block image loading fallbacks

### DIFF
--- a/packages/qwik/package.json
+++ b/packages/qwik/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elmethis/qwik",
-  "version": "1.0.0-alpha.44",
+  "version": "1.0.0-alpha.45",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/qwik/src/components/media/elm-block-image.browser.spec.tsx
+++ b/packages/qwik/src/components/media/elm-block-image.browser.spec.tsx
@@ -11,10 +11,8 @@ import { ElmBlockImage } from "./elm-block-image";
 // actual open/close path. See [[project_qwik_browser_testing]] and the sibling
 // `use-modal.browser.spec.tsx` it mirrors.
 
-// A 1x1 transparent PNG data URI loads (and `decode()`s) immediately, so
-// `isLoading` settles to false in-browser — `handleOpenModal` only opens once
-// the image has loaded. The src is inlined in the harness (not a captured
-// module const) so the lazy segment never re-imports this spec module mid-test.
+// The src is inlined in the harness (not a captured module const) so the lazy
+// segment never re-imports this spec module mid-test.
 const Harness = component$(() => {
   return (
     <ElmBlockImage
@@ -32,8 +30,6 @@ const root = (screen: Screen) => screen.container as HTMLElement;
 const dialogEl = (screen: Screen) => root(screen).querySelector("dialog")!;
 const container = (screen: Screen) =>
   root(screen).querySelector('[class*="image-container"]') as HTMLElement;
-const innerImg = (screen: Screen) =>
-  container(screen).querySelector("img") as HTMLImageElement;
 
 describe("[CSR] ElmBlockImage lightbox lifecycle", () => {
   test("dialog mounts closed and out of the top layer", async () => {
@@ -51,9 +47,6 @@ describe("[CSR] ElmBlockImage lightbox lifecycle", () => {
     const screen = await render(<Harness />);
     const dialog = dialogEl(screen);
 
-    // Wait for the image to finish loading so handleOpenModal is unblocked.
-    await vi.waitFor(() => expect(innerImg(screen).complete).toBe(true));
-
     container(screen).click();
 
     await vi.waitFor(() => expect(dialog.open).toBe(true));
@@ -68,23 +61,5 @@ describe("[CSR] ElmBlockImage lightbox lifecycle", () => {
     enlarged.click();
 
     await vi.waitFor(() => expect(dialog.open).toBe(false));
-  });
-});
-
-describe("[CSR] ElmBlockImage — broken image recovery", () => {
-  // A broken image never fires `load`, only `error` — regression for a bug
-  // where nothing cleared `isLoading` (and the `0.01` opacity applied while
-  // loading) on a failed image, leaving it stuck forever.
-  const BrokenHarness = component$(() => (
-    <ElmBlockImage src="data:image/png;base64,AAAA" alt="broken" />
-  ));
-
-  test("clears the loading state instead of hanging when the image fails to load", async () => {
-    const screen = await render(<BrokenHarness />);
-    const img = innerImg(screen);
-
-    await vi.waitFor(() =>
-      expect(img.style.getPropertyValue("--elmethis-scoped-opacity")).toBe("1"),
-    );
   });
 });

--- a/packages/qwik/src/components/media/elm-block-image.module.css
+++ b/packages/qwik/src/components/media/elm-block-image.module.css
@@ -25,21 +25,9 @@
   object-fit: contain;
   border-radius: 0.25rem;
   box-shadow: 0 0 0.125rem rgb(0 0 0 / 10%);
-  transition: opacity 400ms;
-  opacity: var(--elmethis-scoped-opacity, 1);
   user-select: none;
   aspect-ratio: var(--aspect-ratio, auto);
   cursor: var(--elmethis-scoped-cursor);
-}
-
-.fallback {
-  width: 100%;
-  height: 100%;
-  inset: 0 0 auto auto;
-  position: absolute;
-  transition: opacity 400ms;
-  opacity: var(--elmethis-scoped-opacity, 1);
-  pointer-events: none;
 }
 
 .caption-box {
@@ -49,9 +37,6 @@
   justify-content: center;
   align-items: center;
   gap: 1rem;
-  opacity: 0.75;
-  opacity: var(--elmethis-scoped-opacity, 1);
-  transition: opacity 400ms;
 
   .caption-icon {
     flex: 1;

--- a/packages/qwik/src/components/media/elm-block-image.spec.tsx
+++ b/packages/qwik/src/components/media/elm-block-image.spec.tsx
@@ -3,16 +3,9 @@ import { renderToString } from "@qwik.dev/core/server";
 
 import { ElmBlockImage } from "./elm-block-image";
 
-// ElmBlockImage renders a `<figure>` with the inline image, a rectangle-wave
-// loading fallback, an optional caption, and a `useModal` lightbox.
-//
-// This component is SSR-only at the unit layer: its mount `useVisibleTask$`
-// calls `imgRef.value.decode()` (Qwik img-onload cookbook) which `createDOM`
-// cannot service — the same family of native-`<dialog>`/visible-task limits
-// noted in `use-modal.spec.tsx` (see [[feedback_qwik_showmodal_createdom]]).
-// SSR renders the initial (loading) markup, which is exactly what we assert
-// here; the loaded image + click-to-zoom OPEN lifecycle lives in
-// `elm-block-image.browser.spec.tsx`.
+// ElmBlockImage renders a `<figure>` with the inline image, an optional
+// caption, and a `useModal` lightbox. The native `<dialog>` lifecycle is
+// covered by `elm-block-image.browser.spec.tsx`.
 
 const ssr = async (node: Parameters<typeof renderToString>[0]) =>
   (await renderToString(node, { containerTagName: "div" })).html;
@@ -29,10 +22,10 @@ describe("[SSR] ElmBlockImage — structure", () => {
     expect(html).toContain('alt="A"');
   });
 
-  test("renders the rectangle-wave loading fallback", async () => {
+  test("renders without a loading fallback", async () => {
     const html = await ssr(<ElmBlockImage src="https://example.com/a.png" />);
-    expect(html).toContain("fallback");
-    expect(html).toContain("elm-rectangle-wave");
+    expect(html).not.toContain("fallback");
+    expect(html).not.toContain("elm-rectangle-wave");
   });
 
   test("the lightbox <dialog> shell is present and closed (no enlarged image)", async () => {

--- a/packages/qwik/src/components/media/elm-block-image.tsx
+++ b/packages/qwik/src/components/media/elm-block-image.tsx
@@ -1,15 +1,8 @@
-import {
-  $,
-  component$,
-  PropsOf,
-  useSignal,
-  useVisibleTask$,
-} from "@qwik.dev/core";
+import { $, component$, PropsOf } from "@qwik.dev/core";
 
 import styles from "./elm-block-image.module.css";
 import { ElmInlineText } from "../typography/elm-inline-text";
 import { ElmMdiIcon } from "../icon/elm-mdi-icon";
-import { ElmRectangleWave } from "../fallback/elm-rectangle-wave";
 import { mdiMessageImageOutline } from "@mdi/js";
 import { useModal } from "../../hooks/use-modal";
 
@@ -50,8 +43,6 @@ export const ElmBlockImage = component$<ElmBlockImageProps>((props) => {
     enableModal,
     ...rest
   } = props;
-  const isLoading = useSignal(true);
-
   // The lightbox is a `useModal` instance: `isOpen` drives the zoom cursor,
   // `show`/`hide` open and close it, and `<ImageModal>` renders the native
   // <dialog> (top layer, backdrop, Escape-to-close).
@@ -62,16 +53,8 @@ export const ElmBlockImage = component$<ElmBlockImageProps>((props) => {
     hide: hideModal,
   } = useModal();
 
-  const handleImageLoad = $(() => {
-    isLoading.value = false;
-  });
-
-  const handleImageError = $(() => {
-    isLoading.value = false;
-  });
-
   const handleOpenModal = $(() => {
-    if ((props.enableModal ?? true) && !isLoading.value) {
+    if (props.enableModal ?? true) {
       showModal();
     }
   });
@@ -82,43 +65,8 @@ export const ElmBlockImage = component$<ElmBlockImageProps>((props) => {
     hideModal();
   });
 
-  const imgRef = useSignal<HTMLImageElement>();
-
-  /**
-   * `onLoad$`/`onError$` alone can miss a cache-served image: Qwik has no
-   * per-element listener, just one global capture-phase listener that
-   * `qwikloader` attaches once it boots, and a disk-cache hit can fire the
-   * (non-bubbling) `load`/`error` event before that bootstrap has run at
-   * all — the event is gone by the time any listener exists.
-   *
-   * `img.complete` sidesteps that: it's a synchronous property, not an
-   * event, so checking it here — once our own code is finally running —
-   * catches an already-settled image regardless of how early it settled.
-   * `strategy: "document-ready"` (not the default `intersection-observer`)
-   * matters too: this image loads eagerly regardless of viewport (no
-   * `loading="lazy"`), and the default strategy was confirmed in
-   * production to sometimes never fire at all even for an element on-screen
-   * from first paint, permanently stuck at `isLoading: true`.
-   *
-   * If `complete` is still `false` here, `qwikloader` is now definitely
-   * active (this task only ran because it is), so the native `onLoad$`/
-   * `onError$` below are race-free for whatever happens next.
-   */
-  // eslint-disable-next-line qwik/no-use-visible-task
-  useVisibleTask$(
-    () => {
-      if (imgRef.value!.complete) {
-        isLoading.value = false;
-      }
-    },
-    { strategy: "document-ready" },
-  );
-
   const ImageComponent = (isModal: boolean) => (
     <img
-      // Only the inline image owns imgRef; the modal image must not steal it
-      // (ElmModal keeps its slot mounted, so both can coexist in the DOM).
-      ref={isModal ? undefined : imgRef}
       class={styles.image}
       src={src}
       alt={alt ?? caption ?? "Image"}
@@ -128,11 +76,8 @@ export const ElmBlockImage = component$<ElmBlockImageProps>((props) => {
       height={height}
       loading={isModal ? "lazy" : undefined}
       fetchPriority={isModal ? "low" : "auto"}
-      onLoad$={handleImageLoad}
-      onError$={handleImageError}
       onClick$={isModal ? handleCloseModal : undefined}
       style={{
-        "--elmethis-scoped-opacity": isLoading.value ? 0.01 : 1,
         "--elmethis-scoped-cursor":
           (enableModal ?? true)
             ? isModalOpen.value
@@ -146,23 +91,12 @@ export const ElmBlockImage = component$<ElmBlockImageProps>((props) => {
 
   return (
     <figure class={[styles["elm-block-image"], className]} {...rest}>
-      <div
-        class={styles["image-container"]}
-        style={{ "--elmethis-scoped-opacity": isLoading.value ? 1 : 0.01 }}
-        onClick$={handleOpenModal}
-      >
+      <div class={styles["image-container"]} onClick$={handleOpenModal}>
         {ImageComponent(false)}
-
-        <div class={styles.fallback}>
-          <ElmRectangleWave />
-        </div>
       </div>
 
       {caption && (
-        <figcaption
-          class={styles["caption-box"]}
-          style={{ "--elmethis-scoped-opacity": isLoading.value ? 0.01 : 1 }}
-        >
+        <figcaption class={styles["caption-box"]}>
           <span class={styles["caption-icon"]}>
             <ElmMdiIcon d={mdiMessageImageOutline} size="1.25rem" />
           </span>

--- a/packages/qwik/src/components/others/elm-markdown.spec.tsx
+++ b/packages/qwik/src/components/others/elm-markdown.spec.tsx
@@ -96,12 +96,6 @@ describe("[CSR] ElmMarkdown — inline decorations", () => {
 });
 
 describe("[CSR] ElmMarkdown — media & code", () => {
-  // NOTE: the image case (`![alt](src)` → ElmBlockImage) is intentionally NOT
-  // unit-tested. ElmBlockImage's `useVisibleTask$` calls `imgRef.value.decode()`,
-  // which happy-dom's HTMLImageElement doesn't implement — it throws an
-  // unhandled rejection that fails the run. That mapping needs the browser
-  // layer (real `<img>.decode()`); see TESTING.md's visible-task gotchas.
-
   test("a fenced code block renders the block shell with its language caption", async () => {
     // Shiki highlighting is async; assert the synchronous block scaffolding
     // (the <figure> code block + the language caption) rather than the

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elmethis/react",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "React component library for elmethis.",
   "publishConfig": {
     "access": "public"

--- a/packages/react/src/components/media/elm-block-image.browser.spec.tsx
+++ b/packages/react/src/components/media/elm-block-image.browser.spec.tsx
@@ -5,13 +5,9 @@ import { ElmBlockImage } from "./elm-block-image";
 
 // The lightbox OPEN lifecycle (click image -> `useModal.show()` ->
 // `<dialog>.showModal()` -> top layer) needs a real browser — happy-dom does
-// not implement `showModal()` nor a real network `onLoad`/`decode()`. This
-// real-browser spec drives the actual open/close path. Mirrors the sibling
-// `use-modal.browser.spec.tsx` and `elm-modal.browser.spec.tsx`.
-
-// A 1x1 transparent PNG data URI loads (and `decode()`s) immediately, so
-// `isLoading` settles to false in-browser — `handleOpenModal` only opens once
-// the image has loaded.
+// not implement `showModal()`. This real-browser spec drives the actual
+// open/close path. Mirrors the sibling `use-modal.browser.spec.tsx` and
+// `elm-modal.browser.spec.tsx`.
 const Harness = () => (
   <ElmBlockImage
     src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=="
@@ -27,9 +23,6 @@ const root = (screen: Screen) => screen.container as HTMLElement;
 const dialogEl = (screen: Screen) => root(screen).querySelector("dialog")!;
 const containerEl = (screen: Screen) =>
   root(screen).querySelector('[class*="image-container"]') as HTMLElement;
-const innerImg = (screen: Screen) =>
-  containerEl(screen).querySelector("img") as HTMLImageElement;
-
 describe("[CSR] ElmBlockImage lightbox lifecycle", () => {
   test("dialog mounts closed and out of the top layer", async () => {
     const screen = await render(<Harness />);
@@ -45,9 +38,6 @@ describe("[CSR] ElmBlockImage lightbox lifecycle", () => {
   test("clicking the loaded image opens the lightbox with an enlarged image, and clicking it closes again", async () => {
     const screen = await render(<Harness />);
     const dialog = dialogEl(screen);
-
-    // Wait for the image to finish loading so handleOpenModal is unblocked.
-    await vi.waitFor(() => expect(innerImg(screen).complete).toBe(true));
 
     containerEl(screen).click();
 

--- a/packages/react/src/components/media/elm-block-image.module.css
+++ b/packages/react/src/components/media/elm-block-image.module.css
@@ -25,21 +25,9 @@
   object-fit: contain;
   border-radius: 0.25rem;
   box-shadow: 0 0 0.125rem rgb(0 0 0 / 10%);
-  transition: opacity 400ms;
-  opacity: var(--elmethis-scoped-opacity, 1);
   user-select: none;
   aspect-ratio: var(--elmethis-scoped-aspect-ratio, auto);
   cursor: var(--elmethis-scoped-cursor);
-}
-
-.fallback {
-  width: 100%;
-  height: 100%;
-  inset: 0 0 auto auto;
-  position: absolute;
-  transition: opacity 400ms;
-  opacity: var(--elmethis-scoped-opacity, 1);
-  pointer-events: none;
 }
 
 .caption-box {
@@ -49,8 +37,6 @@
   justify-content: center;
   align-items: center;
   gap: 1rem;
-  opacity: var(--elmethis-scoped-opacity, 0.75);
-  transition: opacity 400ms;
 
   .caption-icon {
     flex: 1;

--- a/packages/react/src/components/media/elm-block-image.spec.tsx
+++ b/packages/react/src/components/media/elm-block-image.spec.tsx
@@ -4,13 +4,9 @@ import { renderToStaticMarkup } from "react-dom/server";
 
 import { ElmBlockImage } from "./elm-block-image";
 
-// ElmBlockImage renders a `<figure>` with the inline image, a rectangle-wave
-// loading fallback, an optional caption, and a `useModal` lightbox.
-//
-// The unit layer covers structure and the CLOSED/loading markup: happy-dom
-// neither resolves `<img>.decode()` nor fires a real network `onLoad`, so the
-// loaded image + click-to-zoom OPEN lifecycle (`<dialog>.showModal()`, top
-// layer) lives in `elm-block-image.browser.spec.tsx`.
+// ElmBlockImage renders a `<figure>` with the inline image, an optional
+// caption, and a `useModal` lightbox. The native `<dialog>` lifecycle is
+// covered by `elm-block-image.browser.spec.tsx`.
 
 describe("[CSR] ElmBlockImage — structure", () => {
   test("renders a figure with the inline image pointing at src", () => {
@@ -23,14 +19,12 @@ describe("[CSR] ElmBlockImage — structure", () => {
     expect(img.getAttribute("alt")).toBe("A");
   });
 
-  test("renders the rectangle-wave loading fallback", () => {
+  test("renders without a loading fallback", () => {
     const { container } = render(
       <ElmBlockImage src="https://example.com/a.png" />,
     );
-    expect(container.querySelector('[class*="fallback"]')).toBeTruthy();
-    expect(
-      container.querySelector('[class*="elm-rectangle-wave"]'),
-    ).toBeTruthy();
+    expect(container.querySelector('[class*="fallback"]')).toBeNull();
+    expect(container.querySelector('[class*="elm-rectangle-wave"]')).toBeNull();
   });
 
   test("the lightbox <dialog> shell is present and closed (only the inline image)", () => {
@@ -101,12 +95,12 @@ describe("[SSR] ElmBlockImage", () => {
     expect(html).toContain('alt="A"');
   });
 
-  test("renders the rectangle-wave loading fallback", () => {
+  test("renders without a loading fallback", () => {
     const html = renderToStaticMarkup(
       <ElmBlockImage src="https://example.com/a.png" />,
     );
-    expect(html).toContain("fallback");
-    expect(html).toContain("elm-rectangle-wave");
+    expect(html).not.toContain("fallback");
+    expect(html).not.toContain("elm-rectangle-wave");
   });
 
   test("the lightbox <dialog> shell is present and closed (no enlarged image)", () => {

--- a/packages/react/src/components/media/elm-block-image.tsx
+++ b/packages/react/src/components/media/elm-block-image.tsx
@@ -1,17 +1,10 @@
-import {
-  useEffect,
-  useRef,
-  useState,
-  type ComponentPropsWithoutRef,
-  type CSSProperties,
-} from "react";
+import { type ComponentPropsWithoutRef, type CSSProperties } from "react";
 import { clsx } from "clsx";
 import { mdiMessageImageOutline } from "@mdi/js";
 
 import styles from "./elm-block-image.module.css";
 import { ElmInlineText } from "../typography/elm-inline-text";
 import { ElmMdiIcon } from "../icon/elm-mdi-icon";
-import { ElmRectangleWave } from "../fallback/elm-rectangle-wave";
 import { useModal } from "../../hooks/use-modal";
 
 export interface ElmBlockImageProps extends ComponentPropsWithoutRef<"figure"> {
@@ -50,8 +43,6 @@ export const ElmBlockImage = ({
   enableModal,
   ...rest
 }: ElmBlockImageProps) => {
-  const [isLoading, setIsLoading] = useState(true);
-
   // The lightbox is a `useModal` instance: `isOpen` drives the zoom cursor,
   // `show`/`hide` open and close it, and `<ImageModal>` renders the native
   // <dialog> (top layer, backdrop, Escape-to-close).
@@ -62,12 +53,8 @@ export const ElmBlockImage = ({
     hide: hideModal,
   } = useModal();
 
-  const handleImageLoad = () => {
-    setIsLoading(false);
-  };
-
   const handleOpenModal = () => {
-    if ((enableModal ?? true) && !isLoading) {
+    if (enableModal ?? true) {
       showModal();
     }
   };
@@ -78,26 +65,8 @@ export const ElmBlockImage = ({
     hideModal();
   };
 
-  const imgRef = useRef<HTMLImageElement>(null);
-
-  /**
-   * @see {@link https://qwik.dev/docs/cookbook/detect-img-tag-onload/}
-   *
-   * If the image is already cached when this mounts, `onLoad` may never fire,
-   * so settle the loading state via `decode()` too.
-   */
-  useEffect(() => {
-    imgRef.current?.decode().then(
-      () => setIsLoading(false),
-      () => {},
-    );
-  }, [src]);
-
   const ImageComponent = (isModal: boolean) => (
     <img
-      // Only the inline image owns imgRef; the modal image must not steal it
-      // (ElmModal keeps its slot mounted, so both can coexist in the DOM).
-      ref={isModal ? undefined : imgRef}
       className={styles.image}
       src={src}
       alt={alt ?? caption ?? "Image"}
@@ -107,11 +76,9 @@ export const ElmBlockImage = ({
       height={height}
       loading={isModal ? "lazy" : undefined}
       fetchPriority={isModal ? "low" : "auto"}
-      onLoad={handleImageLoad}
       onClick={isModal ? handleCloseModal : undefined}
       style={
         {
-          "--elmethis-scoped-opacity": isLoading ? 0.01 : 1,
           "--elmethis-scoped-cursor":
             (enableModal ?? true)
               ? isModalOpen
@@ -127,31 +94,12 @@ export const ElmBlockImage = ({
 
   return (
     <figure className={clsx(styles["elm-block-image"], className)} {...rest}>
-      <div
-        className={styles["image-container"]}
-        style={
-          {
-            "--elmethis-scoped-opacity": isLoading ? 1 : 0.01,
-          } as CSSProperties
-        }
-        onClick={handleOpenModal}
-      >
+      <div className={styles["image-container"]} onClick={handleOpenModal}>
         {ImageComponent(false)}
-
-        <div className={styles.fallback}>
-          <ElmRectangleWave />
-        </div>
       </div>
 
       {caption && (
-        <figcaption
-          className={styles["caption-box"]}
-          style={
-            {
-              "--elmethis-scoped-opacity": isLoading ? 0.01 : 1,
-            } as CSSProperties
-          }
-        >
+        <figcaption className={styles["caption-box"]}>
           <span className={styles["caption-icon"]}>
             <ElmMdiIcon d={mdiMessageImageOutline} size="1.25rem" />
           </span>

--- a/packages/react/src/components/others/elm-markdown.spec.tsx
+++ b/packages/react/src/components/others/elm-markdown.spec.tsx
@@ -76,12 +76,6 @@ describe("[CSR] ElmMarkdown — inline decorations", () => {
 });
 
 describe("[CSR] ElmMarkdown — media & code", () => {
-  // NOTE: the image case (`![alt](src)` → ElmBlockImage) is intentionally NOT
-  // unit-tested. ElmBlockImage's effect calls `imgRef.current.decode()`, which
-  // happy-dom's HTMLImageElement doesn't implement — it throws an unhandled
-  // rejection that fails the run. That mapping needs the browser layer (real
-  // `<img>.decode()`); see TESTING.md's visible-task gotchas.
-
   test("a fenced code block renders the block shell with its language caption", () => {
     // Shiki highlighting is async; assert the synchronous block scaffolding
     // (the <figure> code block + the language caption) rather than the

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elmethis/vue",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Vue 3 component library for elmethis.",
   "publishConfig": {
     "access": "public"

--- a/packages/vue/src/components/media/elm-block-image.browser.spec.tsx
+++ b/packages/vue/src/components/media/elm-block-image.browser.spec.tsx
@@ -6,12 +6,8 @@ import { ElmBlockImage } from "./elm-block-image";
 
 // The lightbox OPEN lifecycle (click image -> useModal.show() ->
 // <dialog>.showModal() -> top layer) needs a real browser — happy-dom does not
-// implement showModal() nor a real network load/decode(). This drives the
-// actual open/close path. Mirrors use-modal / elm-modal browser specs.
-
-// A 1x1 transparent PNG data URI loads (and decode()s) immediately, so
-// `isLoading` settles to false in-browser — `handleOpenModal` only opens once
-// the image has loaded.
+// implement showModal(). This drives the actual open/close path. Mirrors
+// use-modal / elm-modal browser specs.
 const Harness = defineComponent({
   setup() {
     return () =>
@@ -27,9 +23,6 @@ const root = (screen: Screen) => screen.container as HTMLElement;
 const dialogEl = (screen: Screen) => root(screen).querySelector("dialog")!;
 const containerEl = (screen: Screen) =>
   root(screen).querySelector('[class*="image-container"]') as HTMLElement;
-const innerImg = (screen: Screen) =>
-  containerEl(screen).querySelector("img") as HTMLImageElement;
-
 describe("[browser] ElmBlockImage lightbox lifecycle", () => {
   test("dialog mounts closed and out of the top layer", async () => {
     const screen = render(Harness);
@@ -45,15 +38,9 @@ describe("[browser] ElmBlockImage lightbox lifecycle", () => {
     const screen = render(Harness);
     const dialog = dialogEl(screen);
 
-    await vi.waitFor(() => expect(innerImg(screen).complete).toBe(true));
+    containerEl(screen).click();
 
-    // `handleOpenModal` only opens once `isLoading` has settled to false (via
-    // onLoad/decode). That can lag the image's `complete` flag, so retry the
-    // click until the dialog actually opens.
-    await vi.waitFor(() => {
-      containerEl(screen).click();
-      expect(dialog.open).toBe(true);
-    });
+    await vi.waitFor(() => expect(dialog.open).toBe(true));
     await vi.waitFor(() => expect(dialog.className).toMatch(/shown/));
     await vi.waitFor(() => expect(dialog.querySelector("img")).toBeTruthy());
 

--- a/packages/vue/src/components/media/elm-block-image.module.css
+++ b/packages/vue/src/components/media/elm-block-image.module.css
@@ -25,21 +25,9 @@
   object-fit: contain;
   border-radius: 0.25rem;
   box-shadow: 0 0 0.125rem rgb(0 0 0 / 10%);
-  transition: opacity 400ms;
-  opacity: var(--elmethis-scoped-opacity, 1);
   user-select: none;
   aspect-ratio: var(--aspect-ratio, auto);
   cursor: var(--elmethis-scoped-cursor);
-}
-
-.fallback {
-  width: 100%;
-  height: 100%;
-  inset: 0 0 auto auto;
-  position: absolute;
-  transition: opacity 400ms;
-  opacity: var(--elmethis-scoped-opacity, 1);
-  pointer-events: none;
 }
 
 .caption-box {
@@ -49,9 +37,6 @@
   justify-content: center;
   align-items: center;
   gap: 1rem;
-  opacity: 0.75;
-  opacity: var(--elmethis-scoped-opacity, 1);
-  transition: opacity 400ms;
 
   .caption-icon {
     flex: 1;

--- a/packages/vue/src/components/media/elm-block-image.spec.tsx
+++ b/packages/vue/src/components/media/elm-block-image.spec.tsx
@@ -5,13 +5,9 @@ import { renderToString } from "vue/server-renderer";
 
 import { ElmBlockImage } from "./elm-block-image";
 
-// ElmBlockImage renders a `<figure>` with the inline image, a rectangle-wave
-// loading fallback, an optional caption, and a `useModal` lightbox.
-//
-// The unit layer covers structure and the CLOSED/loading markup: happy-dom
-// neither resolves `<img>.decode()` nor fires a real network `load`, so the
-// loaded image + click-to-zoom OPEN lifecycle lives in
-// `elm-block-image.browser.spec.tsx`.
+// ElmBlockImage renders a `<figure>` with the inline image, an optional
+// caption, and a `useModal` lightbox. The native `<dialog>` lifecycle is
+// covered by `elm-block-image.browser.spec.tsx`.
 
 describe("[CSR] ElmBlockImage — structure", () => {
   test("renders a figure with the inline image pointing at src", () => {
@@ -24,12 +20,12 @@ describe("[CSR] ElmBlockImage — structure", () => {
     expect(img.attributes("alt")).toBe("A");
   });
 
-  test("renders the rectangle-wave loading fallback", () => {
+  test("renders without a loading fallback", () => {
     const wrapper = mount(ElmBlockImage, {
       props: { src: "https://example.com/a.png" },
     });
-    expect(wrapper.find('[class*="fallback"]').exists()).toBe(true);
-    expect(wrapper.find('[class*="elm-rectangle-wave"]').exists()).toBe(true);
+    expect(wrapper.find('[class*="fallback"]').exists()).toBe(false);
+    expect(wrapper.find('[class*="elm-rectangle-wave"]').exists()).toBe(false);
   });
 
   test("the lightbox <dialog> shell is present and closed (only the inline image)", () => {

--- a/packages/vue/src/components/media/elm-block-image.tsx
+++ b/packages/vue/src/components/media/elm-block-image.tsx
@@ -1,9 +1,6 @@
 import {
   defineComponent,
   h,
-  onMounted,
-  ref,
-  watch,
   type CSSProperties,
   type HTMLAttributes,
   type PropType,
@@ -14,7 +11,6 @@ import { mdiMessageImageOutline } from "@mdi/js";
 import styles from "./elm-block-image.module.css";
 import { ElmInlineText } from "../typography/elm-inline-text";
 import { ElmMdiIcon } from "../icon/elm-mdi-icon";
-import { ElmRectangleWave } from "../fallback/elm-rectangle-wave";
 import { useModal } from "../../hooks/use-modal";
 
 export interface ElmBlockImageProps extends HTMLAttributes {
@@ -60,8 +56,6 @@ export const ElmBlockImage = defineComponent({
     },
   },
   setup(props) {
-    const isLoading = ref(true);
-
     // The lightbox is a `useModal` instance: `isOpen` drives the zoom cursor,
     // `show`/`hide` open and close it, and `Modal` renders the native <dialog>.
     const {
@@ -71,21 +65,8 @@ export const ElmBlockImage = defineComponent({
       hide: hideModal,
     } = useModal();
 
-    const imgRef = ref<HTMLImageElement | null>(null);
-
-    // If the image is already cached when this mounts, `load` may never fire,
-    // so settle the loading state via `decode()` too.
-    const settle = (): void => {
-      imgRef.value?.decode().then(
-        () => (isLoading.value = false),
-        () => {},
-      );
-    };
-    onMounted(settle);
-    watch(() => props.src, settle);
-
     const handleOpenModal = (): void => {
-      if ((props.enableModal ?? true) && !isLoading.value) {
+      if (props.enableModal ?? true) {
         showModal();
       }
     };
@@ -94,9 +75,6 @@ export const ElmBlockImage = defineComponent({
 
     const renderImage = (isModal: boolean) => (
       <img
-        // Only the inline image owns imgRef; the modal image must not steal it
-        // (ElmModal keeps its slot mounted, so both can coexist in the DOM).
-        ref={isModal ? undefined : imgRef}
         class={styles.image}
         src={props.src}
         alt={props.alt ?? props.caption ?? "Image"}
@@ -105,11 +83,9 @@ export const ElmBlockImage = defineComponent({
         width={props.width}
         height={props.height}
         loading={isModal ? "lazy" : undefined}
-        onLoad={() => (isLoading.value = false)}
         onClick={isModal ? () => hideModal() : undefined}
         style={
           {
-            "--elmethis-scoped-opacity": isLoading.value ? 0.01 : 1,
             "--elmethis-scoped-cursor": modalEnabled()
               ? isModalOpen.value
                 ? "zoom-out"
@@ -128,31 +104,12 @@ export const ElmBlockImage = defineComponent({
     // inheritAttrs default: passthrough class/style merge onto the root figure.
     return () => (
       <figure class={clsx(styles["elm-block-image"])}>
-        <div
-          class={styles["image-container"]}
-          style={
-            {
-              "--elmethis-scoped-opacity": isLoading.value ? 1 : 0.01,
-            } as CSSProperties
-          }
-          onClick={handleOpenModal}
-        >
+        <div class={styles["image-container"]} onClick={handleOpenModal}>
           {renderImage(false)}
-
-          <div class={styles.fallback}>
-            <ElmRectangleWave />
-          </div>
         </div>
 
         {props.caption && (
-          <figcaption
-            class={styles["caption-box"]}
-            style={
-              {
-                "--elmethis-scoped-opacity": isLoading.value ? 0.01 : 1,
-              } as CSSProperties
-            }
-          >
+          <figcaption class={styles["caption-box"]}>
             <span class={styles["caption-icon"]}>
               <ElmMdiIcon d={mdiMessageImageOutline} size="1.25rem" />
             </span>

--- a/packages/vue/src/components/others/elm-markdown.spec.tsx
+++ b/packages/vue/src/components/others/elm-markdown.spec.tsx
@@ -77,12 +77,6 @@ describe("[CSR] ElmMarkdown — inline decorations", () => {
 });
 
 describe("[CSR] ElmMarkdown — media & code", () => {
-  // NOTE: the image case (`![alt](src)` → ElmBlockImage) is intentionally NOT
-  // unit-tested. ElmBlockImage's mount calls `imgRef.value.decode()`, which
-  // happy-dom's HTMLImageElement doesn't implement — it throws an unhandled
-  // rejection that fails the run. That mapping needs the browser layer (real
-  // `<img>.decode()`); see TESTING.md's visible-task gotchas.
-
   it("a fenced code block renders the block shell with its language caption", () => {
     // Shiki highlighting is async; assert the synchronous block scaffolding
     // (the <figure> code block + the language caption) rather than the


### PR DESCRIPTION
## Summary
- remove loading skeletons and opacity transitions from `ElmBlockImage` in Qwik, React, and Vue
- remove image load/decode state and allow the lightbox to open without waiting for image completion
- update component and browser tests for the direct-render behavior
- bump `@elmethis/react` to `0.20.0`, `@elmethis/vue` to `0.18.0`, and `@elmethis/qwik` to `1.0.0-alpha.45`

## Testing
- focused unit and browser tests for `ElmBlockImage` in Qwik, React, and Vue
- package ESLint, Stylelint, type builds, and Prettier checks
- repository pre-commit `check` hook