### PR TITLE
chore(deps-dev): bump @qwik.dev/core

### DIFF
--- a/packages/qwik/package.json
+++ b/packages/qwik/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elmethis/qwik",
-  "version": "1.0.0-alpha.45",
+  "version": "1.0.0-alpha.46",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/qwik/package.json
+++ b/packages/qwik/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@eslint/js": "latest",
-    "@qwik.dev/core": "2.0.0-beta.36",
+    "@qwik.dev/core": "2.0.0-beta.38",
     "@storybook/addon-docs": "^10.5.2",
     "@types/lodash-es": "^4.17.12",
     "@types/node": "26.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -265,8 +265,8 @@ importers:
         specifier: latest
         version: 10.0.1(eslint@10.7.0(jiti@2.4.2))
       '@qwik.dev/core':
-        specifier: 2.0.0-beta.36
-        version: 2.0.0-beta.36(prettier@3.9.5)(vite@7.3.5(@types/node@26.1.1)(jiti@2.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.39.0)(tsx@4.23.1)(yaml@2.8.3))(vitest@4.1.8)
+        specifier: 2.0.0-beta.38
+        version: 2.0.0-beta.38(prettier@3.9.5)(vite@7.3.5(@types/node@26.1.1)(jiti@2.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.39.0)(tsx@4.23.1)(yaml@2.8.3))(vitest@4.1.8)
       '@storybook/addon-docs':
         specifier: ^10.5.2
         version: 10.5.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(rollup@4.61.1)(storybook@10.5.2(@types/react@19.2.17)(prettier@3.9.5)(react@19.2.7))(vite@7.3.5(@types/node@26.1.1)(jiti@2.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.39.0)(tsx@4.23.1)(yaml@2.8.3))
@@ -317,7 +317,7 @@ importers:
         version: 10.5.2(@types/react@19.2.17)(prettier@3.9.5)(react@19.2.7)
       storybook-framework-qwik:
         specifier: 0.6.2--canary.95.25602496384.0
-        version: 0.6.2--canary.95.25602496384.0(@qwik.dev/core@2.0.0-beta.36(prettier@3.9.5)(vite@7.3.5(@types/node@26.1.1)(jiti@2.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.39.0)(tsx@4.23.1)(yaml@2.8.3))(vitest@4.1.8))(esbuild@0.28.1)(rollup@4.61.1)(storybook@10.5.2(@types/react@19.2.17)(prettier@3.9.5)(react@19.2.7))(typescript@5.9.3)(vite@7.3.5(@types/node@26.1.1)(jiti@2.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.39.0)(tsx@4.23.1)(yaml@2.8.3))
+        version: 0.6.2--canary.95.25602496384.0(@qwik.dev/core@2.0.0-beta.38(prettier@3.9.5)(vite@7.3.5(@types/node@26.1.1)(jiti@2.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.39.0)(tsx@4.23.1)(yaml@2.8.3))(vitest@4.1.8))(esbuild@0.28.1)(rollup@4.61.1)(storybook@10.5.2(@types/react@19.2.17)(prettier@3.9.5)(react@19.2.7))(typescript@5.9.3)(vite@7.3.5(@types/node@26.1.1)(jiti@2.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.39.0)(tsx@4.23.1)(yaml@2.8.3))
       stylelint:
         specifier: ^17.14.0
         version: 17.14.0(typescript@5.9.3)
@@ -350,7 +350,7 @@ importers:
         version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.10.6)(vite@7.3.5(@types/node@26.1.1)(jiti@2.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.39.0)(tsx@4.23.1)(yaml@2.8.3))
       vitest-browser-qwik:
         specifier: ^0.3.8
-        version: 0.3.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@qwik.dev/core@2.0.0-beta.36(prettier@3.9.5)(vite@7.3.5(@types/node@26.1.1)(jiti@2.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.39.0)(tsx@4.23.1)(yaml@2.8.3))(vitest@4.1.8))(vite@7.3.5(@types/node@26.1.1)(jiti@2.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.39.0)(tsx@4.23.1)(yaml@2.8.3))(vitest@4.1.8)
+        version: 0.3.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@qwik.dev/core@2.0.0-beta.38(prettier@3.9.5)(vite@7.3.5(@types/node@26.1.1)(jiti@2.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.39.0)(tsx@4.23.1)(yaml@2.8.3))(vitest@4.1.8))(vite@7.3.5(@types/node@26.1.1)(jiti@2.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.39.0)(tsx@4.23.1)(yaml@2.8.3))(vitest@4.1.8)
 
   packages/react:
     dependencies:
@@ -2709,8 +2709,8 @@ packages:
   '@quansync/fs@1.0.0':
     resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
 
-  '@qwik.dev/core@2.0.0-beta.36':
-    resolution: {integrity: sha512-j7+HhecfMSrn97vjELu58PuA9yu+cx0Q/0VIYmfC39mPDP2lnvRvdMTodTa0HEMRuk+SRYP/XKDOXJO0u6VUYA==}
+  '@qwik.dev/core@2.0.0-beta.38':
+    resolution: {integrity: sha512-+tOWhOzHugMnNMoZ1hWSXJpakXvzdZRXlIL92DLjJM0e6EJiQVdVAd59HRazoKhCdyKa8Lhv43VX5synTgEJQQ==}
     engines: {node: ^20.3.0 || >=21.0.0}
     hasBin: true
     peerDependencies:
@@ -10901,7 +10901,7 @@ snapshots:
     dependencies:
       quansync: 1.0.0
 
-  '@qwik.dev/core@2.0.0-beta.36(prettier@3.9.5)(vite@7.3.5(@types/node@26.1.1)(jiti@2.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.39.0)(tsx@4.23.1)(yaml@2.8.3))(vitest@4.1.8)':
+  '@qwik.dev/core@2.0.0-beta.38(prettier@3.9.5)(vite@7.3.5(@types/node@26.1.1)(jiti@2.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.39.0)(tsx@4.23.1)(yaml@2.8.3))(vitest@4.1.8)':
     dependencies:
       '@qwik.dev/optimizer': 2.1.0-beta.5
       csstype: 3.2.3
@@ -10915,12 +10915,12 @@ snapshots:
 
   '@qwik.dev/optimizer@2.1.0-beta.5': {}
 
-  '@qwik.dev/router@2.0.0-beta.34(@qwik.dev/core@2.0.0-beta.36(prettier@3.9.5)(vite@7.3.5(@types/node@26.1.1)(jiti@2.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.39.0)(tsx@4.23.1)(yaml@2.8.3))(vitest@4.1.8))(rollup@4.61.1)(typescript@5.9.3)(vite@7.3.5(@types/node@26.1.1)(jiti@2.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.39.0)(tsx@4.23.1)(yaml@2.8.3))':
+  '@qwik.dev/router@2.0.0-beta.34(@qwik.dev/core@2.0.0-beta.38(prettier@3.9.5)(vite@7.3.5(@types/node@26.1.1)(jiti@2.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.39.0)(tsx@4.23.1)(yaml@2.8.3))(vitest@4.1.8))(rollup@4.61.1)(typescript@5.9.3)(vite@7.3.5(@types/node@26.1.1)(jiti@2.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.39.0)(tsx@4.23.1)(yaml@2.8.3))':
     dependencies:
       '@azure/functions': 3.5.1
       '@mdx-js/mdx': 3.1.1
       '@netlify/edge-functions': 3.0.6
-      '@qwik.dev/core': 2.0.0-beta.36(prettier@3.9.5)(vite@7.3.5(@types/node@26.1.1)(jiti@2.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.39.0)(tsx@4.23.1)(yaml@2.8.3))(vitest@4.1.8)
+      '@qwik.dev/core': 2.0.0-beta.38(prettier@3.9.5)(vite@7.3.5(@types/node@26.1.1)(jiti@2.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.39.0)(tsx@4.23.1)(yaml@2.8.3))(vitest@4.1.8)
       '@types/mdx': 2.0.13
       estree-util-value-to-estree: 3.5.0
       github-slugger: 2.0.0
@@ -17361,14 +17361,14 @@ snapshots:
       es-errors: 1.3.0
       internal-slot: 1.1.0
 
-  storybook-framework-qwik@0.6.2--canary.95.25602496384.0(@qwik.dev/core@2.0.0-beta.36(prettier@3.9.5)(vite@7.3.5(@types/node@26.1.1)(jiti@2.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.39.0)(tsx@4.23.1)(yaml@2.8.3))(vitest@4.1.8))(esbuild@0.28.1)(rollup@4.61.1)(storybook@10.5.2(@types/react@19.2.17)(prettier@3.9.5)(react@19.2.7))(typescript@5.9.3)(vite@7.3.5(@types/node@26.1.1)(jiti@2.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.39.0)(tsx@4.23.1)(yaml@2.8.3)):
+  storybook-framework-qwik@0.6.2--canary.95.25602496384.0(@qwik.dev/core@2.0.0-beta.38(prettier@3.9.5)(vite@7.3.5(@types/node@26.1.1)(jiti@2.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.39.0)(tsx@4.23.1)(yaml@2.8.3))(vitest@4.1.8))(esbuild@0.28.1)(rollup@4.61.1)(storybook@10.5.2(@types/react@19.2.17)(prettier@3.9.5)(react@19.2.7))(typescript@5.9.3)(vite@7.3.5(@types/node@26.1.1)(jiti@2.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.39.0)(tsx@4.23.1)(yaml@2.8.3)):
     dependencies:
-      '@qwik.dev/core': 2.0.0-beta.36(prettier@3.9.5)(vite@7.3.5(@types/node@26.1.1)(jiti@2.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.39.0)(tsx@4.23.1)(yaml@2.8.3))(vitest@4.1.8)
+      '@qwik.dev/core': 2.0.0-beta.38(prettier@3.9.5)(vite@7.3.5(@types/node@26.1.1)(jiti@2.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.39.0)(tsx@4.23.1)(yaml@2.8.3))(vitest@4.1.8)
       '@storybook/builder-vite': 10.4.0(esbuild@0.28.1)(rollup@4.61.1)(storybook@10.5.2(@types/react@19.2.17)(prettier@3.9.5)(react@19.2.7))(vite@7.3.5(@types/node@26.1.1)(jiti@2.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.39.0)(tsx@4.23.1)(yaml@2.8.3))
       magic-string: 0.30.21
       react-docgen-typescript: 2.4.0(typescript@5.9.3)
     optionalDependencies:
-      '@qwik.dev/router': 2.0.0-beta.34(@qwik.dev/core@2.0.0-beta.36(prettier@3.9.5)(vite@7.3.5(@types/node@26.1.1)(jiti@2.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.39.0)(tsx@4.23.1)(yaml@2.8.3))(vitest@4.1.8))(rollup@4.61.1)(typescript@5.9.3)(vite@7.3.5(@types/node@26.1.1)(jiti@2.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.39.0)(tsx@4.23.1)(yaml@2.8.3))
+      '@qwik.dev/router': 2.0.0-beta.34(@qwik.dev/core@2.0.0-beta.38(prettier@3.9.5)(vite@7.3.5(@types/node@26.1.1)(jiti@2.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.39.0)(tsx@4.23.1)(yaml@2.8.3))(vitest@4.1.8))(rollup@4.61.1)(typescript@5.9.3)(vite@7.3.5(@types/node@26.1.1)(jiti@2.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.39.0)(tsx@4.23.1)(yaml@2.8.3))
     transitivePeerDependencies:
       - esbuild
       - rollup
@@ -18221,10 +18221,10 @@ snapshots:
       tsx: 4.23.1
       yaml: 2.8.3
 
-  vitest-browser-qwik@0.3.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@qwik.dev/core@2.0.0-beta.36(prettier@3.9.5)(vite@7.3.5(@types/node@26.1.1)(jiti@2.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.39.0)(tsx@4.23.1)(yaml@2.8.3))(vitest@4.1.8))(vite@7.3.5(@types/node@26.1.1)(jiti@2.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.39.0)(tsx@4.23.1)(yaml@2.8.3))(vitest@4.1.8):
+  vitest-browser-qwik@0.3.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@qwik.dev/core@2.0.0-beta.38(prettier@3.9.5)(vite@7.3.5(@types/node@26.1.1)(jiti@2.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.39.0)(tsx@4.23.1)(yaml@2.8.3))(vitest@4.1.8))(vite@7.3.5(@types/node@26.1.1)(jiti@2.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.39.0)(tsx@4.23.1)(yaml@2.8.3))(vitest@4.1.8):
     dependencies:
       '@oxc-project/types': 0.95.0
-      '@qwik.dev/core': 2.0.0-beta.36(prettier@3.9.5)(vite@7.3.5(@types/node@26.1.1)(jiti@2.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.39.0)(tsx@4.23.1)(yaml@2.8.3))(vitest@4.1.8)
+      '@qwik.dev/core': 2.0.0-beta.38(prettier@3.9.5)(vite@7.3.5(@types/node@26.1.1)(jiti@2.4.2)(lightningcss@1.32.0)(sass@1.101.0)(terser@5.39.0)(tsx@4.23.1)(yaml@2.8.3))(vitest@4.1.8)
       magic-string: 0.30.21
       oxc-parser: 0.95.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       oxc-resolver: 11.20.0


### PR DESCRIPTION
## Summary
- bump `@qwik.dev/core` from `2.0.0-beta.36` to `2.0.0-beta.38`
- refresh the pnpm lockfile for the updated Qwik resolution

## Testing
- `pnpm --filter @elmethis/core run build`
- `pnpm --filter @elmethis/qwik run check`
- `pnpm --filter @elmethis/qwik run build.lib`
- `pnpm --filter @elmethis/qwik run test.unit`
- `pnpm --filter @elmethis/qwik run test.browser`