### PR TITLE
fix: show React parallax backgrounds

### DIFF
--- a/packages/react/src/components/containments/elm-parallax.browser.spec.tsx
+++ b/packages/react/src/components/containments/elm-parallax.browser.spec.tsx
@@ -1,0 +1,14 @@
+import { render } from "vitest-browser-react";
+import { describe, expect, it } from "vitest";
+
+import { ElmParallax } from "./elm-parallax";
+
+describe("[Browser] ElmParallax", () => {
+  it("keeps background layers above the document canvas", async () => {
+    const rendered = await render(<ElmParallax images={["/layer.png"]} />);
+    const root = rendered.container.firstElementChild as HTMLElement;
+
+    expect(getComputedStyle(root).isolation).toBe("isolate");
+    expect(getComputedStyle(root).pointerEvents).toBe("none");
+  });
+});

--- a/packages/react/src/components/containments/elm-parallax.module.css
+++ b/packages/react/src/components/containments/elm-parallax.module.css
@@ -1,3 +1,8 @@
+.elm-parallax {
+  isolation: isolate;
+  pointer-events: none;
+}
+
 .parallax-watcher {
   display: none;
   z-index: -1;

--- a/packages/react/src/components/containments/elm-parallax.tsx
+++ b/packages/react/src/components/containments/elm-parallax.tsx
@@ -4,6 +4,7 @@ import {
   type ComponentPropsWithoutRef,
   type CSSProperties,
 } from "react";
+import { clsx } from "clsx";
 
 import styles from "./elm-parallax.module.css";
 
@@ -30,7 +31,7 @@ export const ElmParallax = ({
   }, []);
 
   return (
-    <div className={className} {...props}>
+    <div className={clsx(styles["elm-parallax"], className)} {...props}>
       <div className={styles["parallax-watcher"]}></div>
 
       {images.map((image, index) => (


### PR DESCRIPTION
## Summary
- keep negative parallax layers above the document canvas with an isolated stacking context
- prevent decorative layers from intercepting pointer interactions
- add browser regression coverage for the stacking and pointer behavior

## Testing
- `pnpm exec vitest run src/components/containments/elm-parallax.spec.tsx`
- `pnpm exec vitest run --config vitest.browser.config.ts src/components/containments/elm-parallax.browser.spec.tsx`
- `pnpm exec prettier --check src/components/containments/elm-parallax.tsx src/components/containments/elm-parallax.module.css src/components/containments/elm-parallax.browser.spec.tsx`
- `pnpm exec eslint src/components/containments/elm-parallax.tsx src/components/containments/elm-parallax.browser.spec.tsx`
- `pnpm exec stylelint src/components/containments/elm-parallax.module.css`
- `pnpm run build.types`
- `pnpm run build-storybook`
- repository pre-commit `check` hook
- manual verification in the Storybook iframe