### PR TITLE
fix: show SolidJS parallax backgrounds

### DIFF
--- a/packages/solid/src/components/containments/elm-parallax.browser.spec.tsx
+++ b/packages/solid/src/components/containments/elm-parallax.browser.spec.tsx
@@ -4,6 +4,18 @@ import { describe, expect, it, vi } from "vitest";
 import { ElmParallax } from "./elm-parallax";
 
 describe("[Browser] ElmParallax", () => {
+  it("renders data URLs above the document canvas", () => {
+    const image =
+      "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3C/svg%3E";
+    const rendered = render(() => <ElmParallax images={[image]} />);
+    const root = rendered.container.firstElementChild as HTMLElement;
+    const layer = root.querySelector<HTMLElement>("[aria-hidden='true']");
+
+    expect(getComputedStyle(root).isolation).toBe("isolate");
+    expect(getComputedStyle(root).pointerEvents).toBe("none");
+    expect(layer?.style.backgroundImage).toContain(image);
+  });
+
   it("tracks real window scrolling and cleans up the listener", async () => {
     const removeEventListener = vi.spyOn(window, "removeEventListener");
     const rendered = render(() => (

--- a/packages/solid/src/components/containments/elm-parallax.module.css
+++ b/packages/solid/src/components/containments/elm-parallax.module.css
@@ -1,3 +1,8 @@
+.elm-parallax {
+  isolation: isolate;
+  pointer-events: none;
+}
+
 .parallax-watcher {
   display: none;
   z-index: -1;

--- a/packages/solid/src/components/containments/elm-parallax.tsx
+++ b/packages/solid/src/components/containments/elm-parallax.tsx
@@ -6,6 +6,7 @@ import {
   splitProps,
   type JSX,
 } from "solid-js";
+import { clsx } from "clsx";
 
 import styles from "./elm-parallax.module.css";
 
@@ -25,7 +26,7 @@ export const ElmParallax = (props: ElmParallaxProps) => {
   });
 
   return (
-    <div class={local.class} {...rest}>
+    <div class={clsx(styles["elm-parallax"], local.class)} {...rest}>
       <div class={styles["parallax-watcher"]} />
       <For each={local.images}>
         {(image, index) => (
@@ -33,7 +34,7 @@ export const ElmParallax = (props: ElmParallaxProps) => {
             aria-hidden="true"
             class={styles.parallax}
             style={{
-              "background-image": `url(${image})`,
+              "background-image": `url(${JSON.stringify(image)})`,
               transform: `scale(1.2) translateY(${scrollY() / (1000 * (index() + 1))}%)`,
               "transform-origin": "bottom",
             }}


### PR DESCRIPTION
## Summary
- quote SolidJS parallax image URLs so SVG data URLs remain valid CSS values
- keep negative parallax layers above the document canvas with an isolated stacking context
- prevent decorative layers from intercepting pointer interactions
- extend browser coverage for data URLs and computed stacking styles

## Testing
- `pnpm exec vitest run src/components/containments/elm-parallax.spec.tsx`
- `pnpm exec vitest run --config vitest.browser.config.ts src/components/containments/elm-parallax.browser.spec.tsx`
- `pnpm exec prettier --check src/components/containments/elm-parallax.tsx src/components/containments/elm-parallax.module.css src/components/containments/elm-parallax.browser.spec.tsx`
- `pnpm exec eslint src/components/containments/elm-parallax.tsx src/components/containments/elm-parallax.browser.spec.tsx`
- `pnpm exec stylelint src/components/containments/elm-parallax.module.css`
- `pnpm run build.types`
- `pnpm run build-storybook`
- repository pre-commit `check` hook
- live Solid Storybook iframe verification