### PR TITLE
fix(solid): clean up detached auto animate controllers

### DIFF
--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elmethis/solid",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "SolidJS component library for elmethis.",
   "publishConfig": {
     "access": "public"

--- a/packages/solid/src/primitives/create-auto-animate.import-failure.spec.tsx
+++ b/packages/solid/src/primitives/create-auto-animate.import-failure.spec.tsx
@@ -1,0 +1,21 @@
+import { render, waitFor } from "@solidjs/testing-library";
+import { describe, expect, it, vi } from "vitest";
+
+import { createAutoAnimate } from "./create-auto-animate";
+
+vi.mock("@formkit/auto-animate", () => {
+  throw new Error("chunk failed to load");
+});
+
+describe("[CSR] createAutoAnimate import failure", () => {
+  it("degrades gracefully when Auto Animate cannot be loaded", async () => {
+    let api!: ReturnType<typeof createAutoAnimate>;
+
+    render(() => {
+      api = createAutoAnimate();
+      return <div ref={api.ref} />;
+    });
+
+    await waitFor(() => expect(api.controller()).toBeUndefined());
+  });
+});

--- a/packages/solid/src/primitives/create-auto-animate.spec.tsx
+++ b/packages/solid/src/primitives/create-auto-animate.spec.tsx
@@ -124,4 +124,33 @@ describe("[CSR] createAutoAnimate", () => {
     rendered.unmount();
     expect(secondController.destroy).toHaveBeenCalledOnce();
   });
+
+  it("destroys the controller when its element is conditionally removed", async () => {
+    const controller = createController(document.createElement("div"));
+    mocks.autoAnimate.mockReturnValue(controller);
+
+    let api!: ReturnType<typeof createAutoAnimate<HTMLUListElement>>;
+    const rendered = render(() => {
+      api = createAutoAnimate<HTMLUListElement>();
+      const [visible, setVisible] = createSignal(true);
+
+      return (
+        <>
+          <button onClick={() => setVisible(false)}>Hide</button>
+          <Show when={visible()}>
+            <ul ref={api.ref} data-testid="parent" />
+          </Show>
+        </>
+      );
+    });
+
+    await waitFor(() => expect(mocks.autoAnimate).toHaveBeenCalledOnce());
+    expect(api.controller()).toBe(controller);
+
+    await fireEvent.click(rendered.getByRole("button", { name: "Hide" }));
+
+    expect(rendered.queryByTestId("parent")).not.toBeInTheDocument();
+    expect(controller.destroy).toHaveBeenCalledOnce();
+    expect(api.controller()).toBeUndefined();
+  });
 });

--- a/packages/solid/src/primitives/create-auto-animate.ts
+++ b/packages/solid/src/primitives/create-auto-animate.ts
@@ -5,6 +5,7 @@ import type {
 } from "@formkit/auto-animate";
 import {
   createSignal,
+  getOwner,
   onCleanup,
   onMount,
   untrack,
@@ -63,7 +64,12 @@ export function createAutoAnimate<T extends HTMLElement = HTMLElement>(
     destroyController();
     if (nextElement === undefined) return;
 
-    const { default: autoAnimate } = await import("@formkit/auto-animate");
+    let autoAnimate: (typeof import("@formkit/auto-animate"))["default"];
+    try {
+      ({ default: autoAnimate } = await import("@formkit/auto-animate"));
+    } catch {
+      return;
+    }
     if (!mounted || generation !== initialization || element !== nextElement) {
       return;
     }
@@ -80,6 +86,11 @@ export function createAutoAnimate<T extends HTMLElement = HTMLElement>(
     if (normalizedElement === element) return;
 
     element = normalizedElement;
+    if (normalizedElement !== undefined && getOwner()) {
+      onCleanup(() => {
+        if (element === normalizedElement) ref(null);
+      });
+    }
     if (mounted) void initialize(element);
   };
 


### PR DESCRIPTION
## Summary
- destroy Auto Animate controllers when Solid conditionally removes their attached element
- degrade gracefully when the Auto Animate dynamic import fails
- add regressions for conditional removal and rejected imports

## Testing
- `pnpm run test.unit`
- `pnpm run build.types`
- `pnpm exec vitest run --config vitest.browser.config.ts src/primitives/create-auto-animate.browser.spec.tsx`
- focused ESLint and Prettier checks