### PR TITLE
fix: include core tokens in framework styles

### DIFF
--- a/.github/workflows/qwik.yml
+++ b/.github/workflows/qwik.yml
@@ -97,6 +97,10 @@ jobs:
         run: pnpm run build
         working-directory: packages/qwik
 
+      - name: Test style artifact
+        run: pnpm run test.style
+        working-directory: packages/qwik
+
   build-storybook:
     name: Build Storybook (@elmethis/qwik)
     runs-on: ubuntu-latest

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -127,6 +127,10 @@ jobs:
         run: pnpm run build
         working-directory: packages/react
 
+      - name: Test style artifact
+        run: pnpm run test.style
+        working-directory: packages/react
+
   build-storybook:
     name: Build Storybook (@elmethis/react)
     runs-on: ubuntu-latest

--- a/.github/workflows/vue.yml
+++ b/.github/workflows/vue.yml
@@ -127,6 +127,10 @@ jobs:
         run: pnpm run build
         working-directory: packages/vue
 
+      - name: Test style artifact
+        run: pnpm run test.style
+        working-directory: packages/vue
+
   build-storybook:
     name: Build Storybook (@elmethis/vue)
     runs-on: ubuntu-latest

--- a/packages/qwik/package.json
+++ b/packages/qwik/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elmethis/qwik",
-  "version": "1.0.0-alpha.46",
+  "version": "1.0.0-alpha.47",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/qwik/package.json
+++ b/packages/qwik/package.json
@@ -55,6 +55,7 @@
     "test.coverage": "vitest --run --coverage",
     "test.browser": "vitest --run --config vitest.browser.config.ts",
     "test.coverage.browser": "vitest --run --coverage --config vitest.browser.config.ts",
+    "test.style": "node ../../scripts/verify-framework-style.mjs .",
     "test.build": "pnpm run build && pnpm run build-storybook",
     "check": "concurrently -g \"pnpm:fmt.check\" \"pnpm:lint\" \"pnpm:lint.css\" \"pnpm:build.types\"",
     "check.ci": "concurrently -g \"pnpm:check\" \"pnpm:test.build\" \"pnpm:test.unit\" \"pnpm:test.browser\"",

--- a/packages/qwik/vite.config.ts
+++ b/packages/qwik/vite.config.ts
@@ -4,7 +4,10 @@ import { qwikVite } from "@qwik.dev/core/optimizer";
 import tsconfigPaths from "vite-tsconfig-paths";
 
 const { dependencies = {}, peerDependencies = {} } = pkg as any;
-const makeRegex = (dep: string) => new RegExp(`^${dep}(/.*)?$`);
+const makeRegex = (dep: string) =>
+  dep === "@elmethis/core"
+    ? /^@elmethis\/core(?:\/(?!tokens\.css$).*)?$/
+    : new RegExp(`^${dep}(/.*)?$`);
 const excludeAll = (obj: Record<string, any>) =>
   Object.keys(obj).map(makeRegex);
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -52,6 +52,7 @@
     "test.coverage": "vitest --run --coverage",
     "test.browser": "vitest --run --config vitest.browser.config.ts",
     "test.coverage.browser": "vitest --run --coverage --config vitest.browser.config.ts",
+    "test.style": "node ../../scripts/verify-framework-style.mjs .",
     "test.build": "pnpm run build && pnpm run build-storybook",
     "check": "concurrently -g \"pnpm:fmt.check\" \"pnpm:lint\" \"pnpm:lint.css\" \"pnpm:build.types\"",
     "check.ci": "concurrently -g \"pnpm:check\" \"pnpm:test.build\" \"pnpm:test.unit\" \"pnpm:test.browser\"",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elmethis/react",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "React component library for elmethis.",
   "publishConfig": {
     "access": "public"

--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -9,7 +9,10 @@ const { dependencies = {}, peerDependencies = {} } = pkg as {
   dependencies?: Record<string, string>;
   peerDependencies?: Record<string, string>;
 };
-const makeRegex = (dep: string) => new RegExp(`^${dep}(/.*)?$`);
+const makeRegex = (dep: string) =>
+  dep === "@elmethis/core"
+    ? /^@elmethis\/core(?:\/(?!tokens\.css$).*)?$/
+    : new RegExp(`^${dep}(/.*)?$`);
 const excludeAll = (obj: Record<string, string>) =>
   Object.keys(obj).map(makeRegex);
 

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elmethis/solid",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "SolidJS component library for elmethis.",
   "publishConfig": {
     "access": "public"

--- a/packages/solid/scripts/test-package.mjs
+++ b/packages/solid/scripts/test-package.mjs
@@ -321,13 +321,26 @@ export const components = <><ElmInlineText {...textProps}>Text</ElmInlineText><E
     path.join(consumerDirectory, "node_modules/@elmethis/solid/lib/style.css"),
     "utf8",
   );
+  const tokenDeclarationIndex = packedStyle.search(
+    /--elmethis-color-primary\s*:/,
+  );
+  const componentStyleIndex = packedStyle.indexOf("elm-divider");
   if (
-    !packedStyle.includes("elm-divider") ||
+    componentStyleIndex < 0 ||
     !packedStyle.includes("elm-inline-icon") ||
-    !packedStyle.includes("elm-inline-text") ||
-    !packedStyle.includes("--elmethis-color-primary")
+    !packedStyle.includes("elm-inline-text")
   ) {
     throw new Error("Packed style.css does not contain ElmDivider styles");
+  }
+  if (tokenDeclarationIndex < 0) {
+    throw new Error(
+      "Packed style.css does not contain core token declarations",
+    );
+  }
+  if (tokenDeclarationIndex > componentStyleIndex) {
+    throw new Error(
+      "Packed style.css does not place core tokens before component styles",
+    );
   }
 
   console.log("Solid package consumer smoke tests passed.");

--- a/packages/solid/vite.config.ts
+++ b/packages/solid/vite.config.ts
@@ -9,7 +9,11 @@ const { dependencies = {}, peerDependencies = {} } = pkg as {
   peerDependencies?: Record<string, string>;
 };
 const makeRegex = (dependency: string) =>
-  new RegExp(`^${dependency.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}(?:/.*)?$`);
+  dependency === "@elmethis/core"
+    ? /^@elmethis\/core(?:\/(?!tokens\.css$).*)?$/
+    : new RegExp(
+        `^${dependency.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}(?:/.*)?$`,
+      );
 const externalDependencies = [dependencies, peerDependencies].flatMap(
   (dependencyGroup) => Object.keys(dependencyGroup).map(makeRegex),
 );

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elmethis/vue",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Vue 3 component library for elmethis.",
   "publishConfig": {
     "access": "public"

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -57,6 +57,7 @@
     "test.coverage": "vitest --run --coverage",
     "test.browser": "vitest --run --config vitest.browser.config.ts",
     "test.coverage.browser": "vitest --run --coverage --config vitest.browser.config.ts",
+    "test.style": "node ../../scripts/verify-framework-style.mjs .",
     "test.build": "pnpm run build && pnpm run build-storybook",
     "check": "concurrently -g \"pnpm:fmt.check\" \"pnpm:lint\" \"pnpm:lint.css\" \"pnpm:build.types\"",
     "check.ci": "concurrently -g \"pnpm:check\" \"pnpm:test.build\" \"pnpm:test.unit\" \"pnpm:test.browser\"",

--- a/packages/vue/vite.config.ts
+++ b/packages/vue/vite.config.ts
@@ -9,7 +9,10 @@ const { dependencies = {}, peerDependencies = {} } = pkg as {
   dependencies?: Record<string, string>;
   peerDependencies?: Record<string, string>;
 };
-const makeRegex = (dep: string) => new RegExp(`^${dep}(/.*)?$`);
+const makeRegex = (dep: string) =>
+  dep === "@elmethis/core"
+    ? /^@elmethis\/core(?:\/(?!tokens\.css$).*)?$/
+    : new RegExp(`^${dep}(/.*)?$`);
 const excludeAll = (obj: Record<string, string>) =>
   Object.keys(obj).map(makeRegex);
 

--- a/scripts/verify-framework-style.mjs
+++ b/scripts/verify-framework-style.mjs
@@ -1,0 +1,39 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+const packageDirectory = path.resolve(process.argv[2] ?? ".");
+const manifest = JSON.parse(
+  await readFile(path.join(packageDirectory, "package.json"), "utf8"),
+);
+const styleExport = manifest.exports?.["./style.css"]?.default;
+
+if (typeof styleExport !== "string") {
+  throw new Error(`${manifest.name} does not export ./style.css`);
+}
+
+const style = await readFile(
+  path.resolve(packageDirectory, styleExport),
+  "utf8",
+);
+const tokenDeclarationIndex = style.search(/--elmethis-color-primary\s*:/);
+const componentStyleIndex = style.indexOf("elm-divider");
+
+if (tokenDeclarationIndex < 0) {
+  throw new Error(
+    `${manifest.name} style.css does not contain core token declarations`,
+  );
+}
+
+if (componentStyleIndex < 0) {
+  throw new Error(
+    `${manifest.name} style.css does not contain component styles`,
+  );
+}
+
+if (tokenDeclarationIndex > componentStyleIndex) {
+  throw new Error(
+    `${manifest.name} style.css does not place core tokens before component styles`,
+  );
+}
+
+console.log(`${manifest.name} style.css is self-contained.`);


### PR DESCRIPTION
## Summary

- bundle `@elmethis/core/tokens.css` into each framework package style export
- add artifact checks that require actual token declarations before component styles
- bump React, Vue, and Solid minor versions and advance the Qwik alpha

## Testing

- built `@elmethis/core` and all four framework packages
- verified all four generated `style.css` artifacts are self-contained
- ran the Solid packed-package consumer smoke test
- passed the pre-commit checks

Closes #1782