### PR TITLE
fix(solid): prevent auto animate grid stretching

### DIFF
--- a/packages/solid/src/primitives/create-auto-animate.stories.tsx
+++ b/packages/solid/src/primitives/create-auto-animate.stories.tsx
@@ -62,6 +62,7 @@ const ListStory = (props: CreateAutoAnimateOptions) => {
         ref={ref}
         style={{
           display: "grid",
+          "align-content": "start",
           gap: "0.5rem",
           margin: "0",
           padding: "0",

--- a/packages/solid/src/primitives/create-auto-animate.ts
+++ b/packages/solid/src/primitives/create-auto-animate.ts
@@ -14,7 +14,13 @@ import {
 } from "solid-js";
 
 export interface CreateAutoAnimateOptions {
-  /** Configuration or plugin passed to Auto Animate. */
+  /**
+   * Configuration or plugin passed to Auto Animate.
+   *
+   * When the parent is a grid or wrapping flex container, use a non-stretching
+   * `align-content` value if children should keep their height while the parent
+   * animates between sizes.
+   */
   config?: Partial<AutoAnimateOptions> | AutoAnimationPlugin;
 
   /** Whether animations are initially enabled. Defaults to `true`. */


### PR DESCRIPTION
## Summary
- prevent grid rows in the `createAutoAnimate` story from stretching during item removal
- document the `align-content` caveat for grid and wrapping flex parents

## Root cause
Auto Animate transitions the parent between its old and new explicit heights. CSS Grid defaults `align-content` to `normal`, which stretches auto-sized rows into the temporarily larger animated height. Setting `align-content: start` keeps child heights stable while preserving the parent collapse animation.

## Verification
- remaining story items stayed at 44px throughout removal in Chromium
- `pnpm exec vitest run src/primitives/create-auto-animate.spec.tsx src/primitives/create-auto-animate.import-failure.spec.tsx`
- `pnpm exec vitest run --config vitest.ssr.config.ts src/primitives/create-auto-animate.ssr.spec.tsx`
- `pnpm exec vitest run --config vitest.browser.config.ts src/primitives/create-auto-animate.browser.spec.tsx`
- `pnpm run build.types`
- Prettier check and repository pre-commit checks