### PR TITLE
fix: render Solid A2UI surfaces during SSR

### DIFF
--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elmethis/solid",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "SolidJS component library for elmethis.",
   "publishConfig": {
     "access": "public"

--- a/packages/solid/src/components/a2ui/component-host.tsx
+++ b/packages/solid/src/components/a2ui/component-host.tsx
@@ -1,6 +1,6 @@
 import {
   createContext,
-  createEffect,
+  createRenderEffect,
   createSignal,
   onCleanup,
   Show,
@@ -56,7 +56,7 @@ export const ComponentHost = (props: ComponentHostProps) => {
     Record<string, unknown>
   >({});
 
-  createEffect(() => {
+  createRenderEffect(() => {
     const id = props.id;
     const currentSurface = surface?.();
     if (isCycle() || currentSurface == null) {
@@ -84,7 +84,7 @@ export const ComponentHost = (props: ComponentHostProps) => {
     });
   });
 
-  createEffect(() => {
+  createRenderEffect(() => {
     const current = model();
     const currentSurface = surface?.();
     const entry = current == null ? undefined : catalog?.().get(current.type);

--- a/packages/solid/src/components/a2ui/elm-a2ui.ssr.spec.tsx
+++ b/packages/solid/src/components/a2ui/elm-a2ui.ssr.spec.tsx
@@ -1,10 +1,12 @@
 import { renderToString } from "solid-js/web";
 import { describe, expect, it } from "vitest";
 
-import { BASIC_CATALOG_ID, ElmA2ui } from "./elm-a2ui";
+import { NOTION_BLOCK_CATALOG_ID } from "@elmethis/core";
+
+import { ElmA2ui } from "./elm-a2ui";
 
 describe("[SSR] ElmA2ui", () => {
-  it("imports and renders its inert shell without browser globals", () => {
+  it("renders controlled messages as a complete surface", () => {
     const html = renderToString(() => (
       <ElmA2ui
         class="server-surface"
@@ -12,13 +14,49 @@ describe("[SSR] ElmA2ui", () => {
         messages={[
           {
             version: "v0.9",
-            createSurface: { surfaceId: "s", catalogId: BASIC_CATALOG_ID },
+            createSurface: {
+              surfaceId: "article",
+              catalogId: NOTION_BLOCK_CATALOG_ID,
+            },
+          },
+          {
+            version: "v0.9",
+            updateComponents: {
+              surfaceId: "article",
+              components: [
+                {
+                  component: "Column",
+                  id: "root",
+                  children: ["paragraph", "code"],
+                },
+                {
+                  component: "Paragraph",
+                  id: "paragraph",
+                  children: ["text"],
+                },
+                {
+                  component: "RichText",
+                  id: "text",
+                  text: "Server-rendered article body",
+                },
+                {
+                  component: "CodeBlock",
+                  id: "code",
+                  language: "typescript",
+                  code: "const ssr = true;",
+                },
+              ],
+            },
           },
         ]}
       />
     ));
     expect(html).toContain("server-surface");
     expect(html).toContain('data-renderer="solid"');
+    expect(html).toContain('data-a2ui-surface-id="article"');
+    expect(html).toContain('data-a2ui-component-id="root"');
+    expect(html).toContain("Server-rendered article body");
+    expect(html).toContain("const ssr = true;");
     expect(html).not.toContain("window");
   });
 });

--- a/packages/solid/src/components/a2ui/elm-a2ui.tsx
+++ b/packages/solid/src/components/a2ui/elm-a2ui.tsx
@@ -1,6 +1,7 @@
 import {
   createEffect,
   createMemo,
+  createRenderEffect,
   createSignal,
   For,
   onCleanup,
@@ -136,7 +137,7 @@ export const ElmA2ui = (props: ElmA2uiProps) => {
     onCleanup(() => controller.abort());
   });
 
-  createEffect(() => {
+  createRenderEffect(() => {
     const effective = local.messages ?? streamMessages();
     const catalogId = local.catalogId;
     const catalog = local.catalog ?? notionBlockCatalog;


### PR DESCRIPTION
## Summary

- process controlled A2UI messages during Solid server rendering
- initialize recursive component models and binders during SSR
- add regression coverage for nested article text and code blocks
- bump `@elmethis/solid` to `0.3.1`

## Testing

- `pnpm run test.unit`
- `pnpm exec vitest run --config vitest.browser.config.ts src/components/a2ui/elm-a2ui.browser.spec.tsx`
- `pnpm run check`

Fixes #1787