### PR TITLE
fix: defer Solid Shiki runtime loading

### DIFF
--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elmethis/solid",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "SolidJS component library for elmethis.",
   "publishConfig": {
     "access": "public"

--- a/packages/solid/scripts/test-package.mjs
+++ b/packages/solid/scripts/test-package.mjs
@@ -191,9 +191,9 @@ export default defineConfig({
   await write(
     "src/server.tsx",
     `import { renderToString } from "solid-js/web";
-import { ElmA2ui, ElmDivider, ElmInlineText } from "@elmethis/solid";
-const html = renderToString(() => <><ElmInlineText bold>ssr</ElmInlineText><ElmDivider data-package-smoke="ssr" /><ElmA2ui messages={[]} /></>);
-if (!html.includes("<hr") || !html.includes("data-package-smoke") || !html.includes("elm-a2ui") || !html.includes("ssr")) {
+import { ElmA2ui, ElmDivider, ElmInlineText, ElmShikiHighlighter } from "@elmethis/solid";
+const html = renderToString(() => <><ElmInlineText bold>ssr</ElmInlineText><ElmDivider data-package-smoke="ssr" /><ElmA2ui messages={[]} /><ElmShikiHighlighter code={'const value = "<safe>";'} language="typescript" /></>);
+if (!html.includes("<hr") || !html.includes("data-package-smoke") || !html.includes("elm-a2ui") || !html.includes("ssr") || !html.includes("&lt;safe>")) {
   throw new Error(\`Unexpected SSR output: \${html}\`);
 }
 console.log(html);

--- a/packages/solid/src/components/code/elm-shiki-highlighter-retry.spec.tsx
+++ b/packages/solid/src/components/code/elm-shiki-highlighter-retry.spec.tsx
@@ -1,0 +1,44 @@
+import { render } from "@solidjs/testing-library";
+import { describe, expect, it, vi } from "vitest";
+
+const shiki = vi.hoisted(() => ({
+  createHighlighter: vi.fn(),
+  loadAttempts: 0,
+}));
+
+vi.mock("shiki", () => {
+  shiki.loadAttempts += 1;
+  if (shiki.loadAttempts === 1) throw new Error("Failed to load Shiki");
+
+  return {
+    bundledLanguages: { rust: {} },
+    createHighlighter: shiki.createHighlighter,
+  };
+});
+vi.mock("@46ki75/ikuma-theme/dark", () => ({ default: {} }));
+vi.mock("@46ki75/ikuma-theme/light", () => ({ default: {} }));
+
+import { ElmShikiHighlighter } from "./elm-shiki-highlighter";
+
+describe("[CSR] ElmShikiHighlighter runtime loading", () => {
+  it("retries loading Shiki after an import failure", async () => {
+    shiki.createHighlighter.mockResolvedValue({
+      codeToHtml: () => '<pre class="shiki">highlighted</pre>',
+      dispose: vi.fn(),
+    });
+
+    const first = render(() => (
+      <ElmShikiHighlighter code="first" language="rust" />
+    ));
+    await vi.waitFor(() => expect(shiki.loadAttempts).toBe(1));
+    first.unmount();
+
+    const second = render(() => (
+      <ElmShikiHighlighter code="second" language="rust" />
+    ));
+    await vi.waitFor(() => expect(shiki.loadAttempts).toBe(2));
+    await vi.waitFor(() =>
+      expect(second.container.innerHTML).toContain("highlighted"),
+    );
+  });
+});

--- a/packages/solid/src/components/code/elm-shiki-highlighter-stale-load.spec.tsx
+++ b/packages/solid/src/components/code/elm-shiki-highlighter-stale-load.spec.tsx
@@ -1,0 +1,46 @@
+import { render } from "@solidjs/testing-library";
+import { createSignal } from "solid-js";
+import { describe, expect, it, vi } from "vitest";
+
+const shiki = vi.hoisted(() => ({
+  createHighlighter: vi.fn(),
+  releaseRuntime: undefined as (() => void) | undefined,
+}));
+
+vi.mock("shiki", async () => {
+  await new Promise<void>((resolve) => {
+    shiki.releaseRuntime = resolve;
+  });
+
+  return {
+    bundledLanguages: { rust: {} },
+    createHighlighter: shiki.createHighlighter,
+  };
+});
+vi.mock("@46ki75/ikuma-theme/dark", () => ({ default: {} }));
+vi.mock("@46ki75/ikuma-theme/light", () => ({ default: {} }));
+
+import { ElmShikiHighlighter } from "./elm-shiki-highlighter";
+
+describe("[CSR] ElmShikiHighlighter runtime loading", () => {
+  it("does not initialize a highlighter for work that became stale while loading Shiki", async () => {
+    shiki.createHighlighter.mockImplementation(async () => ({
+      codeToHtml: (code: string) => `<pre>${code}</pre>`,
+      dispose: vi.fn(),
+    }));
+    const [code, setCode] = createSignal("old code");
+    const rendered = render(() => (
+      <ElmShikiHighlighter code={code()} language="rust" />
+    ));
+
+    await vi.waitFor(() => expect(shiki.releaseRuntime).toBeTypeOf("function"));
+    setCode("new code");
+    await Promise.resolve();
+    shiki.releaseRuntime!();
+
+    await vi.waitFor(() =>
+      expect(rendered.container.textContent).toContain("new code"),
+    );
+    expect(shiki.createHighlighter).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/solid/src/components/code/elm-shiki-highlighter.ssr.spec.tsx
+++ b/packages/solid/src/components/code/elm-shiki-highlighter.ssr.spec.tsx
@@ -1,12 +1,17 @@
 import { renderToString } from "solid-js/web";
 import { describe, expect, it, vi } from "vitest";
 
-const createHighlighter = vi.hoisted(() => vi.fn());
-vi.mock("shiki", () => ({
-  bundledLanguages: { rust: {} },
-  bundledLanguagesAlias: {},
-  createHighlighter,
+const shiki = vi.hoisted(() => ({
+  createHighlighter: vi.fn(),
+  runtimeLoaded: false,
 }));
+vi.mock("shiki", () => {
+  shiki.runtimeLoaded = true;
+  return {
+    bundledLanguages: { rust: {} },
+    createHighlighter: shiki.createHighlighter,
+  };
+});
 vi.mock("@46ki75/ikuma-theme/dark", () => ({ default: {} }));
 vi.mock("@46ki75/ikuma-theme/light", () => ({ default: {} }));
 
@@ -29,6 +34,7 @@ describe("[SSR] ElmShikiHighlighter", () => {
     expect(html).toContain('let server = "&lt;safe> &amp; readable";');
     expect(html).not.toContain("<safe>");
     expect(html).not.toContain('class="shiki"');
-    expect(createHighlighter).not.toHaveBeenCalled();
+    expect(shiki.runtimeLoaded).toBe(false);
+    expect(shiki.createHighlighter).not.toHaveBeenCalled();
   });
 });

--- a/packages/solid/src/components/code/elm-shiki-highlighter.tsx
+++ b/packages/solid/src/components/code/elm-shiki-highlighter.tsx
@@ -9,12 +9,7 @@ import {
   untrack,
 } from "solid-js";
 import { clsx } from "clsx";
-import {
-  bundledLanguages,
-  createHighlighter,
-  type BundledLanguage,
-  type ThemeRegistrationRaw,
-} from "shiki";
+import type { BundledLanguage, ThemeRegistrationRaw } from "shiki";
 import ikumaDark from "@46ki75/ikuma-theme/dark";
 import ikumaLight from "@46ki75/ikuma-theme/light";
 
@@ -30,7 +25,17 @@ export interface ElmShikiHighlighterProps extends JSX.HTMLAttributes<HTMLPreElem
   language?: string;
 }
 
-const resolveLanguage = (language: string): BundledLanguage | "text" => {
+let shikiPromise: Promise<typeof import("shiki")> | undefined;
+const loadShiki = () =>
+  (shikiPromise ??= import("shiki").catch((error: unknown) => {
+    shikiPromise = undefined;
+    throw error;
+  }));
+
+const resolveLanguage = (
+  language: string,
+  bundledLanguages: Record<string, unknown>,
+): BundledLanguage | "text" => {
   const normalized = language.trim().toLowerCase();
   if (normalized in bundledLanguages) return normalized as BundledLanguage;
   return "text";
@@ -51,8 +56,9 @@ export const ElmShikiHighlighter = (props: ElmShikiHighlighterProps) => {
   onMount(() => {
     createEffect(() => {
       const code = local.code;
-      const language = resolveLanguage(local.language);
+      const language = local.language;
       const currentGeneration = ++generation;
+      const isStale = () => disposed || currentGeneration !== generation;
 
       if (!code) {
         setRawHtml("");
@@ -62,21 +68,26 @@ export const ElmShikiHighlighter = (props: ElmShikiHighlighterProps) => {
       // Each generation owns its highlighter, including stale or unmounted work.
       void (async () => {
         let highlighter:
-          Awaited<ReturnType<typeof createHighlighter>> | undefined;
+          | Awaited<ReturnType<(typeof import("shiki"))["createHighlighter"]>>
+          | undefined;
 
         try {
+          const { bundledLanguages, createHighlighter } = await loadShiki();
+          if (isStale()) return;
+
+          const resolvedLanguage = resolveLanguage(language, bundledLanguages);
           highlighter = await createHighlighter({
             themes: [
               ikumaDark as unknown as ThemeRegistrationRaw,
               ikumaLight as unknown as ThemeRegistrationRaw,
             ],
-            langs: language === "text" ? [] : [language],
+            langs: resolvedLanguage === "text" ? [] : [resolvedLanguage],
           });
 
-          if (disposed || currentGeneration !== generation) return;
+          if (isStale()) return;
 
           const html = highlighter.codeToHtml(code, {
-            lang: language,
+            lang: resolvedLanguage,
             themes: {
               dark: ikumaDark as unknown as ThemeRegistrationRaw,
               light: ikumaLight as unknown as ThemeRegistrationRaw,
@@ -88,9 +99,9 @@ export const ElmShikiHighlighter = (props: ElmShikiHighlighterProps) => {
             },
           });
 
-          if (!disposed && currentGeneration === generation) setRawHtml(html);
+          if (!isStale()) setRawHtml(html);
         } catch {
-          if (!disposed && currentGeneration === generation) {
+          if (!isStale()) {
             setRawHtml(`<pre>${escapeHtml(code)}</pre>`);
           }
         } finally {


### PR DESCRIPTION
## Summary
- defer the Shiki runtime import until `ElmShikiHighlighter` mounts in the browser
- retry failed runtime imports and skip highlighter initialization for stale generations
- verify SSR module isolation, retry behavior, stale work, and packed-package SSR consumption

## Verification
- Solid pre-commit checks
- focused CSR and SSR Vitest suites
- browser Vitest suite for `ElmShikiHighlighter`
- `pnpm --filter @elmethis/solid run build`
- `pnpm --filter @elmethis/solid run test.package`

Closes #1790