### PR TITLE
fix: preserve SolidJS host theme

### DIFF
--- a/packages/solid/src/primitives/create-elmethis-theme.browser.spec.tsx
+++ b/packages/solid/src/primitives/create-elmethis-theme.browser.spec.tsx
@@ -39,6 +39,18 @@ describe("[Browser] createElmethisTheme", () => {
     expect(document.documentElement).toHaveAttribute("data-theme", "dark");
   });
 
+  it("preserves a host-provided theme when no choice is stored", async () => {
+    document.documentElement.style.colorScheme = "dark";
+    document.documentElement.setAttribute("data-theme", "dark");
+
+    render(() => <ThemeHarness />);
+
+    await vi.waitFor(() =>
+      expect(document.documentElement).toHaveAttribute("data-theme", "dark"),
+    );
+    expect(document.documentElement.style.colorScheme).toBe("dark");
+  });
+
   it("toggles and observes a native cross-tab storage event", async () => {
     localStorage.setItem(KEY, "light");
     const rendered = render(() => <ThemeHarness />);

--- a/packages/solid/src/primitives/create-elmethis-theme.ts
+++ b/packages/solid/src/primitives/create-elmethis-theme.ts
@@ -93,7 +93,7 @@ export function createElmethisTheme(): ElmethisThemeController {
     setIsDarkTheme(
       storedTheme === null ? resolveAutoTheme() : storedTheme === "dark",
     );
-    applyTheme(storedTheme, false);
+    if (storedTheme !== null) applyTheme(storedTheme, false);
 
     onCleanup(() => {
       window.removeEventListener(THEME_CHANGE_EVENT, onThemeChange);


### PR DESCRIPTION
## Summary
- preserve Storybook-provided `color-scheme` and `data-theme` values when no Elmethis preference is stored
- keep persisted theme hydration behavior unchanged
- add a browser regression test for host-provided themes

## Testing
- `pnpm exec vitest run --config vitest.browser.config.ts src/primitives/create-elmethis-theme.browser.spec.tsx`
- `pnpm exec prettier --check src/primitives/create-elmethis-theme.ts src/primitives/create-elmethis-theme.browser.spec.tsx`
- `pnpm exec eslint src/primitives/create-elmethis-theme.ts src/primitives/create-elmethis-theme.browser.spec.tsx`
- `pnpm run build.types`
- `pnpm run build-storybook`
- repository pre-commit `check` hook