### PR TITLE
perf(solid): defer and reuse Shiki runtime

### DIFF
--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elmethis/solid",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "SolidJS component library for elmethis.",
   "publishConfig": {
     "access": "public"

--- a/packages/solid/src/components/code/elm-shiki-highlighter-deferred-runtime.spec.tsx
+++ b/packages/solid/src/components/code/elm-shiki-highlighter-deferred-runtime.spec.tsx
@@ -1,0 +1,59 @@
+import { render } from "@solidjs/testing-library";
+import { describe, expect, it, vi } from "vitest";
+
+const runtime = vi.hoisted(() => ({
+  codeToHtml: vi.fn(async (code: string) => `<pre class="shiki">${code}</pre>`),
+  shikiLoads: 0,
+  darkThemeLoads: 0,
+  lightThemeLoads: 0,
+}));
+
+vi.mock("shiki", () => {
+  runtime.shikiLoads += 1;
+  return {
+    bundledLanguages: { rust: {} },
+    codeToHtml: runtime.codeToHtml,
+  };
+});
+vi.mock("@46ki75/ikuma-theme/dark", () => {
+  runtime.darkThemeLoads += 1;
+  return { default: { name: "ikuma-dark" } };
+});
+vi.mock("@46ki75/ikuma-theme/light", () => {
+  runtime.lightThemeLoads += 1;
+  return { default: { name: "ikuma-light" } };
+});
+
+import { ElmShikiHighlighter } from "./elm-shiki-highlighter";
+
+describe("[CSR] ElmShikiHighlighter deferred runtime", () => {
+  it("loads Shiki and both themes once only when non-empty code needs highlighting", async () => {
+    const empty = render(() => <ElmShikiHighlighter code="" />);
+
+    await Promise.resolve();
+    expect(runtime.shikiLoads).toBe(0);
+    expect(runtime.darkThemeLoads).toBe(0);
+    expect(runtime.lightThemeLoads).toBe(0);
+    empty.unmount();
+
+    const first = render(() => (
+      <ElmShikiHighlighter code="first" language="rust" />
+    ));
+    await vi.waitFor(() =>
+      expect(first.container.querySelector(".shiki")).not.toBeNull(),
+    );
+    expect(runtime.shikiLoads).toBe(1);
+    expect(runtime.darkThemeLoads).toBe(1);
+    expect(runtime.lightThemeLoads).toBe(1);
+
+    const second = render(() => (
+      <ElmShikiHighlighter code="second" language="rust" />
+    ));
+    await vi.waitFor(() =>
+      expect(second.container.querySelector(".shiki")).not.toBeNull(),
+    );
+    expect(runtime.shikiLoads).toBe(1);
+    expect(runtime.darkThemeLoads).toBe(1);
+    expect(runtime.lightThemeLoads).toBe(1);
+  });
+});

--- a/packages/solid/src/components/code/elm-shiki-highlighter-retry.spec.tsx
+++ b/packages/solid/src/components/code/elm-shiki-highlighter-retry.spec.tsx
@@ -2,7 +2,7 @@ import { render } from "@solidjs/testing-library";
 import { describe, expect, it, vi } from "vitest";
 
 const shiki = vi.hoisted(() => ({
-  createHighlighter: vi.fn(),
+  codeToHtml: vi.fn(),
   loadAttempts: 0,
 }));
 
@@ -12,7 +12,7 @@ vi.mock("shiki", () => {
 
   return {
     bundledLanguages: { rust: {} },
-    createHighlighter: shiki.createHighlighter,
+    codeToHtml: shiki.codeToHtml,
   };
 });
 vi.mock("@46ki75/ikuma-theme/dark", () => ({ default: {} }));
@@ -22,10 +22,7 @@ import { ElmShikiHighlighter } from "./elm-shiki-highlighter";
 
 describe("[CSR] ElmShikiHighlighter runtime loading", () => {
   it("retries loading Shiki after an import failure", async () => {
-    shiki.createHighlighter.mockResolvedValue({
-      codeToHtml: () => '<pre class="shiki">highlighted</pre>',
-      dispose: vi.fn(),
-    });
+    shiki.codeToHtml.mockResolvedValue('<pre class="shiki">highlighted</pre>');
 
     const first = render(() => (
       <ElmShikiHighlighter code="first" language="rust" />

--- a/packages/solid/src/components/code/elm-shiki-highlighter-stale-load.spec.tsx
+++ b/packages/solid/src/components/code/elm-shiki-highlighter-stale-load.spec.tsx
@@ -3,7 +3,7 @@ import { createSignal } from "solid-js";
 import { describe, expect, it, vi } from "vitest";
 
 const shiki = vi.hoisted(() => ({
-  createHighlighter: vi.fn(),
+  codeToHtml: vi.fn(),
   releaseRuntime: undefined as (() => void) | undefined,
 }));
 
@@ -14,7 +14,7 @@ vi.mock("shiki", async () => {
 
   return {
     bundledLanguages: { rust: {} },
-    createHighlighter: shiki.createHighlighter,
+    codeToHtml: shiki.codeToHtml,
   };
 });
 vi.mock("@46ki75/ikuma-theme/dark", () => ({ default: {} }));
@@ -24,10 +24,9 @@ import { ElmShikiHighlighter } from "./elm-shiki-highlighter";
 
 describe("[CSR] ElmShikiHighlighter runtime loading", () => {
   it("does not initialize a highlighter for work that became stale while loading Shiki", async () => {
-    shiki.createHighlighter.mockImplementation(async () => ({
-      codeToHtml: (code: string) => `<pre>${code}</pre>`,
-      dispose: vi.fn(),
-    }));
+    shiki.codeToHtml.mockImplementation(
+      async (code: string) => `<pre>${code}</pre>`,
+    );
     const [code, setCode] = createSignal("old code");
     const rendered = render(() => (
       <ElmShikiHighlighter code={code()} language="rust" />
@@ -41,8 +40,6 @@ describe("[CSR] ElmShikiHighlighter runtime loading", () => {
     await vi.waitFor(() =>
       expect(rendered.container.textContent).toContain("new code"),
     );
-    await vi.waitFor(() =>
-      expect(shiki.createHighlighter).toHaveBeenCalledOnce(),
-    );
+    await vi.waitFor(() => expect(shiki.codeToHtml).toHaveBeenCalledOnce());
   });
 });

--- a/packages/solid/src/components/code/elm-shiki-highlighter.spec.tsx
+++ b/packages/solid/src/components/code/elm-shiki-highlighter.spec.tsx
@@ -3,11 +3,13 @@ import { createSignal } from "solid-js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const shiki = vi.hoisted(() => ({
+  codeToHtml: vi.fn(),
   createHighlighter: vi.fn(),
 }));
 
 vi.mock("shiki", () => ({
   bundledLanguages: { rs: {}, rust: {}, ts: {}, typescript: {} },
+  codeToHtml: shiki.codeToHtml,
   createHighlighter: shiki.createHighlighter,
 }));
 vi.mock("@46ki75/ikuma-theme/dark", () => ({
@@ -19,22 +21,19 @@ vi.mock("@46ki75/ikuma-theme/light", () => ({
 
 import { ElmShikiHighlighter } from "./elm-shiki-highlighter";
 
-const highlighter = () => ({
-  codeToHtml: vi.fn(
-    (code: string) =>
-      `<pre class="shiki"><code><span class="line" style="--shiki-light:#111;--shiki-dark:#eee">${code}</span></code></pre>`,
-  ),
-  dispose: vi.fn(),
-});
+const highlighted = (code: string) =>
+  `<pre class="shiki"><code><span class="line" style="--shiki-light:#111;--shiki-dark:#eee">${code}</span></code></pre>`;
 
 describe("[CSR] ElmShikiHighlighter", () => {
   beforeEach(() => {
+    shiki.codeToHtml.mockReset();
     shiki.createHighlighter.mockReset();
   });
 
-  it("highlights after mount with dual themes and disposes the highlighter", async () => {
-    const instance = highlighter();
-    shiki.createHighlighter.mockResolvedValue(instance);
+  it("highlights after mount with dual themes through Shiki's cached shorthand", async () => {
+    shiki.codeToHtml.mockImplementation(async (code: string) =>
+      highlighted(code),
+    );
     const rendered = render(() => (
       <ElmShikiHighlighter
         code="let value = 1;"
@@ -49,36 +48,38 @@ describe("[CSR] ElmShikiHighlighter", () => {
       expect(rendered.container.innerHTML).toContain("--shiki-light"),
     );
 
-    expect(shiki.createHighlighter).toHaveBeenCalledWith(
-      expect.objectContaining({ langs: ["rust"] }),
-    );
-    expect(instance.codeToHtml).toHaveBeenCalledWith(
+    expect(shiki.codeToHtml).toHaveBeenCalledWith(
       "let value = 1;",
       expect.objectContaining({
         defaultColor: false,
+        lang: "rust",
         themes: expect.objectContaining({ dark: expect.anything() }),
       }),
     );
-    expect(instance.dispose).toHaveBeenCalledOnce();
+    expect(shiki.createHighlighter).not.toHaveBeenCalled();
   });
 
   it("accepts bundled aliases and falls back to Shiki plaintext for unknown languages", async () => {
     const [language, setLanguage] = createSignal("rs");
-    shiki.createHighlighter.mockImplementation(async () => highlighter());
+    shiki.codeToHtml.mockImplementation(async (code: string) =>
+      highlighted(code),
+    );
     const rendered = render(() => (
       <ElmShikiHighlighter code="plain text" language={language()} />
     ));
 
     await vi.waitFor(() =>
-      expect(shiki.createHighlighter).toHaveBeenCalledWith(
-        expect.objectContaining({ langs: ["rs"] }),
+      expect(shiki.codeToHtml).toHaveBeenCalledWith(
+        "plain text",
+        expect.objectContaining({ lang: "rs" }),
       ),
     );
 
     setLanguage("not-a-language");
     await vi.waitFor(() =>
-      expect(shiki.createHighlighter).toHaveBeenLastCalledWith(
-        expect.objectContaining({ langs: [] }),
+      expect(shiki.codeToHtml).toHaveBeenLastCalledWith(
+        "plain text",
+        expect.objectContaining({ lang: "text" }),
       ),
     );
     await vi.waitFor(() =>
@@ -87,8 +88,8 @@ describe("[CSR] ElmShikiHighlighter", () => {
   });
 
   it("does not let an older generation overwrite a newer highlight", async () => {
-    const pending: Array<(value: ReturnType<typeof highlighter>) => void> = [];
-    shiki.createHighlighter.mockImplementation(
+    const pending: Array<(value: string) => void> = [];
+    shiki.codeToHtml.mockImplementation(
       () =>
         new Promise((resolve) => {
           pending.push(resolve);
@@ -103,22 +104,20 @@ describe("[CSR] ElmShikiHighlighter", () => {
     setCode("new code");
     await vi.waitFor(() => expect(pending).toHaveLength(2));
 
-    const newer = highlighter();
-    pending[1](newer);
+    pending[1](highlighted("new code"));
     await vi.waitFor(() =>
       expect(rendered.container.textContent).toContain("new code"),
     );
 
-    const older = highlighter();
-    pending[0](older);
-    await vi.waitFor(() => expect(older.dispose).toHaveBeenCalledOnce());
+    pending[0](highlighted("old code"));
+    await Promise.resolve();
     expect(rendered.container.textContent).toContain("new code");
     expect(rendered.container.textContent).not.toContain("old code");
   });
 
-  it("disposes a highlighter that resolves after unmount without updating DOM", async () => {
-    let resolve: ((value: ReturnType<typeof highlighter>) => void) | undefined;
-    shiki.createHighlighter.mockImplementation(
+  it("ignores highlighting that resolves after unmount", async () => {
+    let resolve: ((value: string) => void) | undefined;
+    shiki.codeToHtml.mockImplementation(
       () =>
         new Promise((next) => {
           resolve = next;
@@ -130,19 +129,48 @@ describe("[CSR] ElmShikiHighlighter", () => {
 
     await vi.waitFor(() => expect(resolve).toBeTypeOf("function"));
     rendered.unmount();
-    const late = highlighter();
-    resolve!(late);
+    resolve!(highlighted("late code"));
 
-    await vi.waitFor(() => expect(late.dispose).toHaveBeenCalledOnce());
+    await Promise.resolve();
     expect(rendered.container.innerHTML).toBe("");
   });
 
-  it("short-circuits empty code without creating a highlighter", async () => {
+  it("short-circuits empty code without invoking Shiki", async () => {
     const rendered = render(() => <ElmShikiHighlighter code="" />);
 
     await Promise.resolve();
     expect(rendered.container.querySelector("pre")).not.toBeNull();
     expect(rendered.container.querySelector("pre")).toBeEmptyDOMElement();
+    expect(shiki.codeToHtml).not.toHaveBeenCalled();
+    expect(shiki.createHighlighter).not.toHaveBeenCalled();
+  });
+
+  it("renders escaped source without nesting pre elements when highlighting fails", async () => {
+    shiki.codeToHtml.mockRejectedValue(new Error("highlight failed"));
+    const rendered = render(() => (
+      <ElmShikiHighlighter code={'const value = "<safe> & readable";'} />
+    ));
+
+    await vi.waitFor(() =>
+      expect(rendered.container.textContent).toContain("<safe> & readable"),
+    );
+    await vi.waitFor(() => expect(shiki.codeToHtml).toHaveBeenCalledOnce());
+    expect(rendered.container.querySelectorAll("pre")).toHaveLength(1);
+    expect(rendered.container.innerHTML).not.toContain("<safe>");
+  });
+
+  it("does not create a highlighter per code block", async () => {
+    shiki.codeToHtml.mockImplementation(async (code: string) =>
+      highlighted(code),
+    );
+    render(() => (
+      <>
+        <ElmShikiHighlighter code="first" language="rust" />
+        <ElmShikiHighlighter code="second" language="typescript" />
+      </>
+    ));
+
+    await vi.waitFor(() => expect(shiki.codeToHtml).toHaveBeenCalledTimes(2));
     expect(shiki.createHighlighter).not.toHaveBeenCalled();
   });
 });

--- a/packages/solid/src/components/code/elm-shiki-highlighter.ssr.spec.tsx
+++ b/packages/solid/src/components/code/elm-shiki-highlighter.ssr.spec.tsx
@@ -2,10 +2,12 @@ import { renderToStringAsync } from "solid-js/web";
 import { describe, expect, it, vi } from "vitest";
 
 const shiki = vi.hoisted(() => ({
+  codeToHtml: vi.fn(),
   createHighlighter: vi.fn(),
 }));
 vi.mock("shiki", () => ({
   bundledLanguages: { rust: {} },
+  codeToHtml: shiki.codeToHtml,
   createHighlighter: shiki.createHighlighter,
 }));
 vi.mock("@46ki75/ikuma-theme/dark", () => ({
@@ -18,15 +20,10 @@ vi.mock("@46ki75/ikuma-theme/light", () => ({
 import { ElmShikiHighlighter } from "./elm-shiki-highlighter";
 
 describe("[SSR] ElmShikiHighlighter", () => {
-  it("renders highlighted code server-side", async () => {
-    const highlighter = {
-      codeToHtml: vi.fn(
-        () =>
-          '<pre class="shiki"><code><span style="--shiki-light:#111;--shiki-dark:#eee">server</span></code></pre>',
-      ),
-      dispose: vi.fn(),
-    };
-    shiki.createHighlighter.mockResolvedValue(highlighter);
+  it("renders highlighted code server-side through Shiki's cached shorthand", async () => {
+    shiki.codeToHtml.mockResolvedValue(
+      '<pre class="shiki"><code><span style="--shiki-light:#111;--shiki-dark:#eee">server</span></code></pre>',
+    );
 
     const html = await renderToStringAsync(() => (
       <ElmShikiHighlighter
@@ -43,16 +40,14 @@ describe("[SSR] ElmShikiHighlighter", () => {
     expect(html).toContain('class="shiki"');
     expect(html).toContain("--shiki-light");
     expect(html).toContain("--shiki-dark");
-    expect(shiki.createHighlighter).toHaveBeenCalledWith(
-      expect.objectContaining({ langs: ["rust"] }),
-    );
-    expect(highlighter.codeToHtml).toHaveBeenCalledWith(
+    expect(shiki.codeToHtml).toHaveBeenCalledWith(
       'let server = "<safe> & readable";',
       expect.objectContaining({
         defaultColor: false,
+        lang: "rust",
         themes: expect.objectContaining({ dark: expect.anything() }),
       }),
     );
-    expect(highlighter.dispose).toHaveBeenCalledOnce();
+    expect(shiki.createHighlighter).not.toHaveBeenCalled();
   });
 });

--- a/packages/solid/src/components/code/elm-shiki-highlighter.tsx
+++ b/packages/solid/src/components/code/elm-shiki-highlighter.tsx
@@ -8,8 +8,6 @@ import {
 } from "solid-js";
 import { clsx } from "clsx";
 import type { BundledLanguage, ThemeRegistrationRaw } from "shiki";
-import ikumaDark from "@46ki75/ikuma-theme/dark";
-import ikumaLight from "@46ki75/ikuma-theme/light";
 
 import styles from "./elm-shiki-highlighter.module.css";
 
@@ -23,12 +21,28 @@ export interface ElmShikiHighlighterProps extends JSX.HTMLAttributes<HTMLPreElem
   language?: string;
 }
 
-let shikiPromise: Promise<typeof import("shiki")> | undefined;
-const loadShiki = () =>
-  (shikiPromise ??= import("shiki").catch((error: unknown) => {
-    shikiPromise = undefined;
-    throw error;
-  }));
+let runtimePromise:
+  | Promise<{
+      shiki: typeof import("shiki");
+      dark: ThemeRegistrationRaw;
+      light: ThemeRegistrationRaw;
+    }>
+  | undefined;
+const loadRuntime = () =>
+  (runtimePromise ??= Promise.all([
+    import("shiki"),
+    import("@46ki75/ikuma-theme/dark"),
+    import("@46ki75/ikuma-theme/light"),
+  ])
+    .then(([shiki, dark, light]) => ({
+      shiki,
+      dark: dark.default as unknown as ThemeRegistrationRaw,
+      light: light.default as unknown as ThemeRegistrationRaw,
+    }))
+    .catch((error: unknown) => {
+      runtimePromise = undefined;
+      throw error;
+    }));
 
 const resolveLanguage = (
   language: string,
@@ -47,30 +61,16 @@ const highlightCode = async (
   language: string,
   isStale: () => boolean,
 ): Promise<string> => {
-  let highlighter:
-    | Awaited<ReturnType<(typeof import("shiki"))["createHighlighter"]>>
-    | undefined;
-
   try {
-    const { bundledLanguages, createHighlighter } = await loadShiki();
+    const { shiki, dark, light } = await loadRuntime();
     if (isStale()) return escapeHtml(code);
 
-    const resolvedLanguage = resolveLanguage(language, bundledLanguages);
-    highlighter = await createHighlighter({
-      themes: [
-        ikumaDark as unknown as ThemeRegistrationRaw,
-        ikumaLight as unknown as ThemeRegistrationRaw,
-      ],
-      langs: resolvedLanguage === "text" ? [] : [resolvedLanguage],
-    });
-
-    if (isStale()) return escapeHtml(code);
-
-    return highlighter.codeToHtml(code, {
+    const resolvedLanguage = resolveLanguage(language, shiki.bundledLanguages);
+    const html = await shiki.codeToHtml(code, {
       lang: resolvedLanguage,
       themes: {
-        dark: ikumaDark as unknown as ThemeRegistrationRaw,
-        light: ikumaLight as unknown as ThemeRegistrationRaw,
+        dark,
+        light,
       },
       defaultColor: false,
       colorReplacements: {
@@ -78,10 +78,10 @@ const highlightCode = async (
         "#121212": "transparent",
       },
     });
+
+    return isStale() ? escapeHtml(code) : html;
   } catch {
-    return `<pre>${escapeHtml(code)}</pre>`;
-  } finally {
-    highlighter?.dispose();
+    return escapeHtml(code);
   }
 };
 
@@ -99,6 +99,7 @@ export const ElmShikiHighlighter = (props: ElmShikiHighlighterProps) => {
     },
     ({ code, language, generation: requestGeneration }) =>
       highlightCode(code, language, () => requestGeneration !== generation),
+    { ssrLoadFrom: "server" },
   );
 
   onCleanup(() => {


### PR DESCRIPTION
## Summary
- defer Shiki and both Ikuma theme registrations behind one cached dynamic loader
- use Shiki cached `codeToHtml` shorthand instead of creating and disposing a highlighter per code block
- preserve asynchronous SSR highlighting and explicitly reuse the server resource during hydration
- keep stale-work protection and return escaped source without nested fallback markup on errors
- add deferred-runtime, retry, stale-load, CSR, and SSR regression coverage
- bump `@elmethis/solid` to `0.3.5`

## Verification
- `pnpm run test.coverage` (306 unit tests and 80 SSR tests)
- `pnpm run test.browser` (97 browser tests)
- `pnpm run check`
- `pnpm run build`
- `pnpm run build-storybook`
- production Storybook network check confirmed unrelated stories do not request Shiki, WASM, or theme chunks; the highlighter story loads them on demand