### PR TITLE
feat(solid): support server-side Shiki highlighting

### DIFF
--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elmethis/solid",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "SolidJS component library for elmethis.",
   "publishConfig": {
     "access": "public"

--- a/packages/solid/src/components/code/elm-shiki-highlighter-stale-load.spec.tsx
+++ b/packages/solid/src/components/code/elm-shiki-highlighter-stale-load.spec.tsx
@@ -41,6 +41,8 @@ describe("[CSR] ElmShikiHighlighter runtime loading", () => {
     await vi.waitFor(() =>
       expect(rendered.container.textContent).toContain("new code"),
     );
-    expect(shiki.createHighlighter).toHaveBeenCalledOnce();
+    await vi.waitFor(() =>
+      expect(shiki.createHighlighter).toHaveBeenCalledOnce(),
+    );
   });
 });

--- a/packages/solid/src/components/code/elm-shiki-highlighter.ssr.spec.tsx
+++ b/packages/solid/src/components/code/elm-shiki-highlighter.ssr.spec.tsx
@@ -1,25 +1,34 @@
-import { renderToString } from "solid-js/web";
+import { renderToStringAsync } from "solid-js/web";
 import { describe, expect, it, vi } from "vitest";
 
 const shiki = vi.hoisted(() => ({
   createHighlighter: vi.fn(),
-  runtimeLoaded: false,
 }));
-vi.mock("shiki", () => {
-  shiki.runtimeLoaded = true;
-  return {
-    bundledLanguages: { rust: {} },
-    createHighlighter: shiki.createHighlighter,
-  };
-});
-vi.mock("@46ki75/ikuma-theme/dark", () => ({ default: {} }));
-vi.mock("@46ki75/ikuma-theme/light", () => ({ default: {} }));
+vi.mock("shiki", () => ({
+  bundledLanguages: { rust: {} },
+  createHighlighter: shiki.createHighlighter,
+}));
+vi.mock("@46ki75/ikuma-theme/dark", () => ({
+  default: { name: "ikuma-dark" },
+}));
+vi.mock("@46ki75/ikuma-theme/light", () => ({
+  default: { name: "ikuma-light" },
+}));
 
 import { ElmShikiHighlighter } from "./elm-shiki-highlighter";
 
 describe("[SSR] ElmShikiHighlighter", () => {
-  it("renders escaped source without starting Shiki server-side", () => {
-    const html = renderToString(() => (
+  it("renders highlighted code server-side", async () => {
+    const highlighter = {
+      codeToHtml: vi.fn(
+        () =>
+          '<pre class="shiki"><code><span style="--shiki-light:#111;--shiki-dark:#eee">server</span></code></pre>',
+      ),
+      dispose: vi.fn(),
+    };
+    shiki.createHighlighter.mockResolvedValue(highlighter);
+
+    const html = await renderToStringAsync(() => (
       <ElmShikiHighlighter
         code={'let server = "<safe> & readable";'}
         language="rust"
@@ -31,10 +40,19 @@ describe("[SSR] ElmShikiHighlighter", () => {
     expect(html).toContain("<pre");
     expect(html).toContain("server-highlighter");
     expect(html).toContain('data-source="ssr"');
-    expect(html).toContain('let server = "&lt;safe> &amp; readable";');
-    expect(html).not.toContain("<safe>");
-    expect(html).not.toContain('class="shiki"');
-    expect(shiki.runtimeLoaded).toBe(false);
-    expect(shiki.createHighlighter).not.toHaveBeenCalled();
+    expect(html).toContain('class="shiki"');
+    expect(html).toContain("--shiki-light");
+    expect(html).toContain("--shiki-dark");
+    expect(shiki.createHighlighter).toHaveBeenCalledWith(
+      expect.objectContaining({ langs: ["rust"] }),
+    );
+    expect(highlighter.codeToHtml).toHaveBeenCalledWith(
+      'let server = "<safe> & readable";',
+      expect.objectContaining({
+        defaultColor: false,
+        themes: expect.objectContaining({ dark: expect.anything() }),
+      }),
+    );
+    expect(highlighter.dispose).toHaveBeenCalledOnce();
   });
 });

--- a/packages/solid/src/components/code/elm-shiki-highlighter.tsx
+++ b/packages/solid/src/components/code/elm-shiki-highlighter.tsx
@@ -1,12 +1,10 @@
 import {
-  createEffect,
-  createSignal,
+  createResource,
   mergeProps,
   onCleanup,
-  onMount,
   splitProps,
+  Suspense,
   type JSX,
-  untrack,
 } from "solid-js";
 import { clsx } from "clsx";
 import type { BundledLanguage, ThemeRegistrationRaw } from "shiki";
@@ -44,83 +42,84 @@ const resolveLanguage = (
 const escapeHtml = (value: string): string =>
   value.replaceAll("&", "&amp;").replaceAll("<", "&lt;");
 
+const highlightCode = async (
+  code: string,
+  language: string,
+  isStale: () => boolean,
+): Promise<string> => {
+  let highlighter:
+    | Awaited<ReturnType<(typeof import("shiki"))["createHighlighter"]>>
+    | undefined;
+
+  try {
+    const { bundledLanguages, createHighlighter } = await loadShiki();
+    if (isStale()) return escapeHtml(code);
+
+    const resolvedLanguage = resolveLanguage(language, bundledLanguages);
+    highlighter = await createHighlighter({
+      themes: [
+        ikumaDark as unknown as ThemeRegistrationRaw,
+        ikumaLight as unknown as ThemeRegistrationRaw,
+      ],
+      langs: resolvedLanguage === "text" ? [] : [resolvedLanguage],
+    });
+
+    if (isStale()) return escapeHtml(code);
+
+    return highlighter.codeToHtml(code, {
+      lang: resolvedLanguage,
+      themes: {
+        dark: ikumaDark as unknown as ThemeRegistrationRaw,
+        light: ikumaLight as unknown as ThemeRegistrationRaw,
+      },
+      defaultColor: false,
+      colorReplacements: {
+        "#ffffff": "transparent",
+        "#121212": "transparent",
+      },
+    });
+  } catch {
+    return `<pre>${escapeHtml(code)}</pre>`;
+  } finally {
+    highlighter?.dispose();
+  }
+};
+
 export const ElmShikiHighlighter = (props: ElmShikiHighlighterProps) => {
   const merged = mergeProps({ language: "txt" }, props);
   const [local, rest] = splitProps(merged, ["class", "code", "language"]);
-  const [rawHtml, setRawHtml] = createSignal(
-    escapeHtml(untrack(() => local.code)),
-  );
   let generation = 0;
-  let disposed = false;
-
-  onMount(() => {
-    createEffect(() => {
+  const [rawHtml] = createResource(
+    () => {
       const code = local.code;
       const language = local.language;
       const currentGeneration = ++generation;
-      const isStale = () => disposed || currentGeneration !== generation;
 
-      if (!code) {
-        setRawHtml("");
-        return;
-      }
-
-      // Each generation owns its highlighter, including stale or unmounted work.
-      void (async () => {
-        let highlighter:
-          | Awaited<ReturnType<(typeof import("shiki"))["createHighlighter"]>>
-          | undefined;
-
-        try {
-          const { bundledLanguages, createHighlighter } = await loadShiki();
-          if (isStale()) return;
-
-          const resolvedLanguage = resolveLanguage(language, bundledLanguages);
-          highlighter = await createHighlighter({
-            themes: [
-              ikumaDark as unknown as ThemeRegistrationRaw,
-              ikumaLight as unknown as ThemeRegistrationRaw,
-            ],
-            langs: resolvedLanguage === "text" ? [] : [resolvedLanguage],
-          });
-
-          if (isStale()) return;
-
-          const html = highlighter.codeToHtml(code, {
-            lang: resolvedLanguage,
-            themes: {
-              dark: ikumaDark as unknown as ThemeRegistrationRaw,
-              light: ikumaLight as unknown as ThemeRegistrationRaw,
-            },
-            defaultColor: false,
-            colorReplacements: {
-              "#ffffff": "transparent",
-              "#121212": "transparent",
-            },
-          });
-
-          if (!isStale()) setRawHtml(html);
-        } catch {
-          if (!isStale()) {
-            setRawHtml(`<pre>${escapeHtml(code)}</pre>`);
-          }
-        } finally {
-          highlighter?.dispose();
-        }
-      })();
-    });
-  });
+      return code ? { code, language, generation: currentGeneration } : false;
+    },
+    ({ code, language, generation: requestGeneration }) =>
+      highlightCode(code, language, () => requestGeneration !== generation),
+  );
 
   onCleanup(() => {
-    disposed = true;
     generation += 1;
   });
 
   return (
-    <pre
-      {...rest}
-      class={clsx(styles["elm-shiki-highlighter"], local.class)}
-      innerHTML={rawHtml()}
-    />
+    <Suspense
+      fallback={
+        <pre
+          {...rest}
+          class={clsx(styles["elm-shiki-highlighter"], local.class)}
+          innerHTML={escapeHtml(local.code)}
+        />
+      }
+    >
+      <pre
+        {...rest}
+        class={clsx(styles["elm-shiki-highlighter"], local.class)}
+        innerHTML={rawHtml() ?? ""}
+      />
+    </Suspense>
   );
 };


### PR DESCRIPTION
## Summary
- run Solid Shiki highlighting through a resource and Suspense boundary so async SSR can await highlighted markup
- preserve escaped fallback output, stale-request protection, language fallback, and highlighter disposal
- update SSR and stale-loading coverage and bump `@elmethis/solid` to 0.3.4

## Testing
- `pnpm run test.unit`
- `pnpm run check`
- `pnpm exec vitest run --config vitest.browser.config.ts src/components/code/elm-shiki-highlighter.browser.spec.tsx`