### PR TITLE
Refine color tokens and simplify ElmMdiIcon

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elmethis/core",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "author": {
     "name": "Ikuma Yamashita",
     "url": "https://www.ikuma.cloud/"

--- a/packages/core/src/style/token-vars.spec.ts
+++ b/packages/core/src/style/token-vars.spec.ts
@@ -48,6 +48,9 @@ describe("tokenVars", () => {
   });
 
   it("keeps non-primitive literals (computed oklch) verbatim", () => {
+    expect(tokenVars["--elmethis-color-modal-backdrop"]).toBe(
+      "oklch(from black l c h / 50%)",
+    );
     expect(tokenVars["--elmethis-color-primary-hover"]).toBe(
       "oklch(from var(--elmethis-color-primary) l c h / 15%)",
     );

--- a/packages/core/src/style/token-vars.spec.ts
+++ b/packages/core/src/style/token-vars.spec.ts
@@ -51,5 +51,8 @@ describe("tokenVars", () => {
     expect(tokenVars["--elmethis-color-primary-hover"]).toBe(
       "oklch(from var(--elmethis-color-primary) l c h / 15%)",
     );
+    expect(tokenVars["--elmethis-color-selection"]).toBe(
+      "oklch(from var(--elmethis-color-primary) l c h / 25%)",
+    );
   });
 });

--- a/packages/core/src/style/token-vars.spec.ts
+++ b/packages/core/src/style/token-vars.spec.ts
@@ -17,6 +17,9 @@ describe("tokenVars", () => {
   });
 
   it("emits themed tokens as light-dark() over primitive references", () => {
+    expect(tokenVars["--elmethis-color-divider"]).toBe(
+      "light-dark(var(--elmethis-primitive-color-gold-300), var(--elmethis-primitive-color-slate-800))",
+    );
     expect(tokenVars["--elmethis-color-surface-base"]).toBe(
       "light-dark(var(--elmethis-primitive-color-gold-200), var(--elmethis-primitive-color-slate-700))",
     );

--- a/packages/core/src/style/token.ts
+++ b/packages/core/src/style/token.ts
@@ -167,6 +167,7 @@ export const semanticTokens = {
 
   // Surfaces
   "color-divider": theme(color.gold[300], color.slate[800]),
+  "color-modal-backdrop": common("oklch(from black l c h / 50%)"),
   "color-surface-sunken": theme(color.gold[300], color.slate[800]),
   "color-surface-base": theme(color.gold[200], color.slate[700]),
   "color-surface-raised": theme(color.gold[100], color.slate[600]),

--- a/packages/core/src/style/token.ts
+++ b/packages/core/src/style/token.ts
@@ -166,6 +166,7 @@ export const semanticTokens = {
   "color-accent-error-surface": theme(color.red[100], color.red[900]),
 
   // Surfaces
+  "color-divider": theme(color.gold[300], color.slate[800]),
   "color-surface-sunken": theme(color.gold[300], color.slate[800]),
   "color-surface-base": theme(color.gold[200], color.slate[700]),
   "color-surface-raised": theme(color.gold[100], color.slate[600]),

--- a/packages/core/src/style/token.ts
+++ b/packages/core/src/style/token.ts
@@ -147,8 +147,13 @@ export const semanticTokens = {
   ),
 
   // Accents
+  "color-accent-link-surface": theme(color.blue[100], color.blue[900]),
   "color-accent-link": common(color.blue[500]),
   "color-accent-link-visited": common(color.purple[500]),
+  "color-accent-link-surface-visited": theme(
+    color.purple[100],
+    color.purple[900],
+  ),
 
   "color-accent-info": common(color.blue[500]),
   "color-accent-info-surface": theme(color.blue[100], color.blue[900]),

--- a/packages/core/src/style/token.ts
+++ b/packages/core/src/style/token.ts
@@ -183,6 +183,9 @@ export const semanticTokens = {
   "color-primary-hover": common(
     "oklch(from var(--elmethis-color-primary) l c h / 15%)",
   ),
+  "color-selection": common(
+    "oklch(from var(--elmethis-color-primary) l c h / 25%)",
+  ),
 
   // Display
   "color-display-red": common(color.red[500]),

--- a/packages/qwik/.storybook/sb.css
+++ b/packages/qwik/.storybook/sb.css
@@ -5,5 +5,5 @@ html {
 body,
 .docs-story {
   transition: background-color 200ms;
-  background-color: light-dark(#efecea, #393e46);
+  background-color: var(--elmethis-color-surface-base);
 }

--- a/packages/qwik/package.json
+++ b/packages/qwik/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elmethis/qwik",
-  "version": "1.0.0-alpha.47",
+  "version": "1.0.0-alpha.48",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/qwik/src/components/a2ui/elm-a2ui.module.css
+++ b/packages/qwik/src/components/a2ui/elm-a2ui.module.css
@@ -94,11 +94,11 @@
 /* ---- card ---- */
 
 .card {
-  border: 1px solid #e0e0e0;
+  border: 1px solid var(--elmethis-color-divider);
   border-radius: 8px;
   padding: 16px;
-  background: #fff;
-  box-shadow: 0 1px 3px rgb(0 0 0 / 8%);
+  background: var(--elmethis-color-surface-raised);
+  box-shadow: 0 1px 3px var(--elmethis-box-shadow-color);
 }
 
 /* ---- button ---- */
@@ -109,7 +109,7 @@
   justify-content: center;
   gap: 4px;
   padding: 8px 16px;
-  border: 1px solid #ccc;
+  border: 1px solid var(--elmethis-color-divider);
   border-radius: 4px;
   background: transparent;
   cursor: pointer;
@@ -119,17 +119,20 @@
 }
 
 .button:hover {
-  background: rgb(0 0 0 / 5%);
+  background: var(--elmethis-color-primary-hover);
 }
 
 .button-primary {
-  background: var(--a2ui-primary, #1976d2);
+  background: var(--a2ui-primary, var(--elmethis-color-primary));
   border-color: transparent;
-  color: #fff;
+  color: oklch(
+    from contrast-color(var(--a2ui-primary, var(--elmethis-color-primary))) l c
+      h / 65%
+  );
 }
 
 .button-primary:hover {
-  background: var(--a2ui-primary-hover, #1565c0);
+  background: var(--a2ui-primary-hover, var(--elmethis-color-primary-strong));
 }
 
 /* ---- image ---- */
@@ -153,13 +156,13 @@
 
 .divider {
   border: none;
-  border-top: 1px solid #e0e0e0;
+  border-top: 1px solid var(--elmethis-color-divider);
   margin: 8px 0;
 }
 
 .divider-vertical {
   border-top: none;
-  border-left: 1px solid #e0e0e0;
+  border-left: 1px solid var(--elmethis-color-divider);
   margin: 0 8px;
   align-self: stretch;
   width: 0;
@@ -176,12 +179,12 @@
 .label {
   font-size: 0.75rem;
   font-weight: 500;
-  color: #555;
+  color: var(--elmethis-color-neutral-strong);
 }
 
 .input {
   padding: 8px 10px;
-  border: 1px solid #ccc;
+  border: 1px solid var(--elmethis-color-divider);
   border-radius: 4px;
   font-size: 0.875rem;
   outline: none;
@@ -189,7 +192,7 @@
 }
 
 .input:focus {
-  border-color: var(--a2ui-primary, #1976d2);
+  border-color: var(--a2ui-primary, var(--elmethis-color-primary));
 }
 
 .checkbox {
@@ -238,7 +241,7 @@
 .choice-picker-label {
   font-size: 0.75rem;
   font-weight: 500;
-  color: #555;
+  color: var(--elmethis-color-neutral-strong);
 }
 
 .choice-picker-options {

--- a/packages/qwik/src/components/ag-ui-client/components/elm-ag-ui-agent.module.css
+++ b/packages/qwik/src/components/ag-ui-client/components/elm-ag-ui-agent.module.css
@@ -5,7 +5,8 @@
   width: 100%;
   height: 100%;
   overflow-y: auto;
-  scrollbar-color: gray transparent;
+  scrollbar-color: var(--elmethis-color-primary-weak)
+    var(--elmethis-color-surface-base);
   scrollbar-gutter: stable;
   scrollbar-width: thin;
   display: flex;
@@ -32,7 +33,7 @@
         align-items: flex-start;
         justify-content: flex-start;
         gap: 0.5rem;
-        background-color: oklch(from #c56565 l c h / 10%);
+        background-color: var(--elmethis-color-accent-error-surface);
       }
     }
   }
@@ -65,7 +66,7 @@
           padding: 0.25rem 0.5rem;
           border-radius: 0.25rem;
           background-color: var(--elmethis-color-surface-raised);
-          box-shadow: 0 0 0.25rem rgb(0 0 0 / 10%);
+          box-shadow: 0 0 0.25rem var(--elmethis-box-shadow-color);
           opacity: 0.85;
 
           .queue-item-icon {
@@ -94,7 +95,7 @@
             transition: background-color 200ms;
 
             &:hover {
-              background-color: oklch(from gray l c h / 25%);
+              background-color: var(--elmethis-color-accent-error-surface);
             }
           }
         }
@@ -114,7 +115,7 @@
           padding: 0.5rem;
           cursor: pointer;
           gap: 0.5rem;
-          box-shadow: 0 0 0.25rem rgb(0 0 0 / 10%);
+          box-shadow: 0 0 0.25rem var(--elmethis-box-shadow-color);
           background-color: var(--elmethis-color-surface-raised);
           border-radius: 1rem;
           transition: opacity 200ms;
@@ -142,6 +143,6 @@
   cursor: pointer;
 
   &:hover {
-    background-color: oklch(from gray l c h / 25%);
+    background-color: var(--elmethis-color-surface-sunken);
   }
 }

--- a/packages/qwik/src/components/ag-ui-client/components/elm-ag-ui-agent.tsx
+++ b/packages/qwik/src/components/ag-ui-client/components/elm-ag-ui-agent.tsx
@@ -175,7 +175,7 @@ export const ElmAgUiAgent = component$<ElmAgUiAgentProps>((props) => {
             <>
               <div class={styles["error"]}>
                 <ElmMdiIcon
-                  d={mdiAlert}
+                  path={mdiAlert}
                   color="var(--elmethis-color-accent-error)"
                   style={{ flexShrink: 0 }}
                 />
@@ -185,7 +185,7 @@ export const ElmAgUiAgent = component$<ElmAgUiAgentProps>((props) => {
               </div>
 
               <span class={styles["clickable-icon"]} onClick$={retry$}>
-                <ElmMdiIcon d={mdiRefresh} size="1.25rem" />
+                <ElmMdiIcon path={mdiRefresh} size="1.25rem" />
               </span>
             </>
           )}
@@ -200,7 +200,7 @@ export const ElmAgUiAgent = component$<ElmAgUiAgentProps>((props) => {
                 <div key={queued.id} class={styles["queue-item"]}>
                   <ElmMdiIcon
                     class={styles["queue-item-icon"]}
-                    d={mdiClockOutline}
+                    path={mdiClockOutline}
                     size="1rem"
                   />
                   <span class={styles["queue-item-text"]}>
@@ -214,7 +214,7 @@ export const ElmAgUiAgent = component$<ElmAgUiAgentProps>((props) => {
                     onClick$={onDequeueClick$}
                     aria-label="Remove from queue"
                   >
-                    <ElmMdiIcon d={mdiClose} size="0.875rem" />
+                    <ElmMdiIcon path={mdiClose} size="0.875rem" />
                   </span>
                 </div>
               ))}
@@ -232,7 +232,7 @@ export const ElmAgUiAgent = component$<ElmAgUiAgentProps>((props) => {
                 >
                   <ElmMdiIcon
                     class={styles["prompt-template-tip-icon"]}
-                    d={mdiForumOutline}
+                    path={mdiForumOutline}
                   />
                   <ElmInlineText>{template.description}</ElmInlineText>
                 </span>

--- a/packages/qwik/src/components/ag-ui-client/components/elm-ag-ui-input.module.css
+++ b/packages/qwik/src/components/ag-ui-client/components/elm-ag-ui-input.module.css
@@ -27,8 +27,8 @@
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-  background-color: #f7f7f9;
-  box-shadow: 0 0 2px oklch(from black l c h / 25%);
+  background-color: var(--elmethis-color-surface-raised);
+  box-shadow: 0 0 2px var(--elmethis-box-shadow-color);
 
   .input {
     /*
@@ -76,7 +76,7 @@
     width: 1.5rem;
     height: 1.5rem;
     border-radius: 0.25rem;
-    background-color: oklch(from black l c h / 60%);
+    background-color: var(--elmethis-color-neutral);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -93,7 +93,7 @@
     width: 1.5rem;
     height: 1.5rem;
     border-radius: 0.25rem;
-    background-color: oklch(from black l c h / 75%);
+    background-color: var(--elmethis-color-neutral);
     display: flex;
     align-items: center;
     justify-content: center;

--- a/packages/qwik/src/components/ag-ui-client/components/elm-ag-ui-input.tsx
+++ b/packages/qwik/src/components/ag-ui-client/components/elm-ag-ui-input.tsx
@@ -314,7 +314,7 @@ export const ElmAgUiInput = component$<ElmAgUiInputProps>(
                 }
               >
                 <ElmMdiIcon
-                  d={isPickerOpen.value ? mdiClose : mdiPlus}
+                  path={isPickerOpen.value ? mdiClose : mdiPlus}
                   size="1rem"
                   color="white"
                 />
@@ -342,7 +342,7 @@ export const ElmAgUiInput = component$<ElmAgUiInputProps>(
                 onClick$={onAbort$}
                 aria-label="Stop"
               >
-                <ElmMdiIcon d={mdiStop} size="1rem" color="white" />
+                <ElmMdiIcon path={mdiStop} size="1rem" color="white" />
               </div>
             )}
 
@@ -351,7 +351,7 @@ export const ElmAgUiInput = component$<ElmAgUiInputProps>(
               onClick$={onSubmit}
               aria-label="Send"
             >
-              <ElmMdiIcon d={mdiSend} size="1rem" color="white" />
+              <ElmMdiIcon path={mdiSend} size="1rem" color="white" />
             </div>
           </div>
         </div>

--- a/packages/qwik/src/components/ag-ui-client/components/elm-ag-ui-message-renderer.module.css
+++ b/packages/qwik/src/components/ag-ui-client/components/elm-ag-ui-message-renderer.module.css
@@ -40,7 +40,7 @@
     flex-grow: 1;
     height: 1px;
     width: 100%;
-    background-color: oklch(from grey l c h / 12.5%);
+    background-color: var(--elmethis-color-divider);
   }
 }
 
@@ -62,7 +62,7 @@
   cursor: pointer;
 
   &:hover {
-    background-color: oklch(from gray l c h / 25%);
+    background-color: var(--elmethis-color-surface-sunken);
   }
 }
 

--- a/packages/qwik/src/components/ag-ui-client/components/elm-ag-ui-message-renderer.tsx
+++ b/packages/qwik/src/components/ag-ui-client/components/elm-ag-ui-message-renderer.tsx
@@ -109,7 +109,7 @@ export const ElmAgUiMessageRenderer = component$<ElmAgUiMessageRendererProps>(
                     <div class={styles["message-content-type"]}>
                       <ElmMdiIcon
                         class={styles["message-content-icon"]}
-                        d={mdiCreation}
+                        path={mdiCreation}
                       />
                       <ElmInlineText>Assistant</ElmInlineText>
                       <div
@@ -131,7 +131,7 @@ export const ElmAgUiMessageRenderer = component$<ElmAgUiMessageRendererProps>(
                           class={styles["clickable-icon"]}
                           onClick$={handleRetry$}
                         >
-                          <ElmMdiIcon d={mdiRefresh} size="1.25rem" />
+                          <ElmMdiIcon path={mdiRefresh} size="1.25rem" />
                         </span>
                       </div>
                     )}
@@ -201,7 +201,7 @@ export const ElmAgUiMessageRenderer = component$<ElmAgUiMessageRendererProps>(
                 <div q:slot="summary" class={styles["message-content-type"]}>
                   <ElmMdiIcon
                     class={styles["message-content-icon"]}
-                    d={mdiLightbulbOn}
+                    path={mdiLightbulbOn}
                   />
                   <ElmInlineText>Reasoning</ElmInlineText>
                   <div
@@ -267,7 +267,7 @@ export const ElmAgUiMessageRenderer = component$<ElmAgUiMessageRendererProps>(
                 <div class={styles["message-content-type"]}>
                   <ElmMdiIcon
                     class={styles["message-content-icon"]}
-                    d={mdiAccount}
+                    path={mdiAccount}
                   />
                   <ElmInlineText>User</ElmInlineText>
                   <div

--- a/packages/qwik/src/components/ag-ui-client/components/elm-ag-ui-prompt-picker.module.css
+++ b/packages/qwik/src/components/ag-ui-client/components/elm-ag-ui-prompt-picker.module.css
@@ -3,20 +3,22 @@
   width: 100%;
   max-height: min(420px, 60vh);
   overflow-y: auto;
-  background-color: white;
+  color: var(--elmethis-color-neutral);
+  background-color: var(--elmethis-color-surface-raised);
   border-radius: 0.5rem;
   padding: 0.25rem;
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
-  scrollbar-color: gray transparent;
+  scrollbar-color: var(--elmethis-color-primary-weak)
+    var(--elmethis-color-surface-base);
   scrollbar-width: thin;
 }
 
 .empty {
   padding: 1rem;
   text-align: center;
-  color: gray;
+  color: var(--elmethis-color-neutral-weak);
   font-size: 0.875rem;
 }
 
@@ -30,9 +32,12 @@
   gap: 0.25rem;
 }
 
-.prompt-row:hover,
+.prompt-row:hover {
+  background-color: var(--elmethis-color-surface-sunken);
+}
+
 .prompt-row-active {
-  background-color: oklch(from gray l c h / 8%);
+  background-color: var(--elmethis-color-surface-base);
 }
 
 .prompt-head {
@@ -48,7 +53,7 @@
 
 .prompt-description {
   font-size: 0.8rem;
-  color: gray;
+  color: var(--elmethis-color-neutral-weak);
   line-height: 1.3;
 }
 
@@ -57,9 +62,10 @@
   width: min(440px, calc(100vw - 2rem));
   max-height: calc(100vh - 4rem);
   overflow-y: auto;
-  background-color: white;
+  color: var(--elmethis-color-neutral);
+  background-color: var(--elmethis-color-surface-raised);
   border-radius: 0.5rem;
-  box-shadow: 0 8px 24px rgb(0 0 0 / 18%);
+  box-shadow: 0 0 0.125rem var(--elmethis-box-shadow-color);
   padding: 1rem;
   display: flex;
   flex-direction: column;
@@ -79,7 +85,7 @@
 
 .modal-description {
   font-size: 0.85rem;
-  color: gray;
+  color: var(--elmethis-color-neutral-weak);
   line-height: 1.4;
 }
 
@@ -98,8 +104,8 @@
 .use-button {
   appearance: none;
   border: none;
-  background-color: oklch(from black l c h / 85%);
-  color: white;
+  background-color: var(--elmethis-color-neutral);
+  color: var(--elmethis-color-surface-raised);
   padding: 0.4rem 0.9rem;
   border-radius: 0.25rem;
   cursor: pointer;
@@ -118,23 +124,26 @@
 
 .cancel-button {
   appearance: none;
-  border: 1px solid oklch(from gray l c h / 30%);
+  border: 1px solid var(--elmethis-color-divider);
   background-color: transparent;
   color: inherit;
   padding: 0.4rem 0.9rem;
   border-radius: 0.25rem;
   cursor: pointer;
   font-size: 0.875rem;
-  transition: background-color 150ms;
+  transition:
+    color 100ms,
+    background-color 100ms;
 }
 
 .cancel-button:hover {
-  background-color: oklch(from gray l c h / 8%);
+  color: contrast-color(var(--elmethis-color-neutral));
+  background-color: var(--elmethis-color-neutral-weak);
 }
 
 .error {
   font-size: 0.8rem;
-  color: #c56565;
+  color: var(--elmethis-color-accent-error);
 }
 
 .field-label {
@@ -145,12 +154,12 @@
 }
 
 .field-name {
-  color: gray;
+  color: var(--elmethis-color-neutral-weak);
   font-size: 0.75rem;
 }
 
 .field-required {
-  color: #c56565;
+  color: var(--elmethis-color-accent-error);
   margin-inline-start: 0.2rem;
 }
 
@@ -158,16 +167,17 @@
   box-sizing: border-box;
   width: 100%;
   padding: 0.4rem 0.5rem;
-  border: 1px solid oklch(from gray l c h / 30%);
+  border: 1px solid var(--elmethis-color-divider);
   border-radius: 0.25rem;
-  background-color: white;
+  color: inherit;
+  background-color: var(--elmethis-color-surface-raised);
   font: inherit;
   outline: none;
   transition: border-color 150ms;
 }
 
 .field-input:focus {
-  border-color: oklch(from black l c h / 50%);
+  border-color: var(--elmethis-color-primary);
 }
 
 /*
@@ -176,7 +186,7 @@
   it visible after a choice is made.
 */
 .field-hint {
-  color: gray;
+  color: var(--elmethis-color-neutral-weak);
   font-size: 0.72rem;
   line-height: 1.3;
 }

--- a/packages/qwik/src/components/ag-ui-client/components/elm-ag-ui-status.tsx
+++ b/packages/qwik/src/components/ag-ui-client/components/elm-ag-ui-status.tsx
@@ -131,7 +131,7 @@ export const ElmAgUiStatus = component$<ElmAgUiStatusProps>(
           class={styles["reel"]}
         >
           <ElmMdiIcon
-            d={view.d}
+            path={view.d}
             size="1rem"
             color={view.color}
             class={view.pulse ? styles.pulse : undefined}

--- a/packages/qwik/src/components/ag-ui-client/components/elm-ag-ui-tool-execution.tsx
+++ b/packages/qwik/src/components/ag-ui-client/components/elm-ag-ui-tool-execution.tsx
@@ -115,7 +115,7 @@ export const ElmAgUiToolExecution = component$<ElmAgUiToolExecutionProps>(
       >
         <ElmToggle isOpen={isOpen} monochrome>
           <div q:slot="summary" class={styles.summary}>
-            <ElmMdiIcon d={mdiHammerScrewdriver} size="1rem" />
+            <ElmMdiIcon path={mdiHammerScrewdriver} size="1rem" />
             <ElmInlineText>{toolName}</ElmInlineText>
           </div>
 
@@ -124,7 +124,7 @@ export const ElmAgUiToolExecution = component$<ElmAgUiToolExecutionProps>(
               past TOOL_CALL_START (i.e. arguments have been prepared). */}
           <div class={styles.summary}>
             <ElmMdiIcon
-              d={mdiFunctionVariant}
+              path={mdiFunctionVariant}
               size="1rem"
               color={
                 toolEventType === EventType.TOOL_CALL_START
@@ -138,7 +138,7 @@ export const ElmAgUiToolExecution = component$<ElmAgUiToolExecutionProps>(
           {isArgsShown.value && (
             <ElmToggle isOpen={isArgsOpen} monochrome>
               <div q:slot="summary" class={styles.summary}>
-                <ElmMdiIcon d={mdiCodeJson} size="1rem" />
+                <ElmMdiIcon path={mdiCodeJson} size="1rem" />
                 <ElmInlineText>Args</ElmInlineText>
               </div>
 
@@ -153,7 +153,7 @@ export const ElmAgUiToolExecution = component$<ElmAgUiToolExecutionProps>(
           {toolEventType === EventType.TOOL_CALL_START ? null : (
             <div class={styles.summary}>
               <ElmMdiIcon
-                d={mdiWrenchClock}
+                path={mdiWrenchClock}
                 size="1rem"
                 color={
                   toolEventType === EventType.TOOL_CALL_ARGS ||
@@ -174,7 +174,7 @@ export const ElmAgUiToolExecution = component$<ElmAgUiToolExecutionProps>(
           {isResultShown.value && (
             <ElmToggle isOpen={isResultOpen} monochrome>
               <div q:slot="summary" class={styles.summary}>
-                <ElmMdiIcon d={mdiCodeJson} size="1rem" />
+                <ElmMdiIcon path={mdiCodeJson} size="1rem" />
                 <ElmInlineText>Result</ElmInlineText>
               </div>
 

--- a/packages/qwik/src/components/ag-ui-client/components/input-content/elm-ag-ui-input-content.module.css
+++ b/packages/qwik/src/components/ag-ui-client/components/input-content/elm-ag-ui-input-content.module.css
@@ -18,12 +18,9 @@
   padding: 0.25rem;
   width: 6rem;
   height: 6rem;
-  border: solid 1px oklch(from gray l c h / 25%);
+  border: solid 1px var(--elmethis-color-divider);
   border-radius: 0.25rem;
-  background-color: light-dark(
-    oklch(from white l c h / 25%),
-    oklch(from black l c h / 25%)
-  );
+  background-color: var(--elmethis-color-surface-raised);
   overflow: hidden;
 
   .image {
@@ -38,10 +35,7 @@
     height: 100%;
     white-space: wrap;
     font-size: 0.25rem;
-    color: light-dark(
-      oklch(from gray l c h / 75%),
-      oklch(from white l c h / 75%)
-    );
+    color: var(--elmethis-color-neutral);
     user-select: none;
   }
 
@@ -62,20 +56,9 @@
     font-family: monospace;
     font-size: 0.65rem;
     border-radius: 0.125rem;
-    background-color: oklch(from white l c h / 80%);
+    background-color: var(--elmethis-color-surface-base);
     backdrop-filter: blur(0.25rem);
-    color: light-dark(
-      var(--elmethis-scoped-color, #606875),
-      var(--elmethis-scoped-color, #b0b5be)
-    );
-
-    &::selection {
-      color: light-dark(#cccfd5, #3e434b);
-      background-color: light-dark(
-        var(--elmethis-scoped-color, #3e434b),
-        var(--elmethis-scoped-color, #cccfd5)
-      );
-    }
+    color: var(--elmethis-color-primary);
   }
 }
 
@@ -84,5 +67,5 @@
   width: fit-content;
   padding: 0.5rem;
   border-radius: 0.25rem;
-  background-color: oklch(from grey l c h / 10%);
+  background-color: var(--elmethis-color-surface-raised);
 }

--- a/packages/qwik/src/components/ag-ui-client/components/input-content/elm-ag-ui-input-content.tsx
+++ b/packages/qwik/src/components/ag-ui-client/components/input-content/elm-ag-ui-input-content.tsx
@@ -45,7 +45,7 @@ export const ElmAgUiInputContent = component$<ElmAgUiInputContentImageProps>(
                   class={[styles["media-component"], className]}
                   style={style}
                 >
-                  <ElmMdiIcon class={styles["type-icon"]} d={mdiTextBox} />
+                  <ElmMdiIcon class={styles["type-icon"]} path={mdiTextBox} />
                   <div>
                     <pre class={styles.text}>{content.source.value}</pre>
                   </div>
@@ -70,7 +70,7 @@ export const ElmAgUiInputContent = component$<ElmAgUiInputContentImageProps>(
 
             mediaComponents.push(
               <div class={[styles["media-component"], className]} style={style}>
-                <ElmMdiIcon class={styles["type-icon"]} d={mdiImage} />
+                <ElmMdiIcon class={styles["type-icon"]} path={mdiImage} />
                 <img class={styles.image} width={96} height={96} src={url} />
                 {source.mimeType && (
                   <div class={styles["mime-type-label"]}>{source.mimeType}</div>

--- a/packages/qwik/src/components/code/elm-code-block.module.css
+++ b/packages/qwik/src/components/code/elm-code-block.module.css
@@ -33,7 +33,7 @@
   grid-area: divider;
   width: calc(100% - 1rem);
   border: none;
-  border-bottom: solid 1px rgb(128 128 128 / 50%);
+  border-bottom: solid 1px var(--elmethis-color-divider);
 }
 
 .code {

--- a/packages/qwik/src/components/code/elm-html-viewer.module.css
+++ b/packages/qwik/src/components/code/elm-html-viewer.module.css
@@ -51,7 +51,7 @@
   width: calc(100% - 1rem);
   margin-inline: auto;
   border: none;
-  border-bottom: solid 1px rgb(128 128 128 / 50%);
+  border-bottom: solid 1px var(--elmethis-color-divider);
 }
 
 .content {

--- a/packages/qwik/src/components/code/elm-html-viewer.tsx
+++ b/packages/qwik/src/components/code/elm-html-viewer.tsx
@@ -145,7 +145,7 @@ export const ElmHtmlViewer = component$<ElmHtmlViewerProps>(
             onClick$={handleDownload}
             aria-label="Download"
           >
-            <ElmMdiIcon d={mdiDownload} size="1.25rem" />
+            <ElmMdiIcon path={mdiDownload} size="1.25rem" />
           </button>
 
           <button
@@ -154,7 +154,7 @@ export const ElmHtmlViewer = component$<ElmHtmlViewerProps>(
             onClick$={handleOpenInNewTab}
             aria-label="Open in new tab"
           >
-            <ElmMdiIcon d={mdiOpenInNew} size="1.25rem" />
+            <ElmMdiIcon path={mdiOpenInNew} size="1.25rem" />
           </button>
         </div>
 

--- a/packages/qwik/src/components/code/elm-shiki-highlighter.module.css
+++ b/packages/qwik/src/components/code/elm-shiki-highlighter.module.css
@@ -22,7 +22,7 @@
     /* stylelint-enable csstools/value-no-unknown-custom-properties */
 
     &::selection {
-      background-color: oklch(from #cdb57b l c h / 25%);
+      background-color: var(--elmethis-color-selection);
     }
   }
 }

--- a/packages/qwik/src/components/containments/elm-modal.module.css
+++ b/packages/qwik/src/components/containments/elm-modal.module.css
@@ -27,6 +27,6 @@
     opacity: 0;
     transition: opacity var(--elmethis-scoped-modal-delay, 200ms);
     background-color: transparent;
-    background-color: oklch(from black l c h / 50%);
+    background-color: var(--elmethis-color-modal-backdrop);
   }
 }

--- a/packages/qwik/src/components/containments/elm-toggle.module.css
+++ b/packages/qwik/src/components/containments/elm-toggle.module.css
@@ -39,7 +39,7 @@
     margin: 0 1rem;
     height: 1px;
     width: 100%;
-    background-color: oklch(from gray l c h / 12.5%);
+    background-color: var(--elmethis-color-divider);
   }
 
   &:hover {
@@ -78,7 +78,7 @@
   width: 1px;
   margin-left: 1rem;
   height: 100%;
-  background-color: oklch(from gray l c h / 12.5%);
+  background-color: var(--elmethis-color-divider);
 }
 
 .content {

--- a/packages/qwik/src/components/containments/elm-toggle.tsx
+++ b/packages/qwik/src/components/containments/elm-toggle.tsx
@@ -62,7 +62,7 @@ export const ElmToggle = component$<ElmToggleProps>((props) => {
         <div class={styles["summary-left"]}>
           <span class={[styles.chevron, { [styles.open]: isOpen.value }]}>
             <ElmMdiIcon
-              d={mdiChevronRight}
+              path={mdiChevronRight}
               color={
                 monochrome
                   ? "var(--elmethis-color-neutral-weak)"
@@ -84,7 +84,7 @@ export const ElmToggle = component$<ElmToggleProps>((props) => {
 
         <span class={[styles.cross, { [styles.open]: isOpen.value }]}>
           <ElmMdiIcon
-            d={mdiPlus}
+            path={mdiPlus}
             size="1rem"
             color={
               monochrome

--- a/packages/qwik/src/components/form/elm-button-dropdown.module.css
+++ b/packages/qwik/src/components/form/elm-button-dropdown.module.css
@@ -27,7 +27,7 @@
     border-bottom-left-radius: 0;
     padding-left: 0.75rem;
     padding-right: 0.75rem;
-    border-left: 1px solid light-dark(rgb(0 0 0 / 15%), rgb(255 255 255 / 20%));
+    border-left: 1px solid var(--elmethis-color-divider);
   }
 
   /* Keep the joined control from shifting per-segment on hover/active. */
@@ -45,8 +45,8 @@
     width: max-content;
     min-width: 100%;
     border-radius: 0.25rem;
-    background-color: light-dark(rgb(255 255 255 / 95%), rgb(51 51 51 / 95%));
-    box-shadow: 0 0 0.125rem light-dark(rgb(0 0 0 / 15%), rgb(0 0 0 / 75%));
+    background-color: var(--elmethis-color-surface-raised);
+    box-shadow: 0 0 0.125rem var(--elmethis-box-shadow-color);
 
     .item {
       overflow: hidden;
@@ -62,18 +62,16 @@
       cursor: pointer;
 
       &:hover {
-        background-color: light-dark(
-          rgb(190 194 202 / 30%),
-          rgb(190 194 202 / 20%)
-        );
+        background-color: var(--elmethis-color-surface-sunken);
       }
 
       &.selected {
-        background-color: light-dark(
-          rgb(190 194 202 / 25%),
-          rgb(190 194 202 / 15%)
-        );
+        background-color: var(--elmethis-color-surface-base);
         color: var(--elmethis-color-primary-weak);
+
+        &:hover {
+          background-color: var(--elmethis-color-surface-sunken);
+        }
       }
 
       &.item-disabled {

--- a/packages/qwik/src/components/form/elm-button-dropdown.tsx
+++ b/packages/qwik/src/components/form/elm-button-dropdown.tsx
@@ -214,7 +214,7 @@ export const ElmButtonDropdown = component$<ElmButtonDropdownProps>((props) => {
           void setOpen$(!isOpen.value);
         })}
       >
-        <ElmMdiIcon d={dropdownIcon} size="1.25rem" />
+        <ElmMdiIcon path={dropdownIcon} size="1.25rem" />
       </ElmButton>
 
       <ElmCollapse isOpen={isOpen.value} class={styles.menu}>
@@ -240,7 +240,7 @@ export const ElmButtonDropdown = component$<ElmButtonDropdownProps>((props) => {
             }}
           >
             <ElmMdiIcon
-              d={mdiChevronRight}
+              path={mdiChevronRight}
               color="var(--elmethis-color-primary-weak)"
               size="0.75em"
             />

--- a/packages/qwik/src/components/form/elm-button.module.css
+++ b/packages/qwik/src/components/form/elm-button.module.css
@@ -46,13 +46,13 @@
   &:hover {
     transform: translateX(-1px) translateY(-1px);
     opacity: var(--elmethis-scoped-opacity, 0.7);
-    box-shadow: 0.125rem 0.125rem 0.125rem rgb(128 128 128 / 25%);
+    box-shadow: 0.125rem 0.125rem 0.125rem var(--elmethis-box-shadow-color);
   }
 
   &:active {
     transform: translateX(1px) translateY(1px);
     opacity: var(--elmethis-scoped-opacity, 0.5);
-    box-shadow: -1px -1px 0.125rem rgb(128 128 128 / 25%);
+    box-shadow: -1px -1px 0.125rem var(--elmethis-box-shadow-color);
   }
 }
 
@@ -78,19 +78,4 @@
     transform: scale(1.2);
     opacity: 0;
   }
-}
-
-.ripple {
-  position: absolute;
-  pointer-events: none;
-  border-radius: 50%;
-  background-color: rgb(205 181 123 / 15%);
-  width: 100%;
-  aspect-ratio: 1 / 1;
-  transition: none;
-  opacity: 0;
-  animation-name: button-ripple;
-  animation-duration: 300ms;
-  animation-fill-mode: both;
-  animation-timing-function: ease-out;
 }

--- a/packages/qwik/src/components/form/elm-button.stories.tsx
+++ b/packages/qwik/src/components/form/elm-button.stories.tsx
@@ -44,11 +44,11 @@ export const Flex: Story = {
     return (
       <div style="display: flex; gap: 1rem;">
         <ElmButton {...this.args}>
-          <ElmMdiIcon d={mdiSquareEditOutline} size="1.25rem" />
+          <ElmMdiIcon path={mdiSquareEditOutline} size="1.25rem" />
           elm-button
         </ElmButton>
         <ElmButton {...this.args}>
-          <ElmMdiIcon d={mdiSquareEditOutline} size="1.25rem" />
+          <ElmMdiIcon path={mdiSquareEditOutline} size="1.25rem" />
           elm-button
         </ElmButton>
       </div>
@@ -69,11 +69,11 @@ export const WithPrimary: Story = {
     return (
       <div style="display: flex; gap: 1rem;">
         <ElmButton {...this.args} primary>
-          <ElmMdiIcon d={mdiSquareEditOutline} size="1.25rem" />
+          <ElmMdiIcon path={mdiSquareEditOutline} size="1.25rem" />
           elm-button
         </ElmButton>
         <ElmButton {...this.args}>
-          <ElmMdiIcon d={mdiSquareEditOutline} size="1.25rem" />
+          <ElmMdiIcon path={mdiSquareEditOutline} size="1.25rem" />
           elm-button
         </ElmButton>
       </div>

--- a/packages/qwik/src/components/form/elm-button.tsx
+++ b/packages/qwik/src/components/form/elm-button.tsx
@@ -3,8 +3,6 @@ import {
   component$,
   PropsOf,
   Slot,
-  useSignal,
-  useTask$,
   type CSSProperties,
   type QRL,
 } from "@qwik.dev/core";
@@ -37,8 +35,6 @@ export interface ElmButtonProps extends PropsOf<"button"> {
 }
 
 export const ElmButton = component$<ElmButtonProps>((props) => {
-  const clicked = useSignal(false);
-  const timer = useSignal<ReturnType<typeof setTimeout>>();
   const {
     class: className,
     onClick$,
@@ -50,17 +46,9 @@ export const ElmButton = component$<ElmButtonProps>((props) => {
     ...rest
   } = props;
 
-  // Clear the ripple timer on unmount so it can't write to a destroyed signal.
-  useTask$(({ cleanup }) => {
-    cleanup(() => clearTimeout(timer.value));
-  });
-
   const handleClick = $(async () => {
     if (!props.isLoading && !props.disabled) {
       if (onClick$) {
-        clicked.value = true;
-        clearTimeout(timer.value);
-        timer.value = setTimeout(() => (clicked.value = false), 300);
         await onClick$();
       }
     }
@@ -94,8 +82,6 @@ export const ElmButton = component$<ElmButtonProps>((props) => {
       }
       {...rest}
     >
-      {clicked.value && <span class={styles.ripple}></span>}
-
       {isLoading ? (
         <ElmDotLoadingIcon size="1.5rem" />
       ) : (

--- a/packages/qwik/src/components/form/elm-checkbox.module.css
+++ b/packages/qwik/src/components/form/elm-checkbox.module.css
@@ -20,7 +20,7 @@
 }
 
 .checkbox {
-  stroke: light-dark(rgb(0 0 0 / 80%), rgb(255 255 255 / 80%));
+  stroke: var(--elmethis-color-neutral-strong);
   fill: transparent;
 }
 
@@ -32,13 +32,13 @@
   }
 
   &.checked {
-    fill: light-dark(rgb(0 0 0 / 80%), rgb(255 255 255 / 80%));
+    fill: var(--elmethis-color-neutral-strong);
   }
 }
 
 .loading-dot {
   transition: opacity 200ms;
-  fill: light-dark(rgb(0 0 0 / 70%), rgb(255 255 255 / 70%));
+  fill: var(--elmethis-color-neutral-strong);
 }
 
 @keyframes elmethis-checkbox-check-line {
@@ -59,5 +59,5 @@
   animation-delay: 0.1s;
   animation-fill-mode: both;
   transform-origin: center;
-  stroke: light-dark(rgb(255 255 255 / 90%), rgb(0 0 0 / 90%));
+  stroke: contrast-color(var(--elmethis-color-neutral-strong));
 }

--- a/packages/qwik/src/components/form/elm-select.module.css
+++ b/packages/qwik/src/components/form/elm-select.module.css
@@ -80,8 +80,8 @@
       width: max-content;
       padding: 0;
       border-radius: 0.25rem;
-      background-color: light-dark(rgb(255 255 255 / 95%), rgb(51 51 51 / 95%));
-      box-shadow: 0 0 0.125rem light-dark(rgb(0 0 0 / 15%), rgb(0 0 0 / 75%));
+      background-color: var(--elmethis-color-surface-raised);
+      box-shadow: 0 0 0.125rem var(--elmethis-box-shadow-color);
 
       .option {
         overflow: hidden;
@@ -97,10 +97,7 @@
         cursor: pointer;
 
         &:hover {
-          background-color: light-dark(
-            rgb(190 194 202 / 30%),
-            rgb(190 194 202 / 20%)
-          );
+          background-color: var(--elmethis-color-surface-sunken);
         }
       }
     }

--- a/packages/qwik/src/components/form/elm-select.stories.tsx
+++ b/packages/qwik/src/components/form/elm-select.stories.tsx
@@ -80,7 +80,7 @@ const WithIconSelect = component$(() => {
       options={OPTIONS}
       selectedOptionId={selectedOptionId}
     >
-      <ElmMdiIcon q:slot="icon" d={mdiAccountOutline} />
+      <ElmMdiIcon q:slot="icon" path={mdiAccountOutline} />
     </ElmSelect>
   );
 });

--- a/packages/qwik/src/components/form/elm-select.tsx
+++ b/packages/qwik/src/components/form/elm-select.tsx
@@ -119,7 +119,7 @@ export const ElmSelect = component$<ElmSelectProps>((props) => {
     >
       <span class={[styles.label, { [styles["label-active"]]: isOpen.value }]}>
         <Slot name="icon">
-          <ElmMdiIcon d={mdiArrowDownDropCircleOutline} size="0.75rem" />
+          <ElmMdiIcon path={mdiArrowDownDropCircleOutline} size="0.75rem" />
         </Slot>
         {label}
       </span>
@@ -140,7 +140,7 @@ export const ElmSelect = component$<ElmSelectProps>((props) => {
           )}
         </div>
 
-        <ElmMdiIcon d={mdiMenuDown} size="1.5rem" />
+        <ElmMdiIcon path={mdiMenuDown} size="1.5rem" />
 
         <ElmCollapse isOpen={isOpen.value} class={styles.pulldown}>
           {options.map((option) => (
@@ -154,7 +154,7 @@ export const ElmSelect = component$<ElmSelectProps>((props) => {
               }}
             >
               <ElmMdiIcon
-                d={mdiChevronRight}
+                path={mdiChevronRight}
                 color="var(--elmethis-color-primary-weak)"
                 size="0.75em"
               />

--- a/packages/qwik/src/components/form/elm-switch.module.css
+++ b/packages/qwik/src/components/form/elm-switch.module.css
@@ -12,11 +12,11 @@
   );
   position: relative;
   cursor: pointer;
-  box-shadow: 0 0 2px rgb(0 0 0 / 10%);
+  box-shadow: 0 0 2px var(--elmethis-box-shadow-color);
   transition:
     opacity 300ms,
     background-color 300ms;
-  background-color: rgb(128 128 128 / 25%);
+  background-color: var(--elmethis-color-surface-sunken);
 
   &.checked {
     background-color: var(--elmethis-scoped-color);
@@ -40,7 +40,7 @@
     transform 300ms,
     opacity 300ms,
     background-color 300ms;
-  background-color: rgb(255 255 255 / 90%);
+  background-color: var(--elmethis-color-surface-raised);
 
   &.checked {
     transform: translateX(
@@ -50,7 +50,7 @@
 
   &.disabled {
     opacity: 0.5;
-    background-color: rgb(128 128 128 / 100%);
+    background-color: var(--elmethis-color-neutral-weak);
   }
 
   &:hover {

--- a/packages/qwik/src/components/form/elm-text-area.module.css
+++ b/packages/qwik/src/components/form/elm-text-area.module.css
@@ -53,12 +53,8 @@
   border-style: solid;
   border-width: 1px;
   border-color: transparent;
-  background-color: light-dark(
-    var(--elmethis-color-surface-raised),
-    oklch(from #393e46 calc(l * 0.9) c h)
-  );
-  box-shadow: 0 0 0.125rem
-    light-dark(var(--elmethis-box-shadow-color), rgb(0 0 0 / 75%));
+  background-color: var(--elmethis-color-surface-raised);
+  box-shadow: 0 0 0.125rem var(--elmethis-box-shadow-color);
 
   &.disabled {
     background-color: var(--elmethis-color-surface-sunken);
@@ -106,10 +102,7 @@
   min-height: 1.5rem;
   font-family: inherit;
   line-height: 1.4;
-  color: light-dark(
-    var(--elmethis-color-neutral),
-    oklch(from white l c h / 70%)
-  );
+  color: var(--elmethis-color-neutral);
   caret-color: var(--highlight-color);
   resize: vertical;
 
@@ -123,13 +116,10 @@
   }
 
   &::selection {
-    color: light-dark(
-      var(--elmethis-color-surface-raised),
-      oklch(from black l c h / 70%)
-    );
-    background-color: light-dark(
-      var(--elmethis-scoped-color, var(--elmethis-color-neutral)),
-      oklch(from white l c h / 70%)
+    color: var(--elmethis-color-surface-raised);
+    background-color: var(
+      --elmethis-scoped-color,
+      var(--elmethis-color-neutral)
     );
   }
 }

--- a/packages/qwik/src/components/form/elm-text-area.stories.tsx
+++ b/packages/qwik/src/components/form/elm-text-area.stories.tsx
@@ -55,7 +55,7 @@ const WithIconTextArea = component$(() => {
       >
         <ElmMdiIcon
           q:slot="icon"
-          d={mdiCommentTextOutline}
+          path={mdiCommentTextOutline}
           size="0.75rem"
           color="gray"
         />

--- a/packages/qwik/src/components/form/elm-text-area.tsx
+++ b/packages/qwik/src/components/form/elm-text-area.tsx
@@ -72,7 +72,7 @@ export const ElmTextArea = component$<ElmTextAreaProps>((props) => {
         class={[styles.header, { [styles["label-active"]]: isFocused.value }]}
       >
         <Slot name="icon">
-          <ElmMdiIcon d={mdiTextLong} size="0.75rem" />
+          <ElmMdiIcon path={mdiTextLong} size="0.75rem" />
         </Slot>
         <span>
           {label}

--- a/packages/qwik/src/components/form/elm-text-field.module.css
+++ b/packages/qwik/src/components/form/elm-text-field.module.css
@@ -134,7 +134,7 @@
     cursor: pointer;
 
     &:hover {
-      background-color: rgb(128 128 128 / 20%);
+      background-color: var(--elmethis-color-surface-sunken);
     }
   }
 }
@@ -145,5 +145,5 @@
   font-size: 0.85em;
   user-select: none;
   transition: color 200ms;
-  color: light-dark(rgb(0 0 0 / 65%), rgb(255 255 255 / 65%));
+  color: var(--elmethis-color-neutral-weak);
 }

--- a/packages/qwik/src/components/form/elm-text-field.stories.tsx
+++ b/packages/qwik/src/components/form/elm-text-field.stories.tsx
@@ -50,7 +50,7 @@ const WithIconTextField = component$(() => {
   return (
     <div>
       <ElmTextField label="Email" placeholder="Enter your email" value={text}>
-        <ElmMdiIcon q:slot="icon" d={mdiEmail} size=".75rem" color="gray" />
+        <ElmMdiIcon q:slot="icon" path={mdiEmail} size=".75rem" color="gray" />
       </ElmTextField>
       <ElmInlineText>{text.value}</ElmInlineText>
     </div>

--- a/packages/qwik/src/components/form/elm-text-field.tsx
+++ b/packages/qwik/src/components/form/elm-text-field.tsx
@@ -78,7 +78,7 @@ export const ElmTextField = component$<ElmTextFieldProps>((props) => {
         class={[styles.header, { [styles["label-active"]]: isFocused.value }]}
       >
         <Slot name="icon">
-          <ElmMdiIcon d={mdiText} size="0.75rem" />
+          <ElmMdiIcon path={mdiText} size="0.75rem" />
         </Slot>
         <span>
           {label}
@@ -134,7 +134,9 @@ export const ElmTextField = component$<ElmTextFieldProps>((props) => {
             })}
           >
             <ElmMdiIcon
-              d={inputType.value === "text" ? mdiEyeOutline : mdiEyeOffOutline}
+              path={
+                inputType.value === "text" ? mdiEyeOutline : mdiEyeOffOutline
+              }
               size="1.25rem"
               color="gray"
             />
@@ -148,7 +150,7 @@ export const ElmTextField = component$<ElmTextFieldProps>((props) => {
               }
             })}
           >
-            <ElmMdiIcon d={mdiTrashCanOutline} size="1.25rem" color="gray" />
+            <ElmMdiIcon path={mdiTrashCanOutline} size="1.25rem" color="gray" />
           </div>
         </div>
       </div>

--- a/packages/qwik/src/components/form/elm-validation.tsx
+++ b/packages/qwik/src/components/form/elm-validation.tsx
@@ -33,7 +33,7 @@ export const ElmValidation = component$<ElmValidationProps>(
         {...props}
       >
         <ElmMdiIcon
-          d={isValid ? mdiCheckCircle : mdiCheckCircleOutline}
+          path={isValid ? mdiCheckCircle : mdiCheckCircleOutline}
           color={isValid ? validColor : undefined}
         />
         <ElmInlineText color={isValid ? validColor : undefined}>

--- a/packages/qwik/src/components/icon/elm-inline-icon.module.css
+++ b/packages/qwik/src/components/icon/elm-inline-icon.module.css
@@ -9,15 +9,11 @@
   /* Light inherits the surrounding text color; dark lightens the glyph. */
   color: light-dark(
     currentcolor,
-    var(--elmethis-scoped-color, rgb(255 255 255 / 70%))
+    var(--elmethis-scoped-color, var(--elmethis-color-neutral))
   );
 
   &::selection {
-    color: light-dark(currentcolor, rgb(0 0 0 / 70%));
-    background-color: light-dark(
-      var(--elmethis-scoped-color, rgb(0 0 0 / 25%)),
-      var(--elmethis-scoped-color, rgb(255 255 255 / 25%))
-    );
+    background-color: var(--elmethis-color-selection);
 
     /* `filter` is not a <color>, so it can't use light-dark(): the OS default
        is the media query; an explicit pin overrides it below. */

--- a/packages/qwik/src/components/icon/elm-language-icon.tsx
+++ b/packages/qwik/src/components/icon/elm-language-icon.tsx
@@ -32,7 +32,7 @@ export const ElmLanguageIcon = component$<ElmLanguageIconProps>(
     const normalized = normalizeLanguage(language);
 
     if (normalized === "file") {
-      return <ElmMdiIcon d={mdiCodeTags} size={String(size)} />;
+      return <ElmMdiIcon path={mdiCodeTags} size={String(size)} />;
     }
 
     return (

--- a/packages/qwik/src/components/icon/elm-mdi-icon.module.css
+++ b/packages/qwik/src/components/icon/elm-mdi-icon.module.css
@@ -1,7 +1,3 @@
 .elm-mdi-icon {
-  fill: light-dark(
-    var(--elmethis-scoped-color-light, var(--elmethis-color-neutral)),
-    var(--elmethis-scoped-color-dark, var(--elmethis-color-neutral))
-  );
   transition: fill 200ms;
 }

--- a/packages/qwik/src/components/icon/elm-mdi-icon.module.css
+++ b/packages/qwik/src/components/icon/elm-mdi-icon.module.css
@@ -1,7 +1,7 @@
 .elm-mdi-icon {
   fill: light-dark(
-    var(--elmethis-scoped-color, #555b67),
-    var(--dark-color, #b0b5be)
+    var(--elmethis-scoped-color-light, var(--elmethis-color-neutral)),
+    var(--elmethis-scoped-color-dark, var(--elmethis-color-neutral))
   );
   transition: fill 200ms;
 }

--- a/packages/qwik/src/components/icon/elm-mdi-icon.spec.tsx
+++ b/packages/qwik/src/components/icon/elm-mdi-icon.spec.tsx
@@ -6,53 +6,64 @@ import { ElmMdiIcon } from "./elm-mdi-icon";
 import { mdiCodeTags } from "@mdi/js";
 
 describe("[CSR]", () => {
-  test("renders an <svg role='img'> with the given path", async () => {
+  test("renders a decorative currentColor SVG with the given path", async () => {
     const { screen, render } = await createDOM();
-    await render(<ElmMdiIcon d={mdiCodeTags} />);
+    await render(<ElmMdiIcon path={mdiCodeTags} />);
     const html = screen.outerHTML.toLowerCase();
     expect(html).toContain("<svg");
-    expect(html).toContain('role="img"');
-    // The `d` prop must reach the inner <path>.
+    expect(html).toContain('aria-hidden="true"');
+    expect(html).not.toContain('role="img"');
+    expect(html).toContain('focusable="false"');
+    expect(html).toContain('fill="currentcolor"');
     expect(html).toContain(`d="${mdiCodeTags.toLowerCase()}"`);
+  });
+
+  test("exposes a labeled icon as an image", async () => {
+    const { screen, render } = await createDOM();
+    await render(<ElmMdiIcon path={mdiCodeTags} label="Code" />);
+    const html = screen.outerHTML.toLowerCase();
+    expect(html).toContain('role="img"');
+    expect(html).not.toContain("aria-hidden");
+    expect(html).toContain("<title>code</title>");
   });
 
   test("size prop drives both width and height", async () => {
     const { screen, render } = await createDOM();
-    await render(<ElmMdiIcon d={mdiCodeTags} size="32px" />);
+    await render(<ElmMdiIcon path={mdiCodeTags} size={32} />);
     const html = screen.outerHTML;
-    expect(html).toContain('width="32px"');
-    expect(html).toContain('height="32px"');
+    expect(html).toContain('width="32"');
+    expect(html).toContain('height="32"');
   });
 
-  test("color prop feeds the svg fill and the scoped light color var", async () => {
-    const { screen, render } = await createDOM();
-    await render(<ElmMdiIcon d={mdiCodeTags} color="#ff0000" />);
-    const html = screen.outerHTML;
-    expect(html).toContain('fill="#ff0000"');
-    // Both theme-specific scoped colors fall back to `color`.
-    expect(html).toContain("--elmethis-scoped-color-light:#ff0000");
-    expect(html).toContain("--elmethis-scoped-color-dark:#ff0000");
-  });
-
-  test("lightColor / darkColor override the scoped color vars independently", async () => {
+  test("color prop sets the currentColor source", async () => {
     const { screen, render } = await createDOM();
     await render(
-      <ElmMdiIcon d={mdiCodeTags} lightColor="#111" darkColor="#eee" />,
+      <ElmMdiIcon path={mdiCodeTags} color="var(--elmethis-color-primary)" />,
     );
     const html = screen.outerHTML;
-    expect(html).toContain("--elmethis-scoped-color-light:#111");
-    expect(html).toContain("--elmethis-scoped-color-dark:#eee");
+    expect(html).toContain('color="var(--elmethis-color-primary)"');
+    expect(html).toContain('fill="currentColor"');
+  });
+
+  test("uses native ARIA naming when provided", async () => {
+    const { screen, render } = await createDOM();
+    await render(<ElmMdiIcon path={mdiCodeTags} aria-label="Code" />);
+    const html = screen.outerHTML;
+    expect(html).toContain('role="img"');
+    expect(html).not.toContain("aria-hidden");
   });
 });
 
 describe("[SSR]", () => {
-  test("renders the svg shell with the path", async () => {
-    const renderResult = await renderToString(<ElmMdiIcon d={mdiCodeTags} />, {
-      containerTagName: "div",
-    });
+  test("renders the labeled svg shell with the path", async () => {
+    const renderResult = await renderToString(
+      <ElmMdiIcon path={mdiCodeTags} label="Code" />,
+      { containerTagName: "div" },
+    );
     const html = renderResult.html.toLowerCase();
     expect(html).toContain("<svg");
     expect(html).toContain('role="img"');
+    expect(html).toMatch(/<title[^>]*>code<\/title>/);
     expect(html).toContain(`d="${mdiCodeTags.toLowerCase()}"`);
   });
 });

--- a/packages/qwik/src/components/icon/elm-mdi-icon.spec.tsx
+++ b/packages/qwik/src/components/icon/elm-mdi-icon.spec.tsx
@@ -29,9 +29,9 @@ describe("[CSR]", () => {
     await render(<ElmMdiIcon d={mdiCodeTags} color="#ff0000" />);
     const html = screen.outerHTML;
     expect(html).toContain('fill="#ff0000"');
-    // Both --elmethis-scoped-color and --dark-color fall back to `color`.
-    expect(html).toContain("--elmethis-scoped-color:#ff0000");
-    expect(html).toContain("--dark-color:#ff0000");
+    // Both theme-specific scoped colors fall back to `color`.
+    expect(html).toContain("--elmethis-scoped-color-light:#ff0000");
+    expect(html).toContain("--elmethis-scoped-color-dark:#ff0000");
   });
 
   test("lightColor / darkColor override the scoped color vars independently", async () => {
@@ -40,8 +40,8 @@ describe("[CSR]", () => {
       <ElmMdiIcon d={mdiCodeTags} lightColor="#111" darkColor="#eee" />,
     );
     const html = screen.outerHTML;
-    expect(html).toContain("--elmethis-scoped-color:#111");
-    expect(html).toContain("--dark-color:#eee");
+    expect(html).toContain("--elmethis-scoped-color-light:#111");
+    expect(html).toContain("--elmethis-scoped-color-dark:#eee");
   });
 });
 

--- a/packages/qwik/src/components/icon/elm-mdi-icon.stories.tsx
+++ b/packages/qwik/src/components/icon/elm-mdi-icon.stories.tsx
@@ -8,8 +8,10 @@ const meta: Meta<ElmMdiIconProps> = {
   tags: ["autodocs"],
   argTypes: {
     color: { control: "color" },
-    lightColor: { control: "color" },
-    darkColor: { control: "color" },
+    label: {
+      control: "text",
+      description: "Accessible label rendered as the SVG title.",
+    },
   },
   args: {},
 };
@@ -20,6 +22,7 @@ type Story = StoryObj<ElmMdiIconProps>;
 export const Primary: Story = {
   args: {
     size: "1.25rem",
-    d: mdiTag,
+    path: mdiTag,
+    label: "Tag",
   },
 };

--- a/packages/qwik/src/components/icon/elm-mdi-icon.tsx
+++ b/packages/qwik/src/components/icon/elm-mdi-icon.tsx
@@ -16,7 +16,7 @@ export const ElmMdiIcon = component$<ElmMdiIconProps>(
     style,
     d,
     size = "1em",
-    color = "currentColor",
+    color,
     lightColor,
     darkColor,
     ...props
@@ -26,8 +26,8 @@ export const ElmMdiIcon = component$<ElmMdiIconProps>(
         class={[styles["elm-mdi-icon"], className]}
         style={
           {
-            "--elmethis-scoped-color": lightColor ?? color,
-            "--dark-color": darkColor ?? color,
+            "--elmethis-scoped-color-light": lightColor ?? color,
+            "--elmethis-scoped-color-dark": darkColor ?? color,
             ...(style as CSSProperties),
           } as CSSProperties
         }

--- a/packages/qwik/src/components/icon/elm-mdi-icon.tsx
+++ b/packages/qwik/src/components/icon/elm-mdi-icon.tsx
@@ -1,46 +1,37 @@
-import { component$, PropsOf, type CSSProperties } from "@qwik.dev/core";
+import { component$, PropsOf } from "@qwik.dev/core";
 
 import styles from "./elm-mdi-icon.module.css";
 
-export interface ElmMdiIconProps extends PropsOf<"svg"> {
-  d: string;
-  size?: string;
+export interface ElmMdiIconProps extends Omit<PropsOf<"svg">, "children"> {
+  path: string;
+  size?: string | number;
   color?: string;
-  lightColor?: string;
-  darkColor?: string;
+  label?: string;
 }
 
 export const ElmMdiIcon = component$<ElmMdiIconProps>(
-  ({
-    class: className,
-    style,
-    d,
-    size = "1em",
-    color,
-    lightColor,
-    darkColor,
-    ...props
-  }) => {
+  ({ class: className, style, path, size = "1em", color, label, ...props }) => {
+    const hasAccessibleName = Boolean(
+      label || props["aria-label"] || props["aria-labelledby"],
+    );
+
     return (
       <svg
         class={[styles["elm-mdi-icon"], className]}
-        style={
-          {
-            "--elmethis-scoped-color-light": lightColor ?? color,
-            "--elmethis-scoped-color-dark": darkColor ?? color,
-            ...(style as CSSProperties),
-          } as CSSProperties
-        }
+        style={style}
         width={size}
         height={size}
         viewBox="0 0 24 24"
-        fill={color}
+        color={color}
+        fill="currentColor"
         xmlns="http://www.w3.org/2000/svg"
         focusable="false"
-        role="img"
+        aria-hidden={hasAccessibleName ? undefined : "true"}
+        role={hasAccessibleName ? "img" : undefined}
         {...props}
       >
-        <path d={d} />
+        {label && <title>{label}</title>}
+        <path d={path} />
       </svg>
     );
   },

--- a/packages/qwik/src/components/icon/elm-toggle-theme.module.css
+++ b/packages/qwik/src/components/icon/elm-toggle-theme.module.css
@@ -2,9 +2,14 @@
   display: block; /* Ensure it behaves like a block/inline-block */
   box-sizing: border-box;
   padding: 0.25rem;
-  color: light-dark(#555b67, #b0b5be);
+  color: var(--elmethis-color-neutral);
   border-radius: 50%;
   cursor: pointer;
-  box-shadow: 0 0 0.125rem light-dark(rgb(0 0 0 / 30%), rgb(0 0 0 / 60%));
-  background-color: light-dark(rgb(255 255 255 / 20%), rgb(0 0 0 / 20%));
+  box-shadow: 0 0 0.125rem var(--elmethis-box-shadow-color);
+  background-color: var(--elmethis-color-surface-raised);
+  transition: background-color 100ms;
+
+  &:hover {
+    background-color: var(--elmethis-color-surface-sunken);
+  }
 }

--- a/packages/qwik/src/components/media/elm-audio-player.tsx
+++ b/packages/qwik/src/components/media/elm-audio-player.tsx
@@ -254,7 +254,7 @@ export const ElmAudioPlayer = component$<ElmAudioPlayerProps>((props) => {
           aria-hidden="true"
         >
           <ElmMdiIcon
-            d={hasError.value ? mdiAlertCircleOutline : mdiMusicNote}
+            path={hasError.value ? mdiAlertCircleOutline : mdiMusicNote}
             size="1.25rem"
           />
         </span>
@@ -277,7 +277,7 @@ export const ElmAudioPlayer = component$<ElmAudioPlayerProps>((props) => {
 
       {hasError.value ? (
         <div class={styles["error-notice"]} role="alert">
-          <ElmMdiIcon d={mdiAlertCircleOutline} size="1.25rem" />
+          <ElmMdiIcon path={mdiAlertCircleOutline} size="1.25rem" />
           <span class={styles["error-message"]}>{errorMessage}</span>
         </div>
       ) : (
@@ -358,7 +358,7 @@ export const ElmAudioPlayer = component$<ElmAudioPlayerProps>((props) => {
                 onClick$={() => seekTo(currentTime.value - seekStep)}
                 aria-label={`Back ${seekStep} seconds`}
               >
-                <ElmMdiIcon d={mdiRewind10} size="1.25rem" />
+                <ElmMdiIcon path={mdiRewind10} size="1.25rem" />
               </button>
 
               <button
@@ -369,7 +369,7 @@ export const ElmAudioPlayer = component$<ElmAudioPlayerProps>((props) => {
                 aria-pressed={isPlaying.value}
               >
                 <ElmMdiIcon
-                  d={isPlaying.value ? mdiPause : mdiPlay}
+                  path={isPlaying.value ? mdiPause : mdiPlay}
                   size="1.5rem"
                 />
               </button>
@@ -380,7 +380,7 @@ export const ElmAudioPlayer = component$<ElmAudioPlayerProps>((props) => {
                 onClick$={() => seekTo(currentTime.value + seekStep)}
                 aria-label={`Forward ${seekStep} seconds`}
               >
-                <ElmMdiIcon d={mdiFastForward10} size="1.25rem" />
+                <ElmMdiIcon path={mdiFastForward10} size="1.25rem" />
               </button>
             </div>
 
@@ -392,7 +392,7 @@ export const ElmAudioPlayer = component$<ElmAudioPlayerProps>((props) => {
                 aria-label={isMuted.value ? "Unmute" : "Mute"}
                 aria-pressed={isMuted.value}
               >
-                <ElmMdiIcon d={volumeIcon.value} size="1.25rem" />
+                <ElmMdiIcon path={volumeIcon.value} size="1.25rem" />
               </button>
               <input
                 class={styles["volume-slider"]}

--- a/packages/qwik/src/components/media/elm-block-image.module.css
+++ b/packages/qwik/src/components/media/elm-block-image.module.css
@@ -24,7 +24,7 @@
   height: auto;
   object-fit: contain;
   border-radius: 0.25rem;
-  box-shadow: 0 0 0.125rem rgb(0 0 0 / 10%);
+  box-shadow: 0 0 0.125rem var(--elmethis-box-shadow-color);
   user-select: none;
   aspect-ratio: var(--aspect-ratio, auto);
   cursor: var(--elmethis-scoped-cursor);

--- a/packages/qwik/src/components/media/elm-block-image.tsx
+++ b/packages/qwik/src/components/media/elm-block-image.tsx
@@ -98,7 +98,7 @@ export const ElmBlockImage = component$<ElmBlockImageProps>((props) => {
       {caption && (
         <figcaption class={styles["caption-box"]}>
           <span class={styles["caption-icon"]}>
-            <ElmMdiIcon d={mdiMessageImageOutline} size="1.25rem" />
+            <ElmMdiIcon path={mdiMessageImageOutline} size="1.25rem" />
           </span>
           <ElmInlineText size="1rem">{caption}</ElmInlineText>
         </figcaption>

--- a/packages/qwik/src/components/media/elm-file.module.css
+++ b/packages/qwik/src/components/media/elm-file.module.css
@@ -4,9 +4,9 @@
   grid-template-columns: 1.5rem 1fr 1fr 1.5rem;
   gap: 1rem;
   align-items: center;
-  box-shadow: 0 0 0.125rem rgb(0 0 0 / 20%);
+  box-shadow: 0 0 0.125rem var(--elmethis-box-shadow-color);
   border-radius: 0.25rem;
-  background-color: light-dark(rgb(255 255 255 / 20%), rgb(0 0 0 / 20%));
+  background-color: var(--elmethis-color-surface-raised);
 }
 
 .file-size {
@@ -28,6 +28,6 @@
     background-color 200ms;
 
   &:hover {
-    background-color: light-dark(rgb(0 0 0 / 10%), rgb(255 255 255 / 10%));
+    background-color: var(--elmethis-color-surface-sunken);
   }
 }

--- a/packages/qwik/src/components/media/elm-file.tsx
+++ b/packages/qwik/src/components/media/elm-file.tsx
@@ -55,7 +55,7 @@ export const ElmFile = component$<ElmFileProps>(
     return (
       <div class={[styles["elm-file"], className]} {...props}>
         <div>
-          <ElmMdiIcon d={mdiFile} size="1.25rem" />
+          <ElmMdiIcon path={mdiFile} size="1.25rem" />
         </div>
 
         <div>
@@ -69,7 +69,7 @@ export const ElmFile = component$<ElmFileProps>(
         </div>
 
         <div class={styles["download-icon"]} onClick$={downloadFile}>
-          <ElmMdiIcon d={mdiDownload} size="1.25rem" />
+          <ElmMdiIcon path={mdiDownload} size="1.25rem" />
         </div>
       </div>
     );

--- a/packages/qwik/src/components/navigation/elm-bookmark.module.css
+++ b/packages/qwik/src/components/navigation/elm-bookmark.module.css
@@ -3,19 +3,19 @@
   display: block;
   container-type: inline-size;
   border-radius: 0.25rem;
-  box-shadow: 0 0 0.125rem rgb(0 0 0 / 10%);
+  box-shadow: 0 0 0.125rem var(--elmethis-box-shadow-color);
   overflow: hidden;
+  background-color: var(--elmethis-color-surface-raised);
   transition:
     background-color 200ms,
     transform 200ms;
 
   &:hover {
-    background-color: rgb(105 135 184 / 10%);
-    transform: translateX(-0.125rem) translateY(-0.125rem);
+    background-color: var(--elmethis-color-surface-sunken);
+    transform: translateX(-2px) translateY(-2px);
   }
 
   &:active {
-    background-color: rgb(89 181 124 / 10%);
     transform: translateX(0) translateY(0);
   }
 }
@@ -61,8 +61,6 @@
   flex-direction: column;
   gap: 0.5rem;
   justify-content: space-between;
-  transition: background-color 200ms;
-  background-color: light-dark(rgb(255 255 255 / 40%), rgb(0 0 0 / 20%));
 
   @container (max-width: 700px) {
     width: 100%;

--- a/packages/qwik/src/components/navigation/elm-bookmark.tsx
+++ b/packages/qwik/src/components/navigation/elm-bookmark.tsx
@@ -74,7 +74,7 @@ export const ElmBookmark = component$<ElmBookmarkProps>(
                 <ElmInlineIcon src={favicon} />
               ) : (
                 <ElmMdiIcon
-                  d={mdiLinkVariant}
+                  path={mdiLinkVariant}
                   color="var(--elmethis-color-accent-info)"
                 />
               )}

--- a/packages/qwik/src/components/navigation/elm-breadcrumb.tsx
+++ b/packages/qwik/src/components/navigation/elm-breadcrumb.tsx
@@ -32,7 +32,7 @@ export const ElmBreadcrumb = component$<ElmBreadcrumbProps>(
             <span class={styles["link-container"]} onClick$={link.onClick$}>
               <ElmMdiIcon
                 class={styles.icon}
-                d={
+                path={
                   index === 0
                     ? mdiHome
                     : index === links.length - 1
@@ -48,7 +48,7 @@ export const ElmBreadcrumb = component$<ElmBreadcrumbProps>(
             {links.length !== index + 1 && (
               <ElmMdiIcon
                 class={styles.chevron}
-                d={mdiChevronRight}
+                path={mdiChevronRight}
                 size="1rem"
               />
             )}

--- a/packages/qwik/src/components/navigation/elm-page-top.module.css
+++ b/packages/qwik/src/components/navigation/elm-page-top.module.css
@@ -57,7 +57,7 @@
       top: 0;
       height: 100%;
       width: 50%;
-      background-color: light-dark(#494f59, #bec2ca);
+      background-color: var(--elmethis-color-neutral);
     }
 
     &::before {
@@ -82,20 +82,7 @@
     font-size: 12px;
     white-space: nowrap;
     user-select: none;
-
-    /* From text.scoped.scss */
-    color: light-dark(
-      var(--elmethis-scoped-color, #606875),
-      var(--elmethis-scoped-color, #b0b5be)
-    );
-
-    &::selection {
-      color: light-dark(#cccfd5, #3e434b);
-      background-color: light-dark(
-        var(--elmethis-scoped-color, #3e434b),
-        var(--elmethis-scoped-color, #cccfd5)
-      );
-    }
+    color: var(--elmethis-color-neutral);
   }
 }
 

--- a/packages/qwik/src/components/others/elm-color-primitive-sample.tsx
+++ b/packages/qwik/src/components/others/elm-color-primitive-sample.tsx
@@ -118,7 +118,9 @@ export const ElmColorPrimitiveSample = component$<ElmColorPrimitiveSampleProps>(
           >
             <ElmMdiIcon
               class={styles["mode-toggle-icon"]}
-              d={copyMode.value === "hex" ? mdiHexadecimal : mdiFormatColorFill}
+              path={
+                copyMode.value === "hex" ? mdiHexadecimal : mdiFormatColorFill
+              }
               size={"1.25rem"}
             />
             Copy: {copyMode.value === "hex" ? "hex value" : "variable name"}

--- a/packages/qwik/src/components/others/elm-color-semantic-sample.tsx
+++ b/packages/qwik/src/components/others/elm-color-semantic-sample.tsx
@@ -309,7 +309,9 @@ export const ElmColorSemanticSample = component$<ElmColorSemanticSampleProps>(
           >
             <ElmMdiIcon
               class={styles["mode-toggle-icon"]}
-              d={copyMode.value === "hex" ? mdiHexadecimal : mdiFormatColorFill}
+              path={
+                copyMode.value === "hex" ? mdiHexadecimal : mdiFormatColorFill
+              }
               size={"1.25rem"}
             />
             Copy: {copyMode.value === "hex" ? "hex value" : "variable name"}

--- a/packages/qwik/src/components/others/use-wordle.module.css
+++ b/packages/qwik/src/components/others/use-wordle.module.css
@@ -24,14 +24,14 @@
     color 0.15s ease;
 
   &.error {
-    background-color: #1a1a1b;
-    color: #fff;
+    background-color: var(--elmethis-color-accent-error);
+    color: contrast-color(var(--elmethis-color-accent-error));
     animation: fade-in 0.15s ease;
   }
 
   &.status {
-    background-color: #538d4e;
-    color: #fff;
+    background-color: var(--elmethis-color-accent-success);
+    color: contrast-color(var(--elmethis-color-accent-success));
     font-size: 1rem;
     animation: fade-in 0.15s ease;
   }
@@ -66,33 +66,33 @@
     border-color 0.2s ease;
 
   &.empty {
-    border-color: gray;
+    border-color: var(--elmethis-color-neutral-weak);
     background-color: transparent;
     color: transparent;
   }
 
   &.tbd {
-    border-color: #565758;
+    border-color: var(--elmethis-color-neutral);
     background-color: transparent;
-    color: #6c7483;
+    color: var(--elmethis-color-neutral);
   }
 
   &.correct {
-    background-color: #538d4e;
-    border-color: #538d4e;
-    color: #fff;
+    background-color: var(--elmethis-color-accent-success);
+    border-color: var(--elmethis-color-accent-success);
+    color: contrast-color(var(--elmethis-color-accent-success));
   }
 
   &.present {
-    background-color: #b59f3b;
-    border-color: #b59f3b;
-    color: #fff;
+    background-color: var(--elmethis-color-accent-warning);
+    border-color: var(--elmethis-color-accent-warning);
+    color: contrast-color(var(--elmethis-color-accent-warning));
   }
 
   &.absent {
-    background-color: #3a3a3c;
-    border-color: #3a3a3c;
-    color: #fff;
+    background-color: var(--elmethis-color-surface-sunken);
+    border-color: var(--elmethis-color-surface-sunken);
+    color: contrast-color(var(--elmethis-color-surface-sunken));
   }
 }
 
@@ -117,8 +117,8 @@
   padding: 0 0.25rem;
   border: none;
   border-radius: 0.25rem;
-  background-color: #818384;
-  color: #fff;
+  background-color: var(--elmethis-color-neutral);
+  color: contrast-color(var(--elmethis-color-neutral));
   font-size: 0.8125rem;
   font-weight: bold;
   cursor: pointer;
@@ -140,15 +140,18 @@
   }
 
   &.correct {
-    background-color: #538d4e;
+    background-color: var(--elmethis-color-accent-success);
+    color: contrast-color(var(--elmethis-color-accent-success));
   }
 
   &.present {
-    background-color: #b59f3b;
+    background-color: var(--elmethis-color-accent-warning);
+    color: contrast-color(var(--elmethis-color-accent-warning));
   }
 
   &.absent {
-    background-color: #3a3a3c;
+    background-color: var(--elmethis-color-surface-sunken);
+    color: contrast-color(var(--elmethis-color-surface-sunken));
   }
 }
 
@@ -165,8 +168,8 @@
   padding: 0.625rem 1.5rem;
   border: none;
   border-radius: 0.25rem;
-  background-color: #538d4e;
-  color: #fff;
+  background-color: var(--elmethis-color-accent-success);
+  color: contrast-color(var(--elmethis-color-accent-success));
   font-size: 1rem;
   font-weight: bold;
   cursor: pointer;
@@ -175,7 +178,9 @@
     transform 0.05s ease;
 
   &:hover {
-    background-color: #6aaa64;
+    background-color: oklch(
+      from var(--elmethis-color-accent-success) calc(l + 0.08) c h
+    );
   }
 
   &:active {

--- a/packages/qwik/src/components/table/elm-table.module.css
+++ b/packages/qwik/src/components/table/elm-table.module.css
@@ -61,7 +61,7 @@
 .elm-table {
   border-collapse: collapse;
   border-spacing: 0;
-  box-shadow: 0 0 0.125rem rgb(0 0 0 / 20%);
+  box-shadow: 0 0 0.125rem var(--elmethis-box-shadow-color);
 }
 
 .caption {
@@ -84,7 +84,7 @@
 .spacing {
   flex-grow: 1;
   height: 1px;
-  background-color: rgb(128 128 128 / 20%);
+  background-color: var(--elmethis-color-divider);
 }
 
 /* Sticky label column. When the first column holds row headers, pin it so the

--- a/packages/qwik/src/components/typography/elm-block-quote.tsx
+++ b/packages/qwik/src/components/typography/elm-block-quote.tsx
@@ -15,7 +15,7 @@ export const ElmBlockQuote = component$<PropsOf<"blockquote">>(
         {...props}
       >
         <div class={[styles.icon, styles["icon-top-left"]]}>
-          <ElmMdiIcon d={mdiFormatQuoteOpen} />
+          <ElmMdiIcon path={mdiFormatQuoteOpen} />
         </div>
 
         <div class={styles.body}>
@@ -23,7 +23,7 @@ export const ElmBlockQuote = component$<PropsOf<"blockquote">>(
         </div>
 
         <div class={[styles.icon, styles["icon-bottom-right"]]}>
-          <ElmMdiIcon d={mdiFormatQuoteClose} />
+          <ElmMdiIcon path={mdiFormatQuoteClose} />
         </div>
       </blockquote>
     );

--- a/packages/qwik/src/components/typography/elm-callout.tsx
+++ b/packages/qwik/src/components/typography/elm-callout.tsx
@@ -36,7 +36,11 @@ export const ElmCallout = component$<ElmCalloutProps>(
         {...props}
       >
         <div class={styles.header}>
-          <ElmMdiIcon class={styles.icon} d={ICON_MAP[type]} size="1.25rem" />
+          <ElmMdiIcon
+            class={styles.icon}
+            path={ICON_MAP[type]}
+            size="1.25rem"
+          />
           <span>{type}</span>
         </div>
 

--- a/packages/qwik/src/components/typography/elm-inline-text.module.css
+++ b/packages/qwik/src/components/typography/elm-inline-text.module.css
@@ -72,7 +72,7 @@
     opacity 200ms;
 
   &:hover {
-    background-color: oklch(from #6987b8 l c h / 20%);
+    background-color: var(--elmethis-color-accent-link-surface);
   }
 
   &:active {

--- a/packages/qwik/src/hooks/use-clipboard.tsx
+++ b/packages/qwik/src/hooks/use-clipboard.tsx
@@ -76,7 +76,7 @@ export const useClipboard = (options: UseClipboardOptions) => {
               [styles["use-clipboard-icon-copied"]]: copied.value,
             },
           ]}
-          d={copied.value ? mdiClipboardCheckOutline : mdiClipboardOutline}
+          path={copied.value ? mdiClipboardCheckOutline : mdiClipboardOutline}
           size="1.25rem"
         />
       </span>

--- a/packages/qwik/stylelint.config.mjs
+++ b/packages/qwik/stylelint.config.mjs
@@ -10,6 +10,31 @@ export default {
   extends: ["stylelint-config-standard", "stylelint-config-css-modules"],
   plugins: ["stylelint-value-no-unknown-custom-properties"],
   rules: {
+    "color-no-hex": [
+      true,
+      {
+        message: "Use an Elmethis color token instead of a hex color",
+        severity: "warning",
+      },
+    ],
+    "color-named": [
+      "never",
+      {
+        message: "Use an Elmethis color token instead of a named color",
+        severity: "warning",
+      },
+    ],
+    "declaration-property-value-disallowed-list": [
+      {
+        "/.*/": [
+          "/(?<![-\\w])(?:rgb|rgba|hsl|hsla|hwb|lab|lch|oklab|oklch|color)\\((?!\\s*from\\b)/i",
+        ],
+      },
+      {
+        message: "Use an Elmethis color token instead of a color function",
+        severity: "warning",
+      },
+    ],
     "csstools/value-no-unknown-custom-properties": [
       true,
       {
@@ -33,5 +58,7 @@ export default {
     "lib-types/**",
     "storybook-static/**",
     "node_modules/**",
+    "./src/components/others/elm-color-primitive-sample.module.css",
+    "./src/components/others/elm-color-semantic-sample.module.css",
   ],
 };

--- a/packages/react/.storybook/sb.css
+++ b/packages/react/.storybook/sb.css
@@ -5,5 +5,5 @@ html {
 body,
 .docs-story {
   transition: background-color 200ms;
-  background-color: light-dark(#efecea, #393e46);
+  background-color: var(--elmethis-color-surface-base);
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elmethis/react",
-  "version": "0.21.1",
+  "version": "0.22.0",
   "description": "React component library for elmethis.",
   "publishConfig": {
     "access": "public"

--- a/packages/react/src/components/code/elm-code-block.module.css
+++ b/packages/react/src/components/code/elm-code-block.module.css
@@ -33,7 +33,7 @@
   grid-area: divider;
   width: calc(100% - 1rem);
   border: none;
-  border-bottom: solid 1px rgb(128 128 128 / 50%);
+  border-bottom: solid 1px var(--elmethis-color-divider);
 }
 
 .code {

--- a/packages/react/src/components/code/elm-html-viewer.module.css
+++ b/packages/react/src/components/code/elm-html-viewer.module.css
@@ -51,7 +51,7 @@
   width: calc(100% - 1rem);
   margin-inline: auto;
   border: none;
-  border-bottom: solid 1px rgb(128 128 128 / 50%);
+  border-bottom: solid 1px var(--elmethis-color-divider);
 }
 
 .content {

--- a/packages/react/src/components/code/elm-html-viewer.tsx
+++ b/packages/react/src/components/code/elm-html-viewer.tsx
@@ -133,7 +133,7 @@ export const ElmHtmlViewer = ({
           onClick={handleDownload}
           aria-label="Download"
         >
-          <ElmMdiIcon d={mdiDownload} size="1.25rem" />
+          <ElmMdiIcon path={mdiDownload} size="1.25rem" />
         </button>
 
         <button
@@ -142,7 +142,7 @@ export const ElmHtmlViewer = ({
           onClick={handleOpenInNewTab}
           aria-label="Open in new tab"
         >
-          <ElmMdiIcon d={mdiOpenInNew} size="1.25rem" />
+          <ElmMdiIcon path={mdiOpenInNew} size="1.25rem" />
         </button>
       </div>
 

--- a/packages/react/src/components/code/elm-shiki-highlighter.module.css
+++ b/packages/react/src/components/code/elm-shiki-highlighter.module.css
@@ -22,7 +22,7 @@
     /* stylelint-enable csstools/value-no-unknown-custom-properties */
 
     &::selection {
-      background-color: oklch(from #cdb57b l c h / 25%);
+      background-color: var(--elmethis-color-selection);
     }
   }
 }

--- a/packages/react/src/components/containments/elm-modal.module.css
+++ b/packages/react/src/components/containments/elm-modal.module.css
@@ -27,6 +27,6 @@
     opacity: 0;
     transition: opacity var(--elmethis-scoped-modal-delay, 200ms);
     background-color: transparent;
-    background-color: oklch(from black l c h / 50%);
+    background-color: var(--elmethis-color-modal-backdrop);
   }
 }

--- a/packages/react/src/components/containments/elm-toggle.module.css
+++ b/packages/react/src/components/containments/elm-toggle.module.css
@@ -39,7 +39,7 @@
     margin: 0 1rem;
     height: 1px;
     width: 100%;
-    background-color: oklch(from gray l c h / 12.5%);
+    background-color: var(--elmethis-color-divider);
   }
 
   &:hover {
@@ -78,7 +78,7 @@
   width: 1px;
   margin-left: 1rem;
   height: 100%;
-  background-color: oklch(from gray l c h / 12.5%);
+  background-color: var(--elmethis-color-divider);
 }
 
 .content {

--- a/packages/react/src/components/containments/elm-toggle.tsx
+++ b/packages/react/src/components/containments/elm-toggle.tsx
@@ -63,7 +63,7 @@ export const ElmToggle = ({
         <div className={styles["summary-left"]}>
           <span className={clsx(styles.chevron, isOpen && styles.open)}>
             <ElmMdiIcon
-              d={mdiChevronRight}
+              path={mdiChevronRight}
               color={
                 monochrome
                   ? "var(--elmethis-color-neutral-weak)"
@@ -85,7 +85,7 @@ export const ElmToggle = ({
 
         <span className={clsx(styles.cross, isOpen && styles.open)}>
           <ElmMdiIcon
-            d={mdiPlus}
+            path={mdiPlus}
             size="1rem"
             color={
               monochrome

--- a/packages/react/src/components/form/elm-button-dropdown.module.css
+++ b/packages/react/src/components/form/elm-button-dropdown.module.css
@@ -27,7 +27,7 @@
     border-bottom-left-radius: 0;
     padding-left: 0.75rem;
     padding-right: 0.75rem;
-    border-left: 1px solid light-dark(rgb(0 0 0 / 15%), rgb(255 255 255 / 20%));
+    border-left: 1px solid var(--elmethis-color-divider);
   }
 
   /* Keep the joined control from shifting per-segment on hover/active. */
@@ -45,8 +45,8 @@
     width: max-content;
     min-width: 100%;
     border-radius: 0.25rem;
-    background-color: light-dark(rgb(255 255 255 / 95%), rgb(51 51 51 / 95%));
-    box-shadow: 0 0 0.125rem light-dark(rgb(0 0 0 / 15%), rgb(0 0 0 / 75%));
+    background-color: var(--elmethis-color-surface-raised);
+    box-shadow: 0 0 0.125rem var(--elmethis-box-shadow-color);
 
     .item {
       overflow: hidden;
@@ -62,18 +62,16 @@
       cursor: pointer;
 
       &:hover {
-        background-color: light-dark(
-          rgb(190 194 202 / 30%),
-          rgb(190 194 202 / 20%)
-        );
+        background-color: var(--elmethis-color-surface-sunken);
       }
 
       &.selected {
-        background-color: light-dark(
-          rgb(190 194 202 / 25%),
-          rgb(190 194 202 / 15%)
-        );
+        background-color: var(--elmethis-color-surface-base);
         color: var(--elmethis-color-primary-weak);
+
+        &:hover {
+          background-color: var(--elmethis-color-surface-sunken);
+        }
       }
 
       &.item-disabled {

--- a/packages/react/src/components/form/elm-button-dropdown.tsx
+++ b/packages/react/src/components/form/elm-button-dropdown.tsx
@@ -211,7 +211,7 @@ export const ElmButtonDropdown = ({
     [setSelected, autoClose, onItemClick, setOpen],
   );
 
-  const caret = <ElmMdiIcon d={dropdownIcon} size="1.25rem" />;
+  const caret = <ElmMdiIcon path={dropdownIcon} size="1.25rem" />;
 
   return (
     <div
@@ -276,7 +276,7 @@ export const ElmButtonDropdown = ({
             }}
           >
             <ElmMdiIcon
-              d={mdiChevronRight}
+              path={mdiChevronRight}
               color="var(--elmethis-color-primary-weak)"
               size="0.75em"
             />

--- a/packages/react/src/components/form/elm-button.module.css
+++ b/packages/react/src/components/form/elm-button.module.css
@@ -46,13 +46,13 @@
   &:hover {
     transform: translateX(-1px) translateY(-1px);
     opacity: var(--elmethis-scoped-opacity, 0.7);
-    box-shadow: 0.125rem 0.125rem 0.125rem rgb(128 128 128 / 25%);
+    box-shadow: 0.125rem 0.125rem 0.125rem var(--elmethis-box-shadow-color);
   }
 
   &:active {
     transform: translateX(1px) translateY(1px);
     opacity: var(--elmethis-scoped-opacity, 0.5);
-    box-shadow: -1px -1px 0.125rem rgb(128 128 128 / 25%);
+    box-shadow: -1px -1px 0.125rem var(--elmethis-box-shadow-color);
   }
 }
 
@@ -78,19 +78,4 @@
     transform: scale(1.2);
     opacity: 0;
   }
-}
-
-.ripple {
-  position: absolute;
-  pointer-events: none;
-  border-radius: 50%;
-  background-color: rgb(205 181 123 / 15%);
-  width: 100%;
-  aspect-ratio: 1 / 1;
-  transition: none;
-  opacity: 0;
-  animation-name: button-ripple;
-  animation-duration: 300ms;
-  animation-fill-mode: both;
-  animation-timing-function: ease-out;
 }

--- a/packages/react/src/components/form/elm-button.stories.tsx
+++ b/packages/react/src/components/form/elm-button.stories.tsx
@@ -37,11 +37,11 @@ export const Flex: Story = {
   render: (args) => (
     <div style={{ display: "flex", gap: "1rem" }}>
       <ElmButton {...args}>
-        <ElmMdiIcon d={mdiSquareEditOutline} size="1.25rem" />
+        <ElmMdiIcon path={mdiSquareEditOutline} size="1.25rem" />
         elm-button
       </ElmButton>
       <ElmButton {...args}>
-        <ElmMdiIcon d={mdiSquareEditOutline} size="1.25rem" />
+        <ElmMdiIcon path={mdiSquareEditOutline} size="1.25rem" />
         elm-button
       </ElmButton>
     </div>
@@ -57,11 +57,11 @@ export const WithPrimary: Story = {
   render: (args) => (
     <div style={{ display: "flex", gap: "1rem" }}>
       <ElmButton {...args} primary>
-        <ElmMdiIcon d={mdiSquareEditOutline} size="1.25rem" />
+        <ElmMdiIcon path={mdiSquareEditOutline} size="1.25rem" />
         elm-button
       </ElmButton>
       <ElmButton {...args}>
-        <ElmMdiIcon d={mdiSquareEditOutline} size="1.25rem" />
+        <ElmMdiIcon path={mdiSquareEditOutline} size="1.25rem" />
         elm-button
       </ElmButton>
     </div>

--- a/packages/react/src/components/form/elm-button.tsx
+++ b/packages/react/src/components/form/elm-button.tsx
@@ -1,10 +1,7 @@
-import {
-  useEffect,
-  useRef,
-  useState,
-  type ComponentPropsWithoutRef,
-  type CSSProperties,
-  type MouseEvent,
+import type {
+  ComponentPropsWithoutRef,
+  CSSProperties,
+  MouseEvent,
 } from "react";
 import { clsx } from "clsx";
 
@@ -42,17 +39,9 @@ export const ElmButton = ({
   children,
   ...props
 }: ElmButtonProps) => {
-  const [clicked, setClicked] = useState(false);
-  const timer = useRef<ReturnType<typeof setTimeout>>(undefined);
-
-  useEffect(() => () => clearTimeout(timer.current), []);
-
   const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
     if (!isLoading && !disabled) {
       if (onClick) {
-        setClicked(true);
-        clearTimeout(timer.current);
-        timer.current = setTimeout(() => setClicked(false), 300);
         onClick(event);
       }
     }
@@ -82,8 +71,6 @@ export const ElmButton = ({
       }
       {...props}
     >
-      {clicked && <span className={styles.ripple}></span>}
-
       {isLoading ? (
         <ElmDotLoadingIcon size="1.5rem" />
       ) : (

--- a/packages/react/src/components/form/elm-checkbox.module.css
+++ b/packages/react/src/components/form/elm-checkbox.module.css
@@ -20,7 +20,7 @@
 }
 
 .checkbox {
-  stroke: light-dark(rgb(0 0 0 / 80%), rgb(255 255 255 / 80%));
+  stroke: var(--elmethis-color-neutral-strong);
   fill: transparent;
 }
 
@@ -32,13 +32,13 @@
   }
 
   &.checked {
-    fill: light-dark(rgb(0 0 0 / 80%), rgb(255 255 255 / 80%));
+    fill: var(--elmethis-color-neutral-strong);
   }
 }
 
 .loading-dot {
   transition: opacity 200ms;
-  fill: light-dark(rgb(0 0 0 / 70%), rgb(255 255 255 / 70%));
+  fill: var(--elmethis-color-neutral-strong);
 }
 
 @keyframes elmethis-checkbox-check-line {
@@ -59,5 +59,5 @@
   animation-delay: 0.1s;
   animation-fill-mode: both;
   transform-origin: center;
-  stroke: light-dark(rgb(255 255 255 / 90%), rgb(0 0 0 / 90%));
+  stroke: contrast-color(var(--elmethis-color-neutral-strong));
 }

--- a/packages/react/src/components/form/elm-select.module.css
+++ b/packages/react/src/components/form/elm-select.module.css
@@ -80,8 +80,8 @@
       width: max-content;
       padding: 0;
       border-radius: 0.25rem;
-      background-color: light-dark(rgb(255 255 255 / 95%), rgb(51 51 51 / 95%));
-      box-shadow: 0 0 0.125rem light-dark(rgb(0 0 0 / 15%), rgb(0 0 0 / 75%));
+      background-color: var(--elmethis-color-surface-raised);
+      box-shadow: 0 0 0.125rem var(--elmethis-box-shadow-color);
 
       .option {
         overflow: hidden;
@@ -97,10 +97,7 @@
         cursor: pointer;
 
         &:hover {
-          background-color: light-dark(
-            rgb(190 194 202 / 30%),
-            rgb(190 194 202 / 20%)
-          );
+          background-color: var(--elmethis-color-surface-sunken);
         }
       }
     }

--- a/packages/react/src/components/form/elm-select.stories.tsx
+++ b/packages/react/src/components/form/elm-select.stories.tsx
@@ -63,7 +63,7 @@ export const Primary: Story = {};
 export const WithIcon: Story = {
   args: {
     label: "Select with icon",
-    icon: <ElmMdiIcon d={mdiAccountOutline} />,
+    icon: <ElmMdiIcon path={mdiAccountOutline} />,
   },
 };
 

--- a/packages/react/src/components/form/elm-select.tsx
+++ b/packages/react/src/components/form/elm-select.tsx
@@ -144,7 +144,7 @@ export const ElmSelect = ({
     >
       <span className={clsx(styles["label"], isOpen && styles["label-active"])}>
         {icon ?? (
-          <ElmMdiIcon d={mdiArrowDownDropCircleOutline} size="0.75rem" />
+          <ElmMdiIcon path={mdiArrowDownDropCircleOutline} size="0.75rem" />
         )}
         {label}
       </span>
@@ -165,7 +165,7 @@ export const ElmSelect = ({
           )}
         </div>
 
-        <ElmMdiIcon d={mdiMenuDown} size="1.5rem" />
+        <ElmMdiIcon path={mdiMenuDown} size="1.5rem" />
 
         <ElmCollapse isOpen={isOpen} className={styles["pulldown"]}>
           {options.map((option) => (
@@ -179,7 +179,7 @@ export const ElmSelect = ({
               }}
             >
               <ElmMdiIcon
-                d={mdiChevronRight}
+                path={mdiChevronRight}
                 color="var(--elmethis-color-primary-weak)"
                 size="0.75em"
               />

--- a/packages/react/src/components/form/elm-switch.module.css
+++ b/packages/react/src/components/form/elm-switch.module.css
@@ -12,11 +12,11 @@
   );
   position: relative;
   cursor: pointer;
-  box-shadow: 0 0 2px rgb(0 0 0 / 10%);
+  box-shadow: 0 0 2px var(--elmethis-box-shadow-color);
   transition:
     opacity 300ms,
     background-color 300ms;
-  background-color: rgb(128 128 128 / 25%);
+  background-color: var(--elmethis-color-surface-sunken);
 
   &.checked {
     background-color: var(--elmethis-scoped-color);
@@ -40,7 +40,7 @@
     transform 300ms,
     opacity 300ms,
     background-color 300ms;
-  background-color: rgb(255 255 255 / 90%);
+  background-color: var(--elmethis-color-surface-raised);
 
   &.checked {
     transform: translateX(
@@ -50,7 +50,7 @@
 
   &.disabled {
     opacity: 0.5;
-    background-color: rgb(128 128 128 / 100%);
+    background-color: var(--elmethis-color-neutral-weak);
   }
 
   &:hover {

--- a/packages/react/src/components/form/elm-text-area.module.css
+++ b/packages/react/src/components/form/elm-text-area.module.css
@@ -53,12 +53,8 @@
   border-style: solid;
   border-width: 1px;
   border-color: transparent;
-  background-color: light-dark(
-    var(--elmethis-color-surface-raised),
-    oklch(from #393e46 calc(l * 0.9) c h)
-  );
-  box-shadow: 0 0 0.125rem
-    light-dark(var(--elmethis-box-shadow-color), rgb(0 0 0 / 75%));
+  background-color: var(--elmethis-color-surface-raised);
+  box-shadow: 0 0 0.125rem var(--elmethis-box-shadow-color);
 
   &.disabled {
     background-color: var(--elmethis-color-surface-sunken);
@@ -106,10 +102,7 @@
   min-height: 1.5rem;
   font-family: inherit;
   line-height: 1.4;
-  color: light-dark(
-    var(--elmethis-color-neutral),
-    oklch(from white l c h / 70%)
-  );
+  color: var(--elmethis-color-neutral);
   caret-color: var(--elmethis-scoped-highlight-color);
   resize: vertical;
 
@@ -123,13 +116,10 @@
   }
 
   &::selection {
-    color: light-dark(
-      var(--elmethis-color-surface-raised),
-      oklch(from black l c h / 70%)
-    );
-    background-color: light-dark(
-      var(--elmethis-scoped-color, var(--elmethis-color-neutral)),
-      oklch(from white l c h / 70%)
+    color: var(--elmethis-color-surface-raised);
+    background-color: var(
+      --elmethis-scoped-color,
+      var(--elmethis-color-neutral)
     );
   }
 }

--- a/packages/react/src/components/form/elm-text-area.stories.tsx
+++ b/packages/react/src/components/form/elm-text-area.stories.tsx
@@ -63,7 +63,11 @@ const WithIconStory = () => {
         onInput={(e) => setText(e.currentTarget.value)}
         rows={5}
         icon={
-          <ElmMdiIcon d={mdiCommentTextOutline} size="0.75rem" color="gray" />
+          <ElmMdiIcon
+            path={mdiCommentTextOutline}
+            size="0.75rem"
+            color="gray"
+          />
         }
       />
       <ElmInlineText>{text}</ElmInlineText>

--- a/packages/react/src/components/form/elm-text-area.tsx
+++ b/packages/react/src/components/form/elm-text-area.tsx
@@ -91,7 +91,7 @@ export const ElmTextArea = ({
       <span
         className={clsx(styles.header, isFocused && styles["label-active"])}
       >
-        {icon ?? <ElmMdiIcon d={mdiTextLong} size="0.75rem" />}
+        {icon ?? <ElmMdiIcon path={mdiTextLong} size="0.75rem" />}
         <span>
           {label}
           {required && <span className={styles.requierd}>*</span>}

--- a/packages/react/src/components/form/elm-text-field.module.css
+++ b/packages/react/src/components/form/elm-text-field.module.css
@@ -134,7 +134,7 @@
     cursor: pointer;
 
     &:hover {
-      background-color: rgb(128 128 128 / 20%);
+      background-color: var(--elmethis-color-surface-sunken);
     }
   }
 }
@@ -145,5 +145,5 @@
   font-size: 0.85em;
   user-select: none;
   transition: color 200ms;
-  color: light-dark(rgb(0 0 0 / 65%), rgb(255 255 255 / 65%));
+  color: var(--elmethis-color-neutral-weak);
 }

--- a/packages/react/src/components/form/elm-text-field.stories.tsx
+++ b/packages/react/src/components/form/elm-text-field.stories.tsx
@@ -61,7 +61,7 @@ const WithIconStory = () => {
         placeholder="Enter your email"
         value={text}
         onChange={(e) => setText(e.target.value)}
-        icon={<ElmMdiIcon d={mdiEmail} size=".75rem" color="gray" />}
+        icon={<ElmMdiIcon path={mdiEmail} size=".75rem" color="gray" />}
       />
       <ElmInlineText>{text}</ElmInlineText>
     </div>

--- a/packages/react/src/components/form/elm-text-field.tsx
+++ b/packages/react/src/components/form/elm-text-field.tsx
@@ -90,7 +90,7 @@ export const ElmTextField = ({
       <span
         className={clsx(styles.header, isFocused && styles["label-active"])}
       >
-        {icon ?? <ElmMdiIcon d={mdiText} size="0.75rem" />}
+        {icon ?? <ElmMdiIcon path={mdiText} size="0.75rem" />}
         <span>
           {label}
           {required && <span className={styles.requierd}>*</span>}
@@ -149,7 +149,7 @@ export const ElmTextField = ({
             }}
           >
             <ElmMdiIcon
-              d={inputType === "text" ? mdiEyeOutline : mdiEyeOffOutline}
+              path={inputType === "text" ? mdiEyeOutline : mdiEyeOffOutline}
               size="1.25rem"
               color="gray"
             />
@@ -163,7 +163,7 @@ export const ElmTextField = ({
               }
             }}
           >
-            <ElmMdiIcon d={mdiTrashCanOutline} size="1.25rem" color="gray" />
+            <ElmMdiIcon path={mdiTrashCanOutline} size="1.25rem" color="gray" />
           </div>
         </div>
       </div>

--- a/packages/react/src/components/form/elm-validation.tsx
+++ b/packages/react/src/components/form/elm-validation.tsx
@@ -33,7 +33,7 @@ export const ElmValidation = ({
       {...props}
     >
       <ElmMdiIcon
-        d={isValid ? mdiCheckCircle : mdiCheckCircleOutline}
+        path={isValid ? mdiCheckCircle : mdiCheckCircleOutline}
         color={isValid ? validColor : undefined}
       />
       <ElmInlineText color={isValid ? validColor : undefined}>

--- a/packages/react/src/components/icon/elm-inline-icon.module.css
+++ b/packages/react/src/components/icon/elm-inline-icon.module.css
@@ -9,15 +9,11 @@
   /* Light inherits the surrounding text color; dark lightens the glyph. */
   color: light-dark(
     currentcolor,
-    var(--elmethis-scoped-color, rgb(255 255 255 / 70%))
+    var(--elmethis-scoped-color, var(--elmethis-color-neutral))
   );
 
   &::selection {
-    color: light-dark(currentcolor, rgb(0 0 0 / 70%));
-    background-color: light-dark(
-      var(--elmethis-scoped-color, rgb(0 0 0 / 25%)),
-      var(--elmethis-scoped-color, rgb(255 255 255 / 25%))
-    );
+    background-color: var(--elmethis-color-selection);
 
     /* `filter` is not a <color>, so it can't use light-dark(): the OS default
        is the media query; an explicit pin overrides it below. */

--- a/packages/react/src/components/icon/elm-language-icon.tsx
+++ b/packages/react/src/components/icon/elm-language-icon.tsx
@@ -38,7 +38,7 @@ export const ElmLanguageIcon = ({
   const normalized = normalizeLanguage(language);
 
   if (normalized === "file") {
-    return <ElmMdiIcon d={mdiCodeTags} size={String(size)} />;
+    return <ElmMdiIcon path={mdiCodeTags} size={String(size)} />;
   }
 
   return (

--- a/packages/react/src/components/icon/elm-mdi-icon.module.css
+++ b/packages/react/src/components/icon/elm-mdi-icon.module.css
@@ -1,7 +1,3 @@
 .elm-mdi-icon {
-  fill: light-dark(
-    var(--elmethis-scoped-color-light, var(--elmethis-color-neutral)),
-    var(--elmethis-scoped-color-dark, var(--elmethis-color-neutral))
-  );
   transition: fill 200ms;
 }

--- a/packages/react/src/components/icon/elm-mdi-icon.module.css
+++ b/packages/react/src/components/icon/elm-mdi-icon.module.css
@@ -1,7 +1,7 @@
 .elm-mdi-icon {
   fill: light-dark(
-    var(--elmethis-scoped-color, #555b67),
-    var(--dark-color, #b0b5be)
+    var(--elmethis-scoped-color-light, var(--elmethis-color-neutral)),
+    var(--elmethis-scoped-color-dark, var(--elmethis-color-neutral))
   );
   transition: fill 200ms;
 }

--- a/packages/react/src/components/icon/elm-mdi-icon.spec.tsx
+++ b/packages/react/src/components/icon/elm-mdi-icon.spec.tsx
@@ -6,65 +6,66 @@ import { ElmMdiIcon } from "./elm-mdi-icon";
 import { mdiCodeTags } from "@mdi/js";
 
 describe("[CSR] ElmMdiIcon", () => {
-  it("renders an <svg role='img'> with the given path", () => {
-    const { container } = render(<ElmMdiIcon d={mdiCodeTags} />);
-    const svg = container.querySelector("svg");
-    expect(svg).not.toBeNull();
-    expect(svg).toHaveAttribute("role", "img");
-    // The `d` prop must reach the inner <path>.
+  it("renders a decorative currentColor SVG with the given path", () => {
+    const { container } = render(<ElmMdiIcon path={mdiCodeTags} />);
+    const svg = container.querySelector("svg")!;
+    expect(svg).toHaveAttribute("aria-hidden", "true");
+    expect(svg).not.toHaveAttribute("role");
+    expect(svg).toHaveAttribute("focusable", "false");
+    expect(svg).toHaveAttribute("fill", "currentColor");
     expect(container.querySelector("path")).toHaveAttribute("d", mdiCodeTags);
   });
 
+  it("exposes a labeled icon as an image", () => {
+    const { container, getByRole } = render(
+      <ElmMdiIcon path={mdiCodeTags} label="Code" />,
+    );
+    const svg = getByRole("img", { name: "Code" });
+    expect(svg).not.toHaveAttribute("aria-hidden");
+    expect(container.querySelector("title")).toHaveTextContent("Code");
+  });
+
   it("size prop drives both width and height", () => {
-    const { container } = render(<ElmMdiIcon d={mdiCodeTags} size="32px" />);
+    const { container } = render(<ElmMdiIcon path={mdiCodeTags} size={32} />);
     const svg = container.querySelector("svg")!;
-    expect(svg).toHaveAttribute("width", "32px");
-    expect(svg).toHaveAttribute("height", "32px");
+    expect(svg).toHaveAttribute("width", "32");
+    expect(svg).toHaveAttribute("height", "32");
   });
 
-  it("color prop feeds the svg fill and the scoped light color var", () => {
+  it("color prop sets the currentColor source", () => {
     const { container } = render(
-      <ElmMdiIcon d={mdiCodeTags} color="#ff0000" />,
+      <ElmMdiIcon path={mdiCodeTags} color="var(--elmethis-color-primary)" />,
     );
     const svg = container.querySelector("svg")!;
-    expect(svg).toHaveAttribute("fill", "#ff0000");
-    // Both theme-specific scoped colors fall back to `color`.
-    expect(svg.style.getPropertyValue("--elmethis-scoped-color-light")).toBe(
-      "#ff0000",
-    );
-    expect(svg.style.getPropertyValue("--elmethis-scoped-color-dark")).toBe(
-      "#ff0000",
-    );
+    expect(svg).toHaveAttribute("color", "var(--elmethis-color-primary)");
+    expect(svg).toHaveAttribute("fill", "currentColor");
   });
 
-  it("lightColor / darkColor override the scoped color vars independently", () => {
-    const { container } = render(
-      <ElmMdiIcon d={mdiCodeTags} lightColor="#111" darkColor="#eee" />,
+  it("uses native ARIA naming when provided", () => {
+    const { getByRole } = render(
+      <ElmMdiIcon path={mdiCodeTags} aria-label="Code" />,
     );
-    const svg = container.querySelector("svg")!;
-    expect(svg.style.getPropertyValue("--elmethis-scoped-color-light")).toBe(
-      "#111",
-    );
-    expect(svg.style.getPropertyValue("--elmethis-scoped-color-dark")).toBe(
-      "#eee",
+    expect(getByRole("img", { name: "Code" })).not.toHaveAttribute(
+      "aria-hidden",
     );
   });
 
   it("merges a passthrough className onto the root", () => {
     const { container } = render(
-      <ElmMdiIcon d={mdiCodeTags} className="custom-class" />,
+      <ElmMdiIcon path={mdiCodeTags} className="custom-class" />,
     );
     expect(container.querySelector("svg")).toHaveClass("custom-class");
   });
 });
 
 describe("[SSR] ElmMdiIcon", () => {
-  it("renders the svg shell with the path", () => {
+  it("renders the labeled svg shell with the path", () => {
     const html = renderToStaticMarkup(
-      <ElmMdiIcon d={mdiCodeTags} />,
+      <ElmMdiIcon path={mdiCodeTags} label="Code" />,
     ).toLowerCase();
     expect(html).toContain("<svg");
     expect(html).toContain('role="img"');
+    expect(html).toContain("<title>code</title>");
     expect(html).toContain(`d="${mdiCodeTags.toLowerCase()}"`);
   });
 });

--- a/packages/react/src/components/icon/elm-mdi-icon.spec.tsx
+++ b/packages/react/src/components/icon/elm-mdi-icon.spec.tsx
@@ -28,11 +28,13 @@ describe("[CSR] ElmMdiIcon", () => {
     );
     const svg = container.querySelector("svg")!;
     expect(svg).toHaveAttribute("fill", "#ff0000");
-    // Both --elmethis-scoped-color and --dark-color fall back to `color`.
-    expect(svg.style.getPropertyValue("--elmethis-scoped-color")).toBe(
+    // Both theme-specific scoped colors fall back to `color`.
+    expect(svg.style.getPropertyValue("--elmethis-scoped-color-light")).toBe(
       "#ff0000",
     );
-    expect(svg.style.getPropertyValue("--dark-color")).toBe("#ff0000");
+    expect(svg.style.getPropertyValue("--elmethis-scoped-color-dark")).toBe(
+      "#ff0000",
+    );
   });
 
   it("lightColor / darkColor override the scoped color vars independently", () => {
@@ -40,8 +42,12 @@ describe("[CSR] ElmMdiIcon", () => {
       <ElmMdiIcon d={mdiCodeTags} lightColor="#111" darkColor="#eee" />,
     );
     const svg = container.querySelector("svg")!;
-    expect(svg.style.getPropertyValue("--elmethis-scoped-color")).toBe("#111");
-    expect(svg.style.getPropertyValue("--dark-color")).toBe("#eee");
+    expect(svg.style.getPropertyValue("--elmethis-scoped-color-light")).toBe(
+      "#111",
+    );
+    expect(svg.style.getPropertyValue("--elmethis-scoped-color-dark")).toBe(
+      "#eee",
+    );
   });
 
   it("merges a passthrough className onto the root", () => {

--- a/packages/react/src/components/icon/elm-mdi-icon.stories.tsx
+++ b/packages/react/src/components/icon/elm-mdi-icon.stories.tsx
@@ -9,8 +9,10 @@ const meta = {
   args: {},
   argTypes: {
     color: { control: "color" },
-    lightColor: { control: "color" },
-    darkColor: { control: "color" },
+    label: {
+      control: "text",
+      description: "Accessible label rendered as the SVG title.",
+    },
   },
   render: (args) => <ElmMdiIcon {...args} />,
 } satisfies Meta<typeof ElmMdiIcon>;
@@ -21,6 +23,7 @@ type Story = StoryObj<typeof meta>;
 export const Primary: Story = {
   args: {
     size: "1.25rem",
-    d: mdiTag,
+    path: mdiTag,
+    label: "Tag",
   },
 };

--- a/packages/react/src/components/icon/elm-mdi-icon.tsx
+++ b/packages/react/src/components/icon/elm-mdi-icon.tsx
@@ -16,7 +16,7 @@ export const ElmMdiIcon = ({
   style,
   d,
   size = "1em",
-  color = "currentColor",
+  color,
   lightColor,
   darkColor,
   ...props
@@ -26,8 +26,8 @@ export const ElmMdiIcon = ({
       className={clsx(styles["elm-mdi-icon"], className)}
       style={
         {
-          "--elmethis-scoped-color": lightColor ?? color,
-          "--dark-color": darkColor ?? color,
+          "--elmethis-scoped-color-light": lightColor ?? color,
+          "--elmethis-scoped-color-dark": darkColor ?? color,
           ...style,
         } as CSSProperties
       }

--- a/packages/react/src/components/icon/elm-mdi-icon.tsx
+++ b/packages/react/src/components/icon/elm-mdi-icon.tsx
@@ -1,46 +1,48 @@
-import type { ComponentPropsWithoutRef, CSSProperties } from "react";
+import type { ComponentPropsWithoutRef } from "react";
 import { clsx } from "clsx";
 
 import styles from "./elm-mdi-icon.module.css";
 
-export interface ElmMdiIconProps extends ComponentPropsWithoutRef<"svg"> {
-  d: string;
-  size?: string;
+export interface ElmMdiIconProps extends Omit<
+  ComponentPropsWithoutRef<"svg">,
+  "children"
+> {
+  path: string;
+  size?: string | number;
   color?: string;
-  lightColor?: string;
-  darkColor?: string;
+  label?: string;
 }
 
 export const ElmMdiIcon = ({
   className,
   style,
-  d,
+  path,
   size = "1em",
   color,
-  lightColor,
-  darkColor,
+  label,
   ...props
 }: ElmMdiIconProps) => {
+  const hasAccessibleName = Boolean(
+    label || props["aria-label"] || props["aria-labelledby"],
+  );
+
   return (
     <svg
       className={clsx(styles["elm-mdi-icon"], className)}
-      style={
-        {
-          "--elmethis-scoped-color-light": lightColor ?? color,
-          "--elmethis-scoped-color-dark": darkColor ?? color,
-          ...style,
-        } as CSSProperties
-      }
+      style={style}
       width={size}
       height={size}
       viewBox="0 0 24 24"
-      fill={color}
+      color={color}
+      fill="currentColor"
       xmlns="http://www.w3.org/2000/svg"
       focusable="false"
-      role="img"
+      aria-hidden={hasAccessibleName ? undefined : "true"}
+      role={hasAccessibleName ? "img" : undefined}
       {...props}
     >
-      <path d={d} />
+      {label && <title>{label}</title>}
+      <path d={path} />
     </svg>
   );
 };

--- a/packages/react/src/components/icon/elm-toggle-theme.module.css
+++ b/packages/react/src/components/icon/elm-toggle-theme.module.css
@@ -2,9 +2,14 @@
   display: block; /* Ensure it behaves like a block/inline-block */
   box-sizing: border-box;
   padding: 0.25rem;
-  color: light-dark(#555b67, #b0b5be);
+  color: var(--elmethis-color-neutral);
   border-radius: 50%;
   cursor: pointer;
-  box-shadow: 0 0 0.125rem light-dark(rgb(0 0 0 / 30%), rgb(0 0 0 / 60%));
-  background-color: light-dark(rgb(255 255 255 / 20%), rgb(0 0 0 / 20%));
+  box-shadow: 0 0 0.125rem var(--elmethis-box-shadow-color);
+  background-color: var(--elmethis-color-surface-raised);
+  transition: background-color 100ms;
+
+  &:hover {
+    background-color: var(--elmethis-color-surface-sunken);
+  }
 }

--- a/packages/react/src/components/media/elm-audio-player.tsx
+++ b/packages/react/src/components/media/elm-audio-player.tsx
@@ -303,7 +303,7 @@ export const ElmAudioPlayer = ({
           aria-hidden="true"
         >
           <ElmMdiIcon
-            d={hasError ? mdiAlertCircleOutline : mdiMusicNote}
+            path={hasError ? mdiAlertCircleOutline : mdiMusicNote}
             size="1.25rem"
           />
         </span>
@@ -326,7 +326,7 @@ export const ElmAudioPlayer = ({
 
       {hasError ? (
         <div className={styles["error-notice"]} role="alert">
-          <ElmMdiIcon d={mdiAlertCircleOutline} size="1.25rem" />
+          <ElmMdiIcon path={mdiAlertCircleOutline} size="1.25rem" />
           <span className={styles["error-message"]}>{errorMessage}</span>
         </div>
       ) : (
@@ -367,7 +367,7 @@ export const ElmAudioPlayer = ({
                 onClick={() => seekTo(currentTime - seekStep)}
                 aria-label={`Back ${seekStep} seconds`}
               >
-                <ElmMdiIcon d={mdiRewind10} size="1.25rem" />
+                <ElmMdiIcon path={mdiRewind10} size="1.25rem" />
               </button>
 
               <button
@@ -377,7 +377,10 @@ export const ElmAudioPlayer = ({
                 aria-label={isPlaying ? "Pause" : "Play"}
                 aria-pressed={isPlaying}
               >
-                <ElmMdiIcon d={isPlaying ? mdiPause : mdiPlay} size="1.5rem" />
+                <ElmMdiIcon
+                  path={isPlaying ? mdiPause : mdiPlay}
+                  size="1.5rem"
+                />
               </button>
 
               <button
@@ -386,7 +389,7 @@ export const ElmAudioPlayer = ({
                 onClick={() => seekTo(currentTime + seekStep)}
                 aria-label={`Forward ${seekStep} seconds`}
               >
-                <ElmMdiIcon d={mdiFastForward10} size="1.25rem" />
+                <ElmMdiIcon path={mdiFastForward10} size="1.25rem" />
               </button>
             </div>
 
@@ -398,7 +401,7 @@ export const ElmAudioPlayer = ({
                 aria-label={isMuted ? "Unmute" : "Mute"}
                 aria-pressed={isMuted}
               >
-                <ElmMdiIcon d={volumeIcon} size="1.25rem" />
+                <ElmMdiIcon path={volumeIcon} size="1.25rem" />
               </button>
               <input
                 className={styles["volume-slider"]}

--- a/packages/react/src/components/media/elm-block-image.module.css
+++ b/packages/react/src/components/media/elm-block-image.module.css
@@ -24,7 +24,7 @@
   height: auto;
   object-fit: contain;
   border-radius: 0.25rem;
-  box-shadow: 0 0 0.125rem rgb(0 0 0 / 10%);
+  box-shadow: 0 0 0.125rem var(--elmethis-box-shadow-color);
   user-select: none;
   aspect-ratio: var(--elmethis-scoped-aspect-ratio, auto);
   cursor: var(--elmethis-scoped-cursor);

--- a/packages/react/src/components/media/elm-block-image.tsx
+++ b/packages/react/src/components/media/elm-block-image.tsx
@@ -101,7 +101,7 @@ export const ElmBlockImage = ({
       {caption && (
         <figcaption className={styles["caption-box"]}>
           <span className={styles["caption-icon"]}>
-            <ElmMdiIcon d={mdiMessageImageOutline} size="1.25rem" />
+            <ElmMdiIcon path={mdiMessageImageOutline} size="1.25rem" />
           </span>
           <ElmInlineText size="1rem">{caption}</ElmInlineText>
         </figcaption>

--- a/packages/react/src/components/media/elm-file.module.css
+++ b/packages/react/src/components/media/elm-file.module.css
@@ -4,9 +4,9 @@
   grid-template-columns: 1.5rem 1fr 1fr 1.5rem;
   gap: 1rem;
   align-items: center;
-  box-shadow: 0 0 0.125rem rgb(0 0 0 / 20%);
+  box-shadow: 0 0 0.125rem var(--elmethis-box-shadow-color);
   border-radius: 0.25rem;
-  background-color: light-dark(rgb(255 255 255 / 20%), rgb(0 0 0 / 20%));
+  background-color: var(--elmethis-color-surface-raised);
 }
 
 .file-size {
@@ -28,6 +28,6 @@
     background-color 200ms;
 
   &:hover {
-    background-color: light-dark(rgb(0 0 0 / 10%), rgb(255 255 255 / 10%));
+    background-color: var(--elmethis-color-surface-sunken);
   }
 }

--- a/packages/react/src/components/media/elm-file.tsx
+++ b/packages/react/src/components/media/elm-file.tsx
@@ -61,7 +61,7 @@ export const ElmFile = ({
   return (
     <div className={clsx(styles["elm-file"], className)} {...props}>
       <div>
-        <ElmMdiIcon d={mdiFile} size="1.25rem" />
+        <ElmMdiIcon path={mdiFile} size="1.25rem" />
       </div>
 
       <div>
@@ -75,7 +75,7 @@ export const ElmFile = ({
       </div>
 
       <div className={styles["download-icon"]} onClick={downloadFile}>
-        <ElmMdiIcon d={mdiDownload} size="1.25rem" />
+        <ElmMdiIcon path={mdiDownload} size="1.25rem" />
       </div>
     </div>
   );

--- a/packages/react/src/components/navigation/elm-bookmark.module.css
+++ b/packages/react/src/components/navigation/elm-bookmark.module.css
@@ -3,19 +3,19 @@
   display: block;
   container-type: inline-size;
   border-radius: 0.25rem;
-  box-shadow: 0 0 0.125rem rgb(0 0 0 / 10%);
+  box-shadow: 0 0 0.125rem var(--elmethis-box-shadow-color);
   overflow: hidden;
+  background-color: var(--elmethis-color-surface-raised);
   transition:
     background-color 200ms,
     transform 200ms;
 
   &:hover {
-    background-color: rgb(105 135 184 / 10%);
-    transform: translateX(-0.125rem) translateY(-0.125rem);
+    background-color: var(--elmethis-color-surface-sunken);
+    transform: translateX(-2px) translateY(-2px);
   }
 
   &:active {
-    background-color: rgb(89 181 124 / 10%);
     transform: translateX(0) translateY(0);
   }
 }
@@ -61,8 +61,6 @@
   flex-direction: column;
   gap: 0.5rem;
   justify-content: space-between;
-  transition: background-color 200ms;
-  background-color: light-dark(rgb(255 255 255 / 40%), rgb(0 0 0 / 20%));
 
   @container (max-width: 700px) {
     width: 100%;

--- a/packages/react/src/components/navigation/elm-bookmark.tsx
+++ b/packages/react/src/components/navigation/elm-bookmark.tsx
@@ -77,7 +77,7 @@ export const ElmBookmark = ({
               <ElmInlineIcon src={favicon} />
             ) : (
               <ElmMdiIcon
-                d={mdiLinkVariant}
+                path={mdiLinkVariant}
                 color="var(--elmethis-color-accent-info)"
               />
             )}

--- a/packages/react/src/components/navigation/elm-breadcrumb.tsx
+++ b/packages/react/src/components/navigation/elm-breadcrumb.tsx
@@ -36,7 +36,7 @@ export const ElmBreadcrumb = ({
           <span className={styles["link-container"]} onClick={link.onClick}>
             <ElmMdiIcon
               className={styles.icon}
-              d={
+              path={
                 index === 0
                   ? mdiHome
                   : index === links.length - 1
@@ -52,7 +52,7 @@ export const ElmBreadcrumb = ({
           {links.length !== index + 1 && (
             <ElmMdiIcon
               className={styles.chevron}
-              d={mdiChevronRight}
+              path={mdiChevronRight}
               size="1rem"
             />
           )}

--- a/packages/react/src/components/navigation/elm-page-top.module.css
+++ b/packages/react/src/components/navigation/elm-page-top.module.css
@@ -57,7 +57,7 @@
       top: 0;
       height: 100%;
       width: 50%;
-      background-color: light-dark(#494f59, #bec2ca);
+      background-color: var(--elmethis-color-neutral);
     }
 
     &::before {
@@ -82,20 +82,7 @@
     font-size: 12px;
     white-space: nowrap;
     user-select: none;
-
-    /* From text.scoped.scss */
-    color: light-dark(
-      var(--elmethis-scoped-color, #606875),
-      var(--elmethis-scoped-color, #b0b5be)
-    );
-
-    &::selection {
-      color: light-dark(#cccfd5, #3e434b);
-      background-color: light-dark(
-        var(--elmethis-scoped-color, #3e434b),
-        var(--elmethis-scoped-color, #cccfd5)
-      );
-    }
+    color: var(--elmethis-color-neutral);
   }
 }
 

--- a/packages/react/src/components/others/elm-color-primitive-sample.tsx
+++ b/packages/react/src/components/others/elm-color-primitive-sample.tsx
@@ -124,7 +124,7 @@ export const ElmColorPrimitiveSample = ({
         >
           <ElmMdiIcon
             className={styles["mode-toggle-icon"]}
-            d={copyMode === "hex" ? mdiHexadecimal : mdiFormatColorFill}
+            path={copyMode === "hex" ? mdiHexadecimal : mdiFormatColorFill}
             size={"1.25rem"}
           />
           Copy: {copyMode === "hex" ? "hex value" : "variable name"}

--- a/packages/react/src/components/others/elm-color-semantic-sample.tsx
+++ b/packages/react/src/components/others/elm-color-semantic-sample.tsx
@@ -305,7 +305,7 @@ export const ElmColorSemanticSample = ({
         >
           <ElmMdiIcon
             className={styles["mode-toggle-icon"]}
-            d={copyMode === "hex" ? mdiHexadecimal : mdiFormatColorFill}
+            path={copyMode === "hex" ? mdiHexadecimal : mdiFormatColorFill}
             size={"1.25rem"}
           />
           Copy: {copyMode === "hex" ? "hex value" : "variable name"}

--- a/packages/react/src/components/others/use-wordle.module.css
+++ b/packages/react/src/components/others/use-wordle.module.css
@@ -24,14 +24,14 @@
     color 0.15s ease;
 
   &.error {
-    background-color: #1a1a1b;
-    color: #fff;
+    background-color: var(--elmethis-color-accent-error);
+    color: contrast-color(var(--elmethis-color-accent-error));
     animation: fade-in 0.15s ease;
   }
 
   &.status {
-    background-color: #538d4e;
-    color: #fff;
+    background-color: var(--elmethis-color-accent-success);
+    color: contrast-color(var(--elmethis-color-accent-success));
     font-size: 1rem;
     animation: fade-in 0.15s ease;
   }
@@ -66,33 +66,33 @@
     border-color 0.2s ease;
 
   &.empty {
-    border-color: gray;
+    border-color: var(--elmethis-color-neutral-weak);
     background-color: transparent;
     color: transparent;
   }
 
   &.tbd {
-    border-color: #565758;
+    border-color: var(--elmethis-color-neutral);
     background-color: transparent;
-    color: #6c7483;
+    color: var(--elmethis-color-neutral);
   }
 
   &.correct {
-    background-color: #538d4e;
-    border-color: #538d4e;
-    color: #fff;
+    background-color: var(--elmethis-color-accent-success);
+    border-color: var(--elmethis-color-accent-success);
+    color: contrast-color(var(--elmethis-color-accent-success));
   }
 
   &.present {
-    background-color: #b59f3b;
-    border-color: #b59f3b;
-    color: #fff;
+    background-color: var(--elmethis-color-accent-warning);
+    border-color: var(--elmethis-color-accent-warning);
+    color: contrast-color(var(--elmethis-color-accent-warning));
   }
 
   &.absent {
-    background-color: #3a3a3c;
-    border-color: #3a3a3c;
-    color: #fff;
+    background-color: var(--elmethis-color-surface-sunken);
+    border-color: var(--elmethis-color-surface-sunken);
+    color: contrast-color(var(--elmethis-color-surface-sunken));
   }
 }
 
@@ -117,8 +117,8 @@
   padding: 0 0.25rem;
   border: none;
   border-radius: 0.25rem;
-  background-color: #818384;
-  color: #fff;
+  background-color: var(--elmethis-color-neutral);
+  color: contrast-color(var(--elmethis-color-neutral));
   font-size: 0.8125rem;
   font-weight: bold;
   cursor: pointer;
@@ -140,15 +140,18 @@
   }
 
   &.correct {
-    background-color: #538d4e;
+    background-color: var(--elmethis-color-accent-success);
+    color: contrast-color(var(--elmethis-color-accent-success));
   }
 
   &.present {
-    background-color: #b59f3b;
+    background-color: var(--elmethis-color-accent-warning);
+    color: contrast-color(var(--elmethis-color-accent-warning));
   }
 
   &.absent {
-    background-color: #3a3a3c;
+    background-color: var(--elmethis-color-surface-sunken);
+    color: contrast-color(var(--elmethis-color-surface-sunken));
   }
 }
 
@@ -165,8 +168,8 @@
   padding: 0.625rem 1.5rem;
   border: none;
   border-radius: 0.25rem;
-  background-color: #538d4e;
-  color: #fff;
+  background-color: var(--elmethis-color-accent-success);
+  color: contrast-color(var(--elmethis-color-accent-success));
   font-size: 1rem;
   font-weight: bold;
   cursor: pointer;
@@ -175,7 +178,9 @@
     transform 0.05s ease;
 
   &:hover {
-    background-color: #6aaa64;
+    background-color: oklch(
+      from var(--elmethis-color-accent-success) calc(l + 0.08) c h
+    );
   }
 
   &:active {

--- a/packages/react/src/components/table/elm-table.module.css
+++ b/packages/react/src/components/table/elm-table.module.css
@@ -61,7 +61,7 @@
 .elm-table {
   border-collapse: collapse;
   border-spacing: 0;
-  box-shadow: 0 0 0.125rem rgb(0 0 0 / 20%);
+  box-shadow: 0 0 0.125rem var(--elmethis-box-shadow-color);
 }
 
 .caption {
@@ -84,7 +84,7 @@
 .spacing {
   flex-grow: 1;
   height: 1px;
-  background-color: rgb(128 128 128 / 20%);
+  background-color: var(--elmethis-color-divider);
 }
 
 /* Sticky label column. When the first column holds row headers, pin it so the

--- a/packages/react/src/components/typography/elm-block-quote.tsx
+++ b/packages/react/src/components/typography/elm-block-quote.tsx
@@ -19,13 +19,13 @@ export const ElmBlockQuote = ({
       {...props}
     >
       <div className={clsx(styles.icon, styles["icon-top-left"])}>
-        <ElmMdiIcon d={mdiFormatQuoteOpen} />
+        <ElmMdiIcon path={mdiFormatQuoteOpen} />
       </div>
 
       <div className={styles.body}>{children}</div>
 
       <div className={clsx(styles.icon, styles["icon-bottom-right"])}>
-        <ElmMdiIcon d={mdiFormatQuoteClose} />
+        <ElmMdiIcon path={mdiFormatQuoteClose} />
       </div>
     </blockquote>
   );

--- a/packages/react/src/components/typography/elm-callout.tsx
+++ b/packages/react/src/components/typography/elm-callout.tsx
@@ -42,7 +42,11 @@ export const ElmCallout = ({
       {...props}
     >
       <div className={styles.header}>
-        <ElmMdiIcon className={styles.icon} d={ICON_MAP[type]} size="1.25rem" />
+        <ElmMdiIcon
+          className={styles.icon}
+          path={ICON_MAP[type]}
+          size="1.25rem"
+        />
         <span>{type}</span>
       </div>
 

--- a/packages/react/src/components/typography/elm-inline-text.module.css
+++ b/packages/react/src/components/typography/elm-inline-text.module.css
@@ -72,7 +72,7 @@
     opacity 200ms;
 
   &:hover {
-    background-color: oklch(from #6987b8 l c h / 20%);
+    background-color: var(--elmethis-color-accent-link-surface);
   }
 
   &:active {

--- a/packages/react/src/hooks/use-clipboard.tsx
+++ b/packages/react/src/hooks/use-clipboard.tsx
@@ -87,7 +87,7 @@ export const useClipboard = (options: UseClipboardOptions) => {
       >
         <ElmMdiIcon
           className={clsx(copied && styles["use-clipboard-icon-copied"])}
-          d={copied ? mdiClipboardCheckOutline : mdiClipboardOutline}
+          path={copied ? mdiClipboardCheckOutline : mdiClipboardOutline}
           size="1.25rem"
         />
       </span>

--- a/packages/react/stylelint.config.mjs
+++ b/packages/react/stylelint.config.mjs
@@ -10,6 +10,31 @@ export default {
   extends: ["stylelint-config-standard", "stylelint-config-css-modules"],
   plugins: ["stylelint-value-no-unknown-custom-properties"],
   rules: {
+    "color-no-hex": [
+      true,
+      {
+        message: "Use an Elmethis color token instead of a hex color",
+        severity: "warning",
+      },
+    ],
+    "color-named": [
+      "never",
+      {
+        message: "Use an Elmethis color token instead of a named color",
+        severity: "warning",
+      },
+    ],
+    "declaration-property-value-disallowed-list": [
+      {
+        "/.*/": [
+          "/(?<![-\\w])(?:rgb|rgba|hsl|hsla|hwb|lab|lch|oklab|oklch|color)\\((?!\\s*from\\b)/i",
+        ],
+      },
+      {
+        message: "Use an Elmethis color token instead of a color function",
+        severity: "warning",
+      },
+    ],
     "csstools/value-no-unknown-custom-properties": [
       true,
       {
@@ -33,5 +58,7 @@ export default {
     "lib-types/**",
     "storybook-static/**",
     "node_modules/**",
+    "./src/components/others/elm-color-primitive-sample.module.css",
+    "./src/components/others/elm-color-semantic-sample.module.css",
   ],
 };

--- a/packages/solid/.storybook/sb.css
+++ b/packages/solid/.storybook/sb.css
@@ -5,5 +5,5 @@ html {
 body,
 .docs-story {
   transition: background-color 200ms;
-  background-color: light-dark(#efecea, #393e46);
+  background-color: var(--elmethis-color-surface-base);
 }

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elmethis/solid",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "SolidJS component library for elmethis.",
   "publishConfig": {
     "access": "public"

--- a/packages/solid/src/components/a2ui/elm-a2ui.module.css
+++ b/packages/solid/src/components/a2ui/elm-a2ui.module.css
@@ -9,13 +9,13 @@
 }
 
 :global(.a2ui-loading) {
-  color: gray;
+  color: var(--elmethis-color-neutral);
   font-size: 0.875em;
   font-style: italic;
 }
 
 :global(.a2ui-unknown) {
-  color: tomato;
+  color: var(--elmethis-color-accent-error);
   font-weight: 600;
 }
 
@@ -47,11 +47,11 @@
 }
 
 .card {
-  border: 1px solid #e0e0e0;
+  border: 1px solid var(--elmethis-color-divider);
   border-radius: 8px;
   padding: 16px;
-  background: #fff;
-  box-shadow: 0 1px 3px rgb(0 0 0 / 8%);
+  background: var(--elmethis-color-surface-raised);
+  box-shadow: 0 1px 3px var(--elmethis-box-shadow-color);
 }
 
 .button {
@@ -60,7 +60,7 @@
   justify-content: center;
   gap: 4px;
   padding: 8px 16px;
-  border: 1px solid #ccc;
+  border: 1px solid var(--elmethis-color-divider);
   border-radius: 4px;
   background: transparent;
   cursor: pointer;
@@ -70,17 +70,20 @@
 }
 
 .button:hover {
-  background: rgb(0 0 0 / 5%);
+  background: var(--elmethis-color-primary-hover);
 }
 
 .button-primary {
-  background: var(--a2ui-primary, #1976d2);
+  background: var(--a2ui-primary, var(--elmethis-color-primary));
   border-color: transparent;
-  color: #fff;
+  color: oklch(
+    from contrast-color(var(--a2ui-primary, var(--elmethis-color-primary))) l c
+      h / 65%
+  );
 }
 
 .button-primary:hover {
-  background: var(--a2ui-primary-hover, #1565c0);
+  background: var(--a2ui-primary-hover, var(--elmethis-color-primary-strong));
 }
 
 .button-disabled {
@@ -107,13 +110,13 @@
 
 .divider {
   border: none;
-  border-top: 1px solid #e0e0e0;
+  border-top: 1px solid var(--elmethis-color-divider);
   margin: 8px 0;
 }
 
 .divider-vertical {
   border-top: none;
-  border-left: 1px solid #e0e0e0;
+  border-left: 1px solid var(--elmethis-color-divider);
   margin: 0 8px;
   align-self: stretch;
   width: 0;
@@ -133,12 +136,12 @@
 .choice-picker-label {
   font-size: 0.75rem;
   font-weight: 500;
-  color: #555;
+  color: var(--elmethis-color-neutral-strong);
 }
 
 .input {
   padding: 8px 10px;
-  border: 1px solid #ccc;
+  border: 1px solid var(--elmethis-color-divider);
   border-radius: 4px;
   font-size: 0.875rem;
   outline: none;
@@ -146,7 +149,7 @@
 }
 
 .input:focus {
-  border-color: var(--a2ui-primary, #1976d2);
+  border-color: var(--a2ui-primary, var(--elmethis-color-primary));
 }
 
 .checkbox,
@@ -188,6 +191,6 @@
 .validation-errors {
   margin: 0;
   padding-inline-start: 1.25rem;
-  color: #b42318;
+  color: var(--elmethis-color-accent-error);
   font-size: 0.75rem;
 }

--- a/packages/solid/src/components/ag-ui-client/components/elm-ag-ui-agent.module.css
+++ b/packages/solid/src/components/ag-ui-client/components/elm-ag-ui-agent.module.css
@@ -5,7 +5,8 @@
   width: 100%;
   height: 100%;
   overflow-y: auto;
-  scrollbar-color: gray transparent;
+  scrollbar-color: var(--elmethis-color-primary-weak)
+    var(--elmethis-color-surface-base);
   scrollbar-gutter: stable;
   scrollbar-width: thin;
   display: flex;
@@ -31,7 +32,7 @@
         display: flex;
         align-items: flex-start;
         gap: 0.5rem;
-        background-color: oklch(from #c56565 l c h / 10%);
+        background-color: var(--elmethis-color-accent-error-surface);
       }
     }
   }
@@ -64,7 +65,7 @@
           padding: 0.25rem 0.5rem;
           border-radius: 0.25rem;
           background-color: var(--elmethis-color-surface-raised);
-          box-shadow: 0 0 0.25rem rgb(0 0 0 / 10%);
+          box-shadow: 0 0 0.25rem var(--elmethis-box-shadow-color);
           opacity: 0.85;
 
           .queue-item-icon {
@@ -95,7 +96,7 @@
             transition: background-color 200ms;
 
             &:hover {
-              background-color: oklch(from gray l c h / 25%);
+              background-color: var(--elmethis-color-accent-error-surface);
             }
           }
         }
@@ -116,7 +117,7 @@
           border: 0;
           cursor: pointer;
           gap: 0.5rem;
-          box-shadow: 0 0 0.25rem rgb(0 0 0 / 10%);
+          box-shadow: 0 0 0.25rem var(--elmethis-box-shadow-color);
           color: inherit;
           background-color: var(--elmethis-color-surface-raised);
           border-radius: 1rem;
@@ -148,6 +149,6 @@
   cursor: pointer;
 
   &:hover {
-    background-color: oklch(from gray l c h / 25%);
+    background-color: var(--elmethis-color-surface-sunken);
   }
 }

--- a/packages/solid/src/components/ag-ui-client/components/elm-ag-ui-agent.tsx
+++ b/packages/solid/src/components/ag-ui-client/components/elm-ag-ui-agent.tsx
@@ -113,7 +113,7 @@ export const ElmAgUiAgent = (props: ElmAgUiAgentProps) => {
               <>
                 <div class={styles.error}>
                   <ElmMdiIcon
-                    d={mdiAlert}
+                    path={mdiAlert}
                     color="var(--elmethis-color-accent-error)"
                     style={{ "flex-shrink": 0 }}
                   />
@@ -127,7 +127,7 @@ export const ElmAgUiAgent = (props: ElmAgUiAgentProps) => {
                   onClick={() => void local.retry()}
                   aria-label="Retry"
                 >
-                  <ElmMdiIcon d={mdiRefresh} size="1.25rem" />
+                  <ElmMdiIcon path={mdiRefresh} size="1.25rem" />
                 </button>
               </>
             )}
@@ -144,7 +144,7 @@ export const ElmAgUiAgent = (props: ElmAgUiAgentProps) => {
                   <div class={styles["queue-item"]}>
                     <ElmMdiIcon
                       class={styles["queue-item-icon"]}
-                      d={mdiClockOutline}
+                      path={mdiClockOutline}
                       size="1rem"
                     />
                     <span class={styles["queue-item-text"]}>
@@ -158,7 +158,7 @@ export const ElmAgUiAgent = (props: ElmAgUiAgentProps) => {
                       onClick={() => local.dequeue(queued.id)}
                       aria-label="Remove from queue"
                     >
-                      <ElmMdiIcon d={mdiClose} size="0.875rem" />
+                      <ElmMdiIcon path={mdiClose} size="0.875rem" />
                     </button>
                   </div>
                 )}
@@ -183,7 +183,7 @@ export const ElmAgUiAgent = (props: ElmAgUiAgentProps) => {
                   >
                     <ElmMdiIcon
                       class={styles["prompt-template-tip-icon"]}
-                      d={mdiForumOutline}
+                      path={mdiForumOutline}
                     />
                     <ElmInlineText>{template.description}</ElmInlineText>
                   </button>

--- a/packages/solid/src/components/ag-ui-client/components/elm-ag-ui-input.module.css
+++ b/packages/solid/src/components/ag-ui-client/components/elm-ag-ui-input.module.css
@@ -19,8 +19,8 @@
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-  background-color: light-dark(#f7f7f9, var(--elmethis-color-surface-raised));
-  box-shadow: 0 0 2px oklch(from black l c h / 25%);
+  background-color: var(--elmethis-color-surface-raised);
+  box-shadow: 0 0 2px var(--elmethis-box-shadow-color);
 
   .input {
     display: block;
@@ -75,12 +75,12 @@
 
   .plus-button {
     grid-area: plus;
-    background-color: oklch(from black l c h / 60%);
+    background-color: var(--elmethis-color-neutral);
   }
 
   .submit-button {
     grid-area: send;
-    background-color: oklch(from black l c h / 75%);
+    background-color: var(--elmethis-color-neutral);
   }
 
   .stop-button {

--- a/packages/solid/src/components/ag-ui-client/components/elm-ag-ui-input.tsx
+++ b/packages/solid/src/components/ag-ui-client/components/elm-ag-ui-input.tsx
@@ -192,7 +192,7 @@ export const ElmAgUiInput = (props: ElmAgUiInputProps) => {
               aria-label={isPickerOpen() ? "Close prompts" : "Open prompts"}
             >
               <ElmMdiIcon
-                d={isPickerOpen() ? mdiClose : mdiPlus}
+                path={isPickerOpen() ? mdiClose : mdiPlus}
                 size="1rem"
                 color="white"
               />
@@ -216,7 +216,7 @@ export const ElmAgUiInput = (props: ElmAgUiInputProps) => {
               onClick={() => local.onAbort()}
               aria-label="Stop"
             >
-              <ElmMdiIcon d={mdiStop} size="1rem" color="white" />
+              <ElmMdiIcon path={mdiStop} size="1rem" color="white" />
             </button>
           </Show>
           <button
@@ -225,7 +225,7 @@ export const ElmAgUiInput = (props: ElmAgUiInputProps) => {
             onClick={submit}
             aria-label="Send"
           >
-            <ElmMdiIcon d={mdiSend} size="1rem" color="white" />
+            <ElmMdiIcon path={mdiSend} size="1rem" color="white" />
           </button>
         </div>
       </div>

--- a/packages/solid/src/components/ag-ui-client/components/elm-ag-ui-message-renderer.module.css
+++ b/packages/solid/src/components/ag-ui-client/components/elm-ag-ui-message-renderer.module.css
@@ -40,7 +40,7 @@
     flex-grow: 1;
     height: 1px;
     width: 100%;
-    background-color: oklch(from gray l c h / 12.5%);
+    background-color: var(--elmethis-color-divider);
   }
 }
 
@@ -65,7 +65,7 @@
   cursor: pointer;
 
   &:hover {
-    background-color: oklch(from gray l c h / 25%);
+    background-color: var(--elmethis-color-surface-sunken);
   }
 }
 

--- a/packages/solid/src/components/ag-ui-client/components/elm-ag-ui-message-renderer.tsx
+++ b/packages/solid/src/components/ag-ui-client/components/elm-ag-ui-message-renderer.tsx
@@ -65,7 +65,7 @@ const Reasoning = (props: ReasoningProps) => {
         <div class={styles["message-content-type"]}>
           <ElmMdiIcon
             class={styles["message-content-icon"]}
-            d={mdiLightbulbOn}
+            path={mdiLightbulbOn}
           />
           <ElmInlineText>Reasoning</ElmInlineText>
           <div aria-hidden="true" class={styles["message-content-spacer"]} />
@@ -159,7 +159,7 @@ export const ElmAgUiMessageRenderer = (props: ElmAgUiMessageRendererProps) => {
                   <div class={styles["message-content-type"]}>
                     <ElmMdiIcon
                       class={styles["message-content-icon"]}
-                      d={mdiCreation}
+                      path={mdiCreation}
                     />
                     <ElmInlineText>Assistant</ElmInlineText>
                     <div
@@ -177,7 +177,7 @@ export const ElmAgUiMessageRenderer = (props: ElmAgUiMessageRendererProps) => {
                         onClick={local.handleRetry}
                         aria-label="Retry"
                       >
-                        <ElmMdiIcon d={mdiRefresh} size="1.25rem" />
+                        <ElmMdiIcon path={mdiRefresh} size="1.25rem" />
                       </button>
                     </div>
                   </Show>
@@ -202,7 +202,7 @@ export const ElmAgUiMessageRenderer = (props: ElmAgUiMessageRendererProps) => {
               <div class={styles["message-content-type"]}>
                 <ElmMdiIcon
                   class={styles["message-content-icon"]}
-                  d={mdiAccount}
+                  path={mdiAccount}
                 />
                 <ElmInlineText>User</ElmInlineText>
                 <div

--- a/packages/solid/src/components/ag-ui-client/components/elm-ag-ui-prompt-picker.module.css
+++ b/packages/solid/src/components/ag-ui-client/components/elm-ag-ui-prompt-picker.module.css
@@ -10,7 +10,8 @@
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
-  scrollbar-color: gray transparent;
+  scrollbar-color: var(--elmethis-color-primary-weak)
+    var(--elmethis-color-surface-base);
   scrollbar-width: thin;
 }
 
@@ -36,9 +37,12 @@
   gap: 0.25rem;
 }
 
-.prompt-row:hover,
+.prompt-row:hover {
+  background-color: var(--elmethis-color-surface-sunken);
+}
+
 .prompt-row-active {
-  background-color: oklch(from gray l c h / 8%);
+  background-color: var(--elmethis-color-surface-base);
 }
 
 .prompt-head {
@@ -66,7 +70,7 @@
   color: var(--elmethis-color-neutral);
   background-color: var(--elmethis-color-surface-raised);
   border-radius: 0.5rem;
-  box-shadow: 0 8px 24px rgb(0 0 0 / 18%);
+  box-shadow: 0 0 0.125rem var(--elmethis-box-shadow-color);
   padding: 1rem;
   display: flex;
   flex-direction: column;
@@ -131,14 +135,17 @@
 }
 
 .cancel-button {
-  border: 1px solid oklch(from gray l c h / 30%);
+  border: 1px solid var(--elmethis-color-divider);
   background-color: transparent;
   color: inherit;
-  transition: background-color 150ms;
+  transition:
+    color 100ms,
+    background-color 100ms;
 }
 
 .cancel-button:hover {
-  background-color: oklch(from gray l c h / 8%);
+  color: contrast-color(var(--elmethis-color-neutral));
+  background-color: var(--elmethis-color-neutral-weak);
 }
 
 .error,
@@ -168,7 +175,7 @@
   box-sizing: border-box;
   width: 100%;
   padding: 0.4rem 0.5rem;
-  border: 1px solid oklch(from gray l c h / 30%);
+  border: 1px solid var(--elmethis-color-divider);
   border-radius: 0.25rem;
   color: inherit;
   background-color: var(--elmethis-color-surface-raised);

--- a/packages/solid/src/components/ag-ui-client/components/elm-ag-ui-status.tsx
+++ b/packages/solid/src/components/ag-ui-client/components/elm-ag-ui-status.tsx
@@ -116,7 +116,7 @@ export const ElmAgUiStatus = (props: ElmAgUiStatusProps) => {
         >
           <div class={styles.reel}>
             <ElmMdiIcon
-              d={current.d}
+              path={current.d}
               size="1rem"
               color={current.color}
               class={current.pulse ? styles.pulse : undefined}

--- a/packages/solid/src/components/ag-ui-client/components/elm-ag-ui-tool-execution.tsx
+++ b/packages/solid/src/components/ag-ui-client/components/elm-ag-ui-tool-execution.tsx
@@ -122,7 +122,7 @@ export const ElmAgUiToolExecution = (props: ElmAgUiToolExecutionProps) => {
     color?: string,
   ): JSX.Element => (
     <div class={styles.summary}>
-      <ElmMdiIcon d={icon} size="1rem" color={color} />
+      <ElmMdiIcon path={icon} size="1rem" color={color} />
       <ElmInlineText>{label}</ElmInlineText>
     </div>
   );

--- a/packages/solid/src/components/ag-ui-client/components/input-content/elm-ag-ui-input-content.module.css
+++ b/packages/solid/src/components/ag-ui-client/components/input-content/elm-ag-ui-input-content.module.css
@@ -18,12 +18,9 @@
   padding: 0.25rem;
   width: 6rem;
   height: 6rem;
-  border: solid 1px oklch(from gray l c h / 25%);
+  border: solid 1px var(--elmethis-color-divider);
   border-radius: 0.25rem;
-  background-color: light-dark(
-    oklch(from white l c h / 25%),
-    oklch(from black l c h / 25%)
-  );
+  background-color: var(--elmethis-color-surface-raised);
   overflow: hidden;
 
   .image {
@@ -38,10 +35,7 @@
     height: 100%;
     white-space: wrap;
     font-size: 0.25rem;
-    color: light-dark(
-      oklch(from gray l c h / 75%),
-      oklch(from white l c h / 75%)
-    );
+    color: var(--elmethis-color-neutral);
     user-select: none;
   }
 
@@ -62,12 +56,9 @@
     font-family: monospace;
     font-size: 0.65rem;
     border-radius: 0.125rem;
-    background-color: oklch(from white l c h / 80%);
+    background-color: var(--elmethis-color-surface-base);
     backdrop-filter: blur(0.25rem);
-    color: light-dark(
-      var(--elmethis-scoped-color, #606875),
-      var(--elmethis-scoped-color, #b0b5be)
-    );
+    color: var(--elmethis-color-primary);
   }
 }
 
@@ -76,5 +67,5 @@
   width: fit-content;
   padding: 0.5rem;
   border-radius: 0.25rem;
-  background-color: oklch(from gray l c h / 10%);
+  background-color: var(--elmethis-color-surface-raised);
 }

--- a/packages/solid/src/components/ag-ui-client/components/input-content/elm-ag-ui-input-content.tsx
+++ b/packages/solid/src/components/ag-ui-client/components/input-content/elm-ag-ui-input-content.tsx
@@ -33,7 +33,7 @@ export const ElmAgUiInputContent = (props: ElmAgUiInputContentImageProps) => {
         case "document":
           return (
             <div class={styles["media-component"]}>
-              <ElmMdiIcon class={styles["type-icon"]} d={mdiTextBox} />
+              <ElmMdiIcon class={styles["type-icon"]} path={mdiTextBox} />
               <pre class={styles.text}>{content.source.value}</pre>
               <div class={styles["mime-type-label"]}>
                 {content.source.mimeType}
@@ -48,7 +48,7 @@ export const ElmAgUiInputContent = (props: ElmAgUiInputContentImageProps) => {
               : source.value;
           media.push(
             <div class={styles["media-component"]}>
-              <ElmMdiIcon class={styles["type-icon"]} d={mdiImage} />
+              <ElmMdiIcon class={styles["type-icon"]} path={mdiImage} />
               <img
                 class={styles.image}
                 width={96}

--- a/packages/solid/src/components/code/elm-code-block.module.css
+++ b/packages/solid/src/components/code/elm-code-block.module.css
@@ -33,7 +33,7 @@
   grid-area: divider;
   width: calc(100% - 1rem);
   border: none;
-  border-bottom: solid 1px rgb(128 128 128 / 50%);
+  border-bottom: solid 1px var(--elmethis-color-divider);
 }
 
 .code {

--- a/packages/solid/src/components/code/elm-html-viewer.module.css
+++ b/packages/solid/src/components/code/elm-html-viewer.module.css
@@ -51,7 +51,7 @@
   width: calc(100% - 1rem);
   margin-inline: auto;
   border: none;
-  border-bottom: solid 1px rgb(128 128 128 / 50%);
+  border-bottom: solid 1px var(--elmethis-color-divider);
 }
 
 .content {

--- a/packages/solid/src/components/code/elm-html-viewer.tsx
+++ b/packages/solid/src/components/code/elm-html-viewer.tsx
@@ -128,7 +128,7 @@ export const ElmHtmlViewer = (props: ElmHtmlViewerProps) => {
           onClick={handleDownload}
           aria-label="Download"
         >
-          <ElmMdiIcon d={mdiDownload} size="1.25rem" />
+          <ElmMdiIcon path={mdiDownload} size="1.25rem" />
         </button>
 
         <button
@@ -137,7 +137,7 @@ export const ElmHtmlViewer = (props: ElmHtmlViewerProps) => {
           onClick={handleOpenInNewTab}
           aria-label="Open in new tab"
         >
-          <ElmMdiIcon d={mdiOpenInNew} size="1.25rem" />
+          <ElmMdiIcon path={mdiOpenInNew} size="1.25rem" />
         </button>
       </div>
 

--- a/packages/solid/src/components/code/elm-shiki-highlighter.module.css
+++ b/packages/solid/src/components/code/elm-shiki-highlighter.module.css
@@ -19,7 +19,7 @@
     /* stylelint-enable csstools/value-no-unknown-custom-properties */
 
     &::selection {
-      background-color: oklch(from #cdb57b l c h / 25%);
+      background-color: var(--elmethis-color-selection);
     }
   }
 }

--- a/packages/solid/src/components/containments/elm-modal.module.css
+++ b/packages/solid/src/components/containments/elm-modal.module.css
@@ -23,6 +23,6 @@
     opacity: 0;
     transition: opacity var(--elmethis-scoped-modal-delay, 200ms);
     background-color: transparent;
-    background-color: oklch(from black l c h / 50%);
+    background-color: var(--elmethis-color-modal-backdrop);
   }
 }

--- a/packages/solid/src/components/containments/elm-toggle.module.css
+++ b/packages/solid/src/components/containments/elm-toggle.module.css
@@ -39,7 +39,7 @@
     margin: 0 1rem;
     height: 1px;
     width: 100%;
-    background-color: oklch(from gray l c h / 12.5%);
+    background-color: var(--elmethis-color-divider);
   }
 
   &:hover {
@@ -78,7 +78,7 @@
   width: 1px;
   margin-left: 1rem;
   height: 100%;
-  background-color: oklch(from gray l c h / 12.5%);
+  background-color: var(--elmethis-color-divider);
 }
 
 .content {

--- a/packages/solid/src/components/containments/elm-toggle.spec.tsx
+++ b/packages/solid/src/components/containments/elm-toggle.spec.tsx
@@ -128,8 +128,9 @@ describe("[CSR] ElmToggle", () => {
     expect(toggle).not.toHaveClass("closed-toggle");
     expect(toggle).toHaveTextContent("Open summary");
     for (const icon of toggle.querySelectorAll("svg")) {
+      expect(icon).toHaveAttribute("fill", "currentColor");
       expect(icon).toHaveAttribute(
-        "fill",
+        "color",
         "var(--elmethis-color-neutral-weak)",
       );
     }

--- a/packages/solid/src/components/containments/elm-toggle.tsx
+++ b/packages/solid/src/components/containments/elm-toggle.tsx
@@ -60,7 +60,7 @@ export const ElmToggle = (props: ElmToggleProps) => {
         <div class={styles["summary-left"]}>
           <span class={clsx(styles.chevron, isOpen() && styles.open)}>
             <ElmMdiIcon
-              d={mdiChevronRight}
+              path={mdiChevronRight}
               color={
                 local.monochrome
                   ? "var(--elmethis-color-neutral-weak)"
@@ -82,7 +82,7 @@ export const ElmToggle = (props: ElmToggleProps) => {
 
         <span class={clsx(styles.cross, isOpen() && styles.open)}>
           <ElmMdiIcon
-            d={mdiPlus}
+            path={mdiPlus}
             size="1rem"
             color={
               local.monochrome

--- a/packages/solid/src/components/form/elm-button-dropdown.module.css
+++ b/packages/solid/src/components/form/elm-button-dropdown.module.css
@@ -25,7 +25,7 @@
     border-bottom-left-radius: 0;
     padding-left: 0.75rem;
     padding-right: 0.75rem;
-    border-left: 1px solid light-dark(rgb(0 0 0 / 15%), rgb(255 255 255 / 20%));
+    border-left: 1px solid var(--elmethis-color-divider);
   }
 
   .segment:hover,
@@ -42,8 +42,8 @@
     width: max-content;
     min-width: 100%;
     border-radius: 0.25rem;
-    background-color: light-dark(rgb(255 255 255 / 95%), rgb(51 51 51 / 95%));
-    box-shadow: 0 0 0.125rem light-dark(rgb(0 0 0 / 15%), rgb(0 0 0 / 75%));
+    background-color: var(--elmethis-color-surface-raised);
+    box-shadow: 0 0 0.125rem var(--elmethis-box-shadow-color);
 
     .item {
       overflow: hidden;
@@ -59,18 +59,16 @@
       cursor: pointer;
 
       &:hover {
-        background-color: light-dark(
-          rgb(190 194 202 / 30%),
-          rgb(190 194 202 / 20%)
-        );
+        background-color: var(--elmethis-color-surface-sunken);
       }
 
       &.selected {
-        background-color: light-dark(
-          rgb(190 194 202 / 25%),
-          rgb(190 194 202 / 15%)
-        );
+        background-color: var(--elmethis-color-surface-base);
         color: var(--elmethis-color-primary-weak);
+
+        &:hover {
+          background-color: var(--elmethis-color-surface-sunken);
+        }
       }
 
       &.item-disabled {

--- a/packages/solid/src/components/form/elm-button-dropdown.tsx
+++ b/packages/solid/src/components/form/elm-button-dropdown.tsx
@@ -226,7 +226,7 @@ export const ElmButtonDropdown = (props: ElmButtonDropdownProps) => {
         aria-label="Toggle dropdown"
         aria-expanded={isOpen()}
       >
-        <ElmMdiIcon d={local.dropdownIcon} size="1.25rem" />
+        <ElmMdiIcon path={local.dropdownIcon} size="1.25rem" />
       </ElmButton>
 
       <ElmCollapse isOpen={isOpen()} class={styles.menu}>
@@ -246,7 +246,7 @@ export const ElmButtonDropdown = (props: ElmButtonDropdownProps) => {
               }}
             >
               <ElmMdiIcon
-                d={mdiChevronRight}
+                path={mdiChevronRight}
                 color="var(--elmethis-color-primary-weak)"
                 size="0.75em"
               />

--- a/packages/solid/src/components/form/elm-button.module.css
+++ b/packages/solid/src/components/form/elm-button.module.css
@@ -46,13 +46,13 @@
   &:hover {
     transform: translateX(-1px) translateY(-1px);
     opacity: var(--elmethis-scoped-opacity, 0.7);
-    box-shadow: 0.125rem 0.125rem 0.125rem rgb(128 128 128 / 25%);
+    box-shadow: 0.125rem 0.125rem 0.125rem var(--elmethis-box-shadow-color);
   }
 
   &:active {
     transform: translateX(1px) translateY(1px);
     opacity: var(--elmethis-scoped-opacity, 0.5);
-    box-shadow: -1px -1px 0.125rem rgb(128 128 128 / 25%);
+    box-shadow: -1px -1px 0.125rem var(--elmethis-box-shadow-color);
   }
 }
 
@@ -78,19 +78,4 @@
     transform: scale(1.2);
     opacity: 0;
   }
-}
-
-.ripple {
-  position: absolute;
-  pointer-events: none;
-  border-radius: 50%;
-  background-color: rgb(205 181 123 / 15%);
-  width: 100%;
-  aspect-ratio: 1 / 1;
-  transition: none;
-  opacity: 0;
-  animation-name: button-ripple;
-  animation-duration: 300ms;
-  animation-fill-mode: both;
-  animation-timing-function: ease-out;
 }

--- a/packages/solid/src/components/form/elm-button.spec.tsx
+++ b/packages/solid/src/components/form/elm-button.spec.tsx
@@ -105,38 +105,25 @@ describe("[CSR] ElmButton", () => {
     expect(button.style.cursor).toBe("not-allowed");
   });
 
-  it("composes function and tuple click handlers and shows a transient ripple", () => {
-    vi.useFakeTimers();
-    try {
-      const functionHandler = vi.fn();
-      const tupleHandler = vi.fn();
-      const first = render(() => (
-        <ElmButton onClick={functionHandler}>Go</ElmButton>
-      ));
-      const button = first.getByRole("button");
+  it("composes function and tuple click handlers", () => {
+    const functionHandler = vi.fn();
+    const tupleHandler = vi.fn();
+    const first = render(() => (
+      <ElmButton onClick={functionHandler}>Go</ElmButton>
+    ));
 
-      fireEvent.click(button);
-      expect(functionHandler).toHaveBeenCalledOnce();
-      expect(button.querySelector(`.${styles.ripple}`)).not.toBeNull();
+    fireEvent.click(first.getByRole("button"));
+    expect(functionHandler).toHaveBeenCalledOnce();
 
-      vi.advanceTimersByTime(300);
-      expect(button.querySelector(`.${styles.ripple}`)).toBeNull();
-
-      first.unmount();
-      const second = render(() => (
-        <ElmButton onClick={[tupleHandler, "bound"]}>Again</ElmButton>
-      ));
-      fireEvent.click(second.getByRole("button"));
-      expect(tupleHandler).toHaveBeenCalledWith(
-        "bound",
-        expect.any(MouseEvent),
-      );
-    } finally {
-      vi.useRealTimers();
-    }
+    first.unmount();
+    const second = render(() => (
+      <ElmButton onClick={[tupleHandler, "bound"]}>Again</ElmButton>
+    ));
+    fireEvent.click(second.getByRole("button"));
+    expect(tupleHandler).toHaveBeenCalledWith("bound", expect.any(MouseEvent));
   });
 
-  it("suppresses clicks and ripple while loading or disabled", () => {
+  it("suppresses clicks while loading or disabled", () => {
     const onClick = vi.fn();
     const { getAllByRole } = render(() => (
       <>
@@ -150,21 +137,5 @@ describe("[CSR] ElmButton", () => {
     for (const button of getAllByRole("button")) fireEvent.click(button);
 
     expect(onClick).not.toHaveBeenCalled();
-    expect(document.querySelector(`.${styles.ripple}`)).toBeNull();
-  });
-
-  it("clears the ripple timer on cleanup", () => {
-    vi.useFakeTimers();
-    try {
-      const { getByRole, unmount } = render(() => (
-        <ElmButton onClick={() => undefined}>Go</ElmButton>
-      ));
-      fireEvent.click(getByRole("button"));
-      unmount();
-
-      expect(() => vi.advanceTimersByTime(300)).not.toThrow();
-    } finally {
-      vi.useRealTimers();
-    }
   });
 });

--- a/packages/solid/src/components/form/elm-button.stories.tsx
+++ b/packages/solid/src/components/form/elm-button.stories.tsx
@@ -34,11 +34,11 @@ export const Flex: Story = {
   render: (args) => (
     <div style={{ display: "flex", gap: "1rem" }}>
       <ElmButton {...args}>
-        <ElmMdiIcon d={mdiSquareEditOutline} size="1.25rem" />
+        <ElmMdiIcon path={mdiSquareEditOutline} size="1.25rem" />
         elm-button
       </ElmButton>
       <ElmButton {...args}>
-        <ElmMdiIcon d={mdiSquareEditOutline} size="1.25rem" />
+        <ElmMdiIcon path={mdiSquareEditOutline} size="1.25rem" />
         elm-button
       </ElmButton>
     </div>
@@ -52,11 +52,11 @@ export const WithPrimary: Story = {
   render: (args) => (
     <div style={{ display: "flex", gap: "1rem" }}>
       <ElmButton {...args} primary>
-        <ElmMdiIcon d={mdiSquareEditOutline} size="1.25rem" />
+        <ElmMdiIcon path={mdiSquareEditOutline} size="1.25rem" />
         elm-button
       </ElmButton>
       <ElmButton {...args}>
-        <ElmMdiIcon d={mdiSquareEditOutline} size="1.25rem" />
+        <ElmMdiIcon path={mdiSquareEditOutline} size="1.25rem" />
         elm-button
       </ElmButton>
     </div>

--- a/packages/solid/src/components/form/elm-button.tsx
+++ b/packages/solid/src/components/form/elm-button.tsx
@@ -1,4 +1,4 @@
-import { createSignal, onCleanup, Show, splitProps, type JSX } from "solid-js";
+import { Show, splitProps, type JSX } from "solid-js";
 import { clsx } from "clsx";
 
 import { callEventHandler } from "../../primitives/call-event-handler";
@@ -31,19 +31,12 @@ export const ElmButton = (props: ElmButtonProps) => {
     "disabled",
     "children",
   ]);
-  const [clicked, setClicked] = createSignal(false);
-  let timer: ReturnType<typeof setTimeout> | undefined;
-
-  onCleanup(() => clearTimeout(timer));
 
   const handleClick: JSX.EventHandler<HTMLButtonElement, MouseEvent> = (
     event,
   ) => {
     if (local.isLoading || local.disabled || !local.onClick) return;
 
-    setClicked(true);
-    clearTimeout(timer);
-    timer = setTimeout(() => setClicked(false), 300);
     callEventHandler(local.onClick, event);
   };
 
@@ -73,9 +66,6 @@ export const ElmButton = (props: ElmButtonProps) => {
         "--elmethis-scoped-color": local.color,
       })}
     >
-      <Show when={clicked()}>
-        <span class={styles.ripple} />
-      </Show>
       <Show
         when={!local.isLoading}
         fallback={<ElmDotLoadingIcon size="1.5rem" />}

--- a/packages/solid/src/components/form/elm-checkbox.module.css
+++ b/packages/solid/src/components/form/elm-checkbox.module.css
@@ -20,7 +20,7 @@
 }
 
 .checkbox {
-  stroke: light-dark(rgb(0 0 0 / 80%), rgb(255 255 255 / 80%));
+  stroke: var(--elmethis-color-neutral-strong);
   fill: transparent;
 }
 
@@ -32,13 +32,13 @@
   }
 
   &.checked {
-    fill: light-dark(rgb(0 0 0 / 80%), rgb(255 255 255 / 80%));
+    fill: var(--elmethis-color-neutral-strong);
   }
 }
 
 .loading-dot {
   transition: opacity 200ms;
-  fill: light-dark(rgb(0 0 0 / 70%), rgb(255 255 255 / 70%));
+  fill: var(--elmethis-color-neutral-strong);
 }
 
 @keyframes elmethis-checkbox-check-line {
@@ -59,5 +59,5 @@
   animation-delay: 0.1s;
   animation-fill-mode: both;
   transform-origin: center;
-  stroke: light-dark(rgb(255 255 255 / 90%), rgb(0 0 0 / 90%));
+  stroke: contrast-color(var(--elmethis-color-neutral-strong));
 }

--- a/packages/solid/src/components/form/elm-select.module.css
+++ b/packages/solid/src/components/form/elm-select.module.css
@@ -80,8 +80,8 @@
       width: max-content;
       padding: 0;
       border-radius: 0.25rem;
-      background-color: light-dark(rgb(255 255 255 / 95%), rgb(51 51 51 / 95%));
-      box-shadow: 0 0 0.125rem light-dark(rgb(0 0 0 / 15%), rgb(0 0 0 / 75%));
+      background-color: var(--elmethis-color-surface-raised);
+      box-shadow: 0 0 0.125rem var(--elmethis-box-shadow-color);
 
       .option {
         overflow: hidden;
@@ -97,10 +97,7 @@
         cursor: pointer;
 
         &:hover {
-          background-color: light-dark(
-            rgb(190 194 202 / 30%),
-            rgb(190 194 202 / 20%)
-          );
+          background-color: var(--elmethis-color-surface-sunken);
         }
       }
     }

--- a/packages/solid/src/components/form/elm-select.stories.tsx
+++ b/packages/solid/src/components/form/elm-select.stories.tsx
@@ -40,7 +40,7 @@ export const Primary: Story = {};
 export const WithIcon: Story = {
   args: {
     label: "Select with icon",
-    icon: <ElmMdiIcon d={mdiAccountOutline} />,
+    icon: <ElmMdiIcon path={mdiAccountOutline} />,
   },
 };
 

--- a/packages/solid/src/components/form/elm-select.tsx
+++ b/packages/solid/src/components/form/elm-select.tsx
@@ -132,7 +132,7 @@ export const ElmSelect = (props: ElmSelectProps) => {
     >
       <span class={clsx(styles.label, isOpen() && styles["label-active"])}>
         {local.icon ?? (
-          <ElmMdiIcon d={mdiArrowDownDropCircleOutline} size="0.75rem" />
+          <ElmMdiIcon path={mdiArrowDownDropCircleOutline} size="0.75rem" />
         )}
         {local.label}
       </span>
@@ -159,7 +159,7 @@ export const ElmSelect = (props: ElmSelectProps) => {
           </Show>
         </div>
 
-        <ElmMdiIcon d={mdiMenuDown} size="1.5rem" />
+        <ElmMdiIcon path={mdiMenuDown} size="1.5rem" />
 
         <ElmCollapse isOpen={isOpen()} class={styles.pulldown}>
           <For each={local.options}>
@@ -173,7 +173,7 @@ export const ElmSelect = (props: ElmSelectProps) => {
                 }}
               >
                 <ElmMdiIcon
-                  d={mdiChevronRight}
+                  path={mdiChevronRight}
                   color="var(--elmethis-color-primary-weak)"
                   size="0.75em"
                 />

--- a/packages/solid/src/components/form/elm-switch.module.css
+++ b/packages/solid/src/components/form/elm-switch.module.css
@@ -12,11 +12,11 @@
   );
   position: relative;
   cursor: pointer;
-  box-shadow: 0 0 2px rgb(0 0 0 / 10%);
+  box-shadow: 0 0 2px var(--elmethis-box-shadow-color);
   transition:
     opacity 300ms,
     background-color 300ms;
-  background-color: rgb(128 128 128 / 25%);
+  background-color: var(--elmethis-color-surface-sunken);
 
   &.checked {
     background-color: var(--elmethis-scoped-color);
@@ -40,7 +40,7 @@
     transform 300ms,
     opacity 300ms,
     background-color 300ms;
-  background-color: rgb(255 255 255 / 90%);
+  background-color: var(--elmethis-color-surface-raised);
 
   &.checked {
     transform: translateX(
@@ -50,7 +50,7 @@
 
   &.disabled {
     opacity: 0.5;
-    background-color: rgb(128 128 128 / 100%);
+    background-color: var(--elmethis-color-neutral-weak);
   }
 
   &:hover {

--- a/packages/solid/src/components/form/elm-text-area.module.css
+++ b/packages/solid/src/components/form/elm-text-area.module.css
@@ -53,12 +53,8 @@
   border-style: solid;
   border-width: 1px;
   border-color: transparent;
-  background-color: light-dark(
-    var(--elmethis-color-surface-raised),
-    oklch(from #393e46 calc(l * 0.9) c h)
-  );
-  box-shadow: 0 0 0.125rem
-    light-dark(var(--elmethis-box-shadow-color), rgb(0 0 0 / 75%));
+  background-color: var(--elmethis-color-surface-raised);
+  box-shadow: 0 0 0.125rem var(--elmethis-box-shadow-color);
 
   &.disabled {
     background-color: var(--elmethis-color-surface-sunken);
@@ -106,10 +102,7 @@
   min-height: 1.5rem;
   font-family: inherit;
   line-height: 1.4;
-  color: light-dark(
-    var(--elmethis-color-neutral),
-    oklch(from white l c h / 70%)
-  );
+  color: var(--elmethis-color-neutral);
   caret-color: var(--elmethis-scoped-highlight-color);
   resize: vertical;
   overflow: auto;
@@ -121,13 +114,10 @@
   }
 
   &::selection {
-    color: light-dark(
-      var(--elmethis-color-surface-raised),
-      oklch(from black l c h / 70%)
-    );
-    background-color: light-dark(
-      var(--elmethis-scoped-color, var(--elmethis-color-neutral)),
-      oklch(from white l c h / 70%)
+    color: var(--elmethis-color-surface-raised);
+    background-color: var(
+      --elmethis-scoped-color,
+      var(--elmethis-color-neutral)
     );
   }
 }

--- a/packages/solid/src/components/form/elm-text-area.stories.tsx
+++ b/packages/solid/src/components/form/elm-text-area.stories.tsx
@@ -46,7 +46,9 @@ export const Primary: Story = {
 export const WithIcon: Story = {
   args: {
     label: "Comment",
-    icon: <ElmMdiIcon d={mdiCommentTextOutline} size="0.75rem" color="gray" />,
+    icon: (
+      <ElmMdiIcon path={mdiCommentTextOutline} size="0.75rem" color="gray" />
+    ),
   },
 };
 

--- a/packages/solid/src/components/form/elm-text-area.tsx
+++ b/packages/solid/src/components/form/elm-text-area.tsx
@@ -94,7 +94,7 @@ export const ElmTextArea = (props: ElmTextAreaProps) => {
       style={local.style}
     >
       <span class={clsx(styles.header, isFocused() && styles["label-active"])}>
-        {local.icon ?? <ElmMdiIcon d={mdiTextLong} size="0.75rem" />}
+        {local.icon ?? <ElmMdiIcon path={mdiTextLong} size="0.75rem" />}
         <span>
           {local.label}
           <Show when={local.required}>

--- a/packages/solid/src/components/form/elm-text-field.module.css
+++ b/packages/solid/src/components/form/elm-text-field.module.css
@@ -135,7 +135,7 @@
     cursor: pointer;
 
     &:not(:disabled):hover {
-      background-color: rgb(128 128 128 / 20%);
+      background-color: var(--elmethis-color-surface-sunken);
     }
 
     &:focus-visible {
@@ -154,5 +154,5 @@
   font-size: 0.85em;
   user-select: none;
   transition: color 200ms;
-  color: light-dark(rgb(0 0 0 / 65%), rgb(255 255 255 / 65%));
+  color: var(--elmethis-color-neutral-weak);
 }

--- a/packages/solid/src/components/form/elm-text-field.stories.tsx
+++ b/packages/solid/src/components/form/elm-text-field.stories.tsx
@@ -49,7 +49,7 @@ export const Primary: Story = {
 
 export const WithIcon: Story = {
   args: {
-    icon: <ElmMdiIcon d={mdiEmail} size="0.75rem" color="gray" />,
+    icon: <ElmMdiIcon path={mdiEmail} size="0.75rem" color="gray" />,
   },
 };
 

--- a/packages/solid/src/components/form/elm-text-field.tsx
+++ b/packages/solid/src/components/form/elm-text-field.tsx
@@ -113,7 +113,7 @@ export const ElmTextField = (props: ElmTextFieldProps) => {
       style={local.style}
     >
       <span class={clsx(styles.header, isFocused() && styles["label-active"])}>
-        {local.icon ?? <ElmMdiIcon d={mdiText} size="0.75rem" />}
+        {local.icon ?? <ElmMdiIcon path={mdiText} size="0.75rem" />}
         <span>
           {local.label}
           <Show when={local.required}>
@@ -192,7 +192,7 @@ export const ElmTextField = (props: ElmTextFieldProps) => {
             }
           >
             <ElmMdiIcon
-              d={inputType() === "text" ? mdiEyeOutline : mdiEyeOffOutline}
+              path={inputType() === "text" ? mdiEyeOutline : mdiEyeOffOutline}
               size="1.25rem"
               color="gray"
             />
@@ -205,7 +205,7 @@ export const ElmTextField = (props: ElmTextFieldProps) => {
             disabled={local.disabled || local.isLoading}
             onClick={() => setNativeValue("")}
           >
-            <ElmMdiIcon d={mdiTrashCanOutline} size="1.25rem" color="gray" />
+            <ElmMdiIcon path={mdiTrashCanOutline} size="1.25rem" color="gray" />
           </button>
         </div>
       </div>

--- a/packages/solid/src/components/form/elm-validation.spec.tsx
+++ b/packages/solid/src/components/form/elm-validation.spec.tsx
@@ -28,7 +28,10 @@ describe("[CSR] ElmValidation", () => {
     expect(validation).toHaveAttribute("aria-label", "Password requirement");
     expect(validation).not.toHaveAttribute("isValid");
     expect(validation).not.toHaveAttribute("validColor");
-    expect(validation.querySelector("svg")).toHaveAttribute("role", "img");
+    expect(validation.querySelector("svg")).toHaveAttribute(
+      "aria-hidden",
+      "true",
+    );
 
     fireEvent.click(validation);
     expect(onClick).toHaveBeenCalledOnce();
@@ -99,9 +102,8 @@ describe("[CSR] ElmValidation", () => {
     expect(validation.style.getPropertyValue("--elmethis-scoped-opacity")).toBe(
       "1",
     );
-    expect(icon.style.getPropertyValue("--elmethis-scoped-color")).toBe(
-      "rgb(10, 20, 30)",
-    );
+    expect(icon).toHaveAttribute("color", "rgb(10, 20, 30)");
+    expect(icon).toHaveAttribute("fill", "currentColor");
     expect(icon.querySelector("path")!.getAttribute("d")).not.toBe(initialPath);
   });
 });

--- a/packages/solid/src/components/form/elm-validation.tsx
+++ b/packages/solid/src/components/form/elm-validation.tsx
@@ -38,7 +38,7 @@ export const ElmValidation = (props: ElmValidationProps) => {
       })}
     >
       <ElmMdiIcon
-        d={local.isValid ? CHECK_CIRCLE_PATH : CHECK_CIRCLE_OUTLINE_PATH}
+        path={local.isValid ? CHECK_CIRCLE_PATH : CHECK_CIRCLE_OUTLINE_PATH}
         color={local.isValid ? local.validColor : undefined}
       />
       <ElmInlineText color={local.isValid ? local.validColor : undefined}>

--- a/packages/solid/src/components/icon/elm-copy-icon.tsx
+++ b/packages/solid/src/components/icon/elm-copy-icon.tsx
@@ -57,7 +57,9 @@ export const ElmCopyIcon = (props: ElmCopyIconProps) => {
         aria-hidden="true"
         role="presentation"
         class={clsx(clipboard.copied() && styles["elm-copy-icon-copied"])}
-        d={clipboard.copied() ? mdiClipboardCheckOutline : mdiClipboardOutline}
+        path={
+          clipboard.copied() ? mdiClipboardCheckOutline : mdiClipboardOutline
+        }
         size="1.25rem"
       />
     </button>

--- a/packages/solid/src/components/icon/elm-inline-icon.module.css
+++ b/packages/solid/src/components/icon/elm-inline-icon.module.css
@@ -9,15 +9,11 @@
   /* Light inherits the surrounding text color; dark lightens the glyph. */
   color: light-dark(
     currentcolor,
-    var(--elmethis-scoped-color, rgb(255 255 255 / 70%))
+    var(--elmethis-scoped-color, var(--elmethis-color-neutral))
   );
 
   &::selection {
-    color: light-dark(currentcolor, rgb(0 0 0 / 70%));
-    background-color: light-dark(
-      var(--elmethis-scoped-color, rgb(0 0 0 / 25%)),
-      var(--elmethis-scoped-color, rgb(255 255 255 / 25%))
-    );
+    background-color: var(--elmethis-color-selection);
 
     /* `filter` is not a <color>, so it can't use light-dark(): the OS default
        is the media query; an explicit pin overrides it below. */

--- a/packages/solid/src/components/icon/elm-language-icon.tsx
+++ b/packages/solid/src/components/icon/elm-language-icon.tsx
@@ -36,7 +36,7 @@ export const ElmLanguageIcon = (props: ElmLanguageIconProps) => {
       keyed
       fallback={
         <ElmMdiIcon
-          d={MDI_CODE_TAGS}
+          path={MDI_CODE_TAGS}
           size={String(merged.size)}
           class={merged.class}
           style={merged.style}

--- a/packages/solid/src/components/icon/elm-mdi-icon.module.css
+++ b/packages/solid/src/components/icon/elm-mdi-icon.module.css
@@ -1,7 +1,3 @@
 .elm-mdi-icon {
-  fill: light-dark(
-    var(--elmethis-scoped-color-light, var(--elmethis-color-neutral)),
-    var(--elmethis-scoped-color-dark, var(--elmethis-color-neutral))
-  );
   transition: fill 200ms;
 }

--- a/packages/solid/src/components/icon/elm-mdi-icon.module.css
+++ b/packages/solid/src/components/icon/elm-mdi-icon.module.css
@@ -1,7 +1,7 @@
 .elm-mdi-icon {
   fill: light-dark(
-    var(--elmethis-scoped-color, #555b67),
-    var(--dark-color, #b0b5be)
+    var(--elmethis-scoped-color-light, var(--elmethis-color-neutral)),
+    var(--elmethis-scoped-color-dark, var(--elmethis-color-neutral))
   );
   transition: fill 200ms;
 }

--- a/packages/solid/src/components/icon/elm-mdi-icon.spec.tsx
+++ b/packages/solid/src/components/icon/elm-mdi-icon.spec.tsx
@@ -7,56 +7,67 @@ import { ElmMdiIcon } from "./elm-mdi-icon";
 const PATH = "M2 12L8 6L9.4 7.4L4.8 12L9.4 16.6L8 18Z";
 
 describe("[CSR] ElmMdiIcon", () => {
-  it("renders its path and forwards root SVG attributes and refs", () => {
+  it("renders a decorative currentColor SVG and forwards attributes and refs", () => {
     let root: SVGSVGElement | undefined;
-    const { container, getByLabelText } = render(() => (
+    const { container } = render(() => (
       <ElmMdiIcon
         ref={(element) => {
           root = element;
         }}
-        d={PATH}
+        path={PATH}
         class="custom-icon"
-        aria-label="Code"
         data-icon="mdi"
-      />
-    ));
-    const icon = getByLabelText("Code");
-
-    expect(icon).toBe(root);
-    expect(icon).toHaveClass("custom-icon");
-    expect(icon).toHaveAttribute("data-icon", "mdi");
-    expect(icon).toHaveAttribute("role", "img");
-    expect(icon).toHaveAttribute("focusable", "false");
-    expect(container.querySelector("path")).toHaveAttribute("d", PATH);
-  });
-
-  it("reactively updates size, colors, path, class, and consumer style overrides", () => {
-    const [large, setLarge] = createSignal(false);
-    const { container } = render(() => (
-      <ElmMdiIcon
-        d={large() ? "M1 1" : PATH}
-        size={large() ? "32px" : "16px"}
-        color={large() ? "red" : "blue"}
-        lightColor={large() ? "pink" : undefined}
-        darkColor={large() ? "maroon" : undefined}
-        class={large() ? "large" : "small"}
-        style={{ "--dark-color": large() ? "black" : undefined }}
       />
     ));
     const icon = container.querySelector("svg")!;
 
-    expect(icon).toHaveAttribute("width", "16px");
-    expect(icon.style.getPropertyValue("--elmethis-scoped-color")).toBe("blue");
+    expect(icon).toBe(root);
+    expect(icon).toHaveClass("custom-icon");
+    expect(icon).toHaveAttribute("data-icon", "mdi");
+    expect(icon).toHaveAttribute("aria-hidden", "true");
+    expect(icon).not.toHaveAttribute("role");
+    expect(icon).toHaveAttribute("focusable", "false");
+    expect(icon).toHaveAttribute("fill", "currentColor");
+    expect(container.querySelector("path")).toHaveAttribute("d", PATH);
+  });
+
+  it("reactively updates size, color, path, label, and class", () => {
+    const [large, setLarge] = createSignal(false);
+    const { container } = render(() => (
+      <ElmMdiIcon
+        path={large() ? "M1 1" : PATH}
+        size={large() ? 32 : 16}
+        color={large() ? "red" : "blue"}
+        label={large() ? "Large" : undefined}
+        class={large() ? "large" : "small"}
+      />
+    ));
+    const icon = container.querySelector("svg")!;
+
+    expect(icon).toHaveAttribute("width", "16");
+    expect(icon).toHaveAttribute("color", "blue");
+    expect(icon).toHaveAttribute("aria-hidden", "true");
 
     setLarge(true);
 
-    expect(icon).toHaveAttribute("width", "32px");
-    expect(icon).toHaveAttribute("height", "32px");
-    expect(icon).toHaveAttribute("fill", "red");
+    expect(icon).toHaveAttribute("width", "32");
+    expect(icon).toHaveAttribute("height", "32");
+    expect(icon).toHaveAttribute("color", "red");
+    expect(icon).toHaveAttribute("fill", "currentColor");
+    expect(icon).toHaveAttribute("role", "img");
+    expect(icon).not.toHaveAttribute("aria-hidden");
     expect(icon).toHaveClass("large");
     expect(icon).not.toHaveClass("small");
-    expect(icon.style.getPropertyValue("--elmethis-scoped-color")).toBe("pink");
-    expect(icon.style.getPropertyValue("--dark-color")).toBe("black");
+    expect(container.querySelector("title")).toHaveTextContent("Large");
     expect(container.querySelector("path")).toHaveAttribute("d", "M1 1");
+  });
+
+  it("uses native ARIA naming when provided", () => {
+    const { getByRole } = render(() => (
+      <ElmMdiIcon path={PATH} aria-label="Code" />
+    ));
+    expect(getByRole("img", { name: "Code" })).not.toHaveAttribute(
+      "aria-hidden",
+    );
   });
 });

--- a/packages/solid/src/components/icon/elm-mdi-icon.ssr.spec.tsx
+++ b/packages/solid/src/components/icon/elm-mdi-icon.ssr.spec.tsx
@@ -6,14 +6,14 @@ import { ElmMdiIcon } from "./elm-mdi-icon";
 describe("[SSR] ElmMdiIcon", () => {
   it("renders its SVG shell, path, defaults, and forwarded attributes", () => {
     const html = renderToString(() => (
-      <ElmMdiIcon d="M1 2L3 4" aria-label="Code" data-icon="mdi" />
+      <ElmMdiIcon path="M1 2L3 4" label="Code" data-icon="mdi" />
     ));
 
     expect(html).toContain("<svg");
     expect(html).toContain('role="img"');
     expect(html).toContain('focusable="false"');
     expect(html).toContain('width="1em"');
-    expect(html).toContain('aria-label="Code"');
+    expect(html).toMatch(/<title[^>]*>Code<\/title>/);
     expect(html).toContain('data-icon="mdi"');
     expect(html).toContain('d="M1 2L3 4"');
   });

--- a/packages/solid/src/components/icon/elm-mdi-icon.stories.tsx
+++ b/packages/solid/src/components/icon/elm-mdi-icon.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "storybook-solidjs-vite";
 
 import { ElmMdiIcon } from "./elm-mdi-icon";
+import { mdiArrowAll } from "@mdi/js";
 
 const meta = {
   title: "Components/Icon/elm-mdi-icon",
@@ -20,6 +21,6 @@ type Story = StoryObj<typeof meta>;
 export const Primary: Story = {
   args: {
     size: "1.25rem",
-    d: "M14.6,16.6L19.2,12L14.6,7.4L16,6L22,12L16,18L14.6,16.6M9.4,16.6L4.8,12L9.4,7.4L8,6L2,12L8,18L9.4,16.6Z",
+    d: mdiArrowAll,
   },
 };

--- a/packages/solid/src/components/icon/elm-mdi-icon.stories.tsx
+++ b/packages/solid/src/components/icon/elm-mdi-icon.stories.tsx
@@ -10,8 +10,10 @@ const meta = {
   args: {},
   argTypes: {
     color: { control: "color" },
-    lightColor: { control: "color" },
-    darkColor: { control: "color" },
+    label: {
+      control: "text",
+      description: "Accessible name rendered in the SVG title element",
+    },
   },
 } satisfies Meta<typeof ElmMdiIcon>;
 
@@ -21,6 +23,7 @@ type Story = StoryObj<typeof meta>;
 export const Primary: Story = {
   args: {
     size: "1.25rem",
-    d: mdiArrowAll,
+    path: mdiArrowAll,
+    label: "Move",
   },
 };

--- a/packages/solid/src/components/icon/elm-mdi-icon.tsx
+++ b/packages/solid/src/components/icon/elm-mdi-icon.tsx
@@ -17,7 +17,7 @@ export interface ElmMdiIconProps extends JSX.SvgSVGAttributes<SVGSVGElement> {
 }
 
 export const ElmMdiIcon = (props: ElmMdiIconProps) => {
-  const merged = mergeProps({ size: "1em", color: "currentColor" }, props);
+  const merged = mergeProps({ size: "1em" }, props);
   const [local, rest] = splitProps(merged, [
     "class",
     "style",
@@ -33,8 +33,8 @@ export const ElmMdiIcon = (props: ElmMdiIconProps) => {
     <svg
       class={clsx(styles["elm-mdi-icon"], local.class)}
       style={mergeStyle(local.style, {
-        "--elmethis-scoped-color": local.lightColor ?? local.color,
-        "--dark-color": local.darkColor ?? local.color,
+        "--elmethis-scoped-color-light": local.lightColor ?? local.color,
+        "--elmethis-scoped-color-dark": local.darkColor ?? local.color,
       })}
       width={local.size}
       height={local.size}

--- a/packages/solid/src/components/icon/elm-mdi-icon.tsx
+++ b/packages/solid/src/components/icon/elm-mdi-icon.tsx
@@ -1,51 +1,52 @@
-import { mergeProps, splitProps, type JSX } from "solid-js";
+import { mergeProps, Show, splitProps, type JSX } from "solid-js";
 import { clsx } from "clsx";
 
 import styles from "./elm-mdi-icon.module.css";
-import { mergeStyle } from "../../styles/merge-style";
 
 const NON_FOCUSABLE = {
   focusable: "false",
 } as unknown as JSX.SvgSVGAttributes<SVGSVGElement>;
 
-export interface ElmMdiIconProps extends JSX.SvgSVGAttributes<SVGSVGElement> {
-  d: string;
-  size?: string;
+export type ElmMdiIconProps = Omit<
+  JSX.SvgSVGAttributes<SVGSVGElement>,
+  "children"
+> & {
+  path: string;
+  size?: string | number;
   color?: string;
-  lightColor?: string;
-  darkColor?: string;
-}
+  label?: string;
+};
 
 export const ElmMdiIcon = (props: ElmMdiIconProps) => {
   const merged = mergeProps({ size: "1em" }, props);
   const [local, rest] = splitProps(merged, [
     "class",
     "style",
-    "children",
-    "d",
+    "path",
     "size",
     "color",
-    "lightColor",
-    "darkColor",
+    "label",
   ]);
+  const hasAccessibleName = () =>
+    Boolean(local.label || rest["aria-label"] || rest["aria-labelledby"]);
 
   return (
     <svg
       class={clsx(styles["elm-mdi-icon"], local.class)}
-      style={mergeStyle(local.style, {
-        "--elmethis-scoped-color-light": local.lightColor ?? local.color,
-        "--elmethis-scoped-color-dark": local.darkColor ?? local.color,
-      })}
+      style={local.style}
       width={local.size}
       height={local.size}
       viewBox="0 0 24 24"
-      fill={local.color}
+      color={local.color}
+      fill="currentColor"
       xmlns="http://www.w3.org/2000/svg"
-      role="img"
+      aria-hidden={hasAccessibleName() ? undefined : "true"}
+      role={hasAccessibleName() ? "img" : undefined}
       {...NON_FOCUSABLE}
       {...rest}
     >
-      <path d={local.d} />
+      <Show when={local.label}>{(label) => <title>{label()}</title>}</Show>
+      <path d={local.path} />
     </svg>
   );
 };

--- a/packages/solid/src/components/icon/elm-toggle-theme.module.css
+++ b/packages/solid/src/components/icon/elm-toggle-theme.module.css
@@ -2,14 +2,14 @@
   display: block;
   box-sizing: border-box;
   padding: 0.25rem;
-  color: light-dark(#555b67, #b0b5be);
+  color: var(--elmethis-color-neutral);
   border-radius: 50%;
   cursor: pointer;
-  box-shadow: 0 0 0.125rem light-dark(rgb(0 0 0 / 30%), rgb(0 0 0 / 60%));
-  background-color: light-dark(rgb(255 255 255 / 20%), rgb(0 0 0 / 20%));
+  box-shadow: 0 0 0.125rem var(--elmethis-box-shadow-color);
+  background-color: var(--elmethis-color-surface-raised);
+  transition: background-color 100ms;
 
-  &:focus-visible {
-    outline: 2px solid var(--elmethis-color-primary);
-    outline-offset: 2px;
+  &:hover {
+    background-color: var(--elmethis-color-surface-sunken);
   }
 }

--- a/packages/solid/src/components/media/elm-audio-player.tsx
+++ b/packages/solid/src/components/media/elm-audio-player.tsx
@@ -308,7 +308,7 @@ export const ElmAudioPlayer = (props: ElmAudioPlayerProps) => {
           aria-hidden="true"
         >
           <ElmMdiIcon
-            d={hasError() ? mdiAlertCircleOutline : mdiMusicNote}
+            path={hasError() ? mdiAlertCircleOutline : mdiMusicNote}
             size="1.25rem"
           />
         </span>
@@ -330,7 +330,7 @@ export const ElmAudioPlayer = (props: ElmAudioPlayerProps) => {
 
       {hasError() ? (
         <div class={styles["error-notice"]} role="alert">
-          <ElmMdiIcon d={mdiAlertCircleOutline} size="1.25rem" />
+          <ElmMdiIcon path={mdiAlertCircleOutline} size="1.25rem" />
           <span class={styles["error-message"]}>{local.errorMessage}</span>
         </div>
       ) : (
@@ -371,7 +371,7 @@ export const ElmAudioPlayer = (props: ElmAudioPlayerProps) => {
                 onClick={() => seekTo(currentTime() - local.seekStep)}
                 aria-label={`Back ${local.seekStep} seconds`}
               >
-                <ElmMdiIcon d={mdiRewind10} size="1.25rem" />
+                <ElmMdiIcon path={mdiRewind10} size="1.25rem" />
               </button>
 
               <button
@@ -382,7 +382,7 @@ export const ElmAudioPlayer = (props: ElmAudioPlayerProps) => {
                 aria-pressed={isPlaying()}
               >
                 <ElmMdiIcon
-                  d={isPlaying() ? mdiPause : mdiPlay}
+                  path={isPlaying() ? mdiPause : mdiPlay}
                   size="1.5rem"
                 />
               </button>
@@ -393,7 +393,7 @@ export const ElmAudioPlayer = (props: ElmAudioPlayerProps) => {
                 onClick={() => seekTo(currentTime() + local.seekStep)}
                 aria-label={`Forward ${local.seekStep} seconds`}
               >
-                <ElmMdiIcon d={mdiFastForward10} size="1.25rem" />
+                <ElmMdiIcon path={mdiFastForward10} size="1.25rem" />
               </button>
             </div>
 
@@ -405,7 +405,7 @@ export const ElmAudioPlayer = (props: ElmAudioPlayerProps) => {
                 aria-label={isMuted() ? "Unmute" : "Mute"}
                 aria-pressed={isMuted()}
               >
-                <ElmMdiIcon d={volumeIcon()} size="1.25rem" />
+                <ElmMdiIcon path={volumeIcon()} size="1.25rem" />
               </button>
               <input
                 class={styles["volume-slider"]}

--- a/packages/solid/src/components/media/elm-block-image.module.css
+++ b/packages/solid/src/components/media/elm-block-image.module.css
@@ -24,7 +24,7 @@
   height: auto;
   object-fit: contain;
   border-radius: 0.25rem;
-  box-shadow: 0 0 0.125rem rgb(0 0 0 / 10%);
+  box-shadow: 0 0 0.125rem var(--elmethis-box-shadow-color);
   user-select: none;
   aspect-ratio: var(--elmethis-scoped-aspect-ratio, auto);
   cursor: var(--elmethis-scoped-cursor);

--- a/packages/solid/src/components/media/elm-block-image.tsx
+++ b/packages/solid/src/components/media/elm-block-image.tsx
@@ -76,7 +76,7 @@ export const ElmBlockImage = (props: ElmBlockImageProps) => {
         {(caption) => (
           <figcaption class={styles["caption-box"]}>
             <span class={styles["caption-icon"]}>
-              <ElmMdiIcon d={mdiMessageImageOutline} size="1.25rem" />
+              <ElmMdiIcon path={mdiMessageImageOutline} size="1.25rem" />
             </span>
             <ElmInlineText size="1rem">{caption()}</ElmInlineText>
           </figcaption>

--- a/packages/solid/src/components/media/elm-file.module.css
+++ b/packages/solid/src/components/media/elm-file.module.css
@@ -4,9 +4,9 @@
   grid-template-columns: 1.5rem 1fr 1fr 1.5rem;
   gap: 1rem;
   align-items: center;
-  box-shadow: 0 0 0.125rem rgb(0 0 0 / 20%);
+  box-shadow: 0 0 0.125rem var(--elmethis-box-shadow-color);
   border-radius: 0.25rem;
-  background-color: light-dark(rgb(255 255 255 / 20%), rgb(0 0 0 / 20%));
+  background-color: var(--elmethis-color-surface-raised);
 }
 
 .file-size {
@@ -28,6 +28,6 @@
     background-color 200ms;
 
   &:hover {
-    background-color: light-dark(rgb(0 0 0 / 10%), rgb(255 255 255 / 10%));
+    background-color: var(--elmethis-color-surface-sunken);
   }
 }

--- a/packages/solid/src/components/media/elm-file.tsx
+++ b/packages/solid/src/components/media/elm-file.tsx
@@ -63,7 +63,7 @@ export const ElmFile = (props: ElmFileProps) => {
   return (
     <div class={clsx(styles["elm-file"], local.class)} {...rest}>
       <div>
-        <ElmMdiIcon d={mdiFile} size="1.25rem" />
+        <ElmMdiIcon path={mdiFile} size="1.25rem" />
       </div>
 
       <div>
@@ -77,7 +77,7 @@ export const ElmFile = (props: ElmFileProps) => {
       </div>
 
       <div class={styles["download-icon"]} onClick={() => void downloadFile()}>
-        <ElmMdiIcon d={mdiDownload} size="1.25rem" />
+        <ElmMdiIcon path={mdiDownload} size="1.25rem" />
       </div>
     </div>
   );

--- a/packages/solid/src/components/navigation/elm-bookmark.module.css
+++ b/packages/solid/src/components/navigation/elm-bookmark.module.css
@@ -3,19 +3,19 @@
   display: block;
   container-type: inline-size;
   border-radius: 0.25rem;
-  box-shadow: 0 0 0.125rem rgb(0 0 0 / 10%);
+  box-shadow: 0 0 0.125rem var(--elmethis-box-shadow-color);
   overflow: hidden;
+  background-color: var(--elmethis-color-surface-raised);
   transition:
     background-color 200ms,
     transform 200ms;
 
   &:hover {
-    background-color: rgb(105 135 184 / 10%);
-    transform: translateX(-0.125rem) translateY(-0.125rem);
+    background-color: var(--elmethis-color-surface-sunken);
+    transform: translateX(-2px) translateY(-2px);
   }
 
   &:active {
-    background-color: rgb(89 181 124 / 10%);
     transform: translateX(0) translateY(0);
   }
 }
@@ -61,8 +61,6 @@
   flex-direction: column;
   gap: 0.5rem;
   justify-content: space-between;
-  transition: background-color 200ms;
-  background-color: light-dark(rgb(255 255 255 / 40%), rgb(0 0 0 / 20%));
 
   @container (max-width: 700px) {
     width: 100%;

--- a/packages/solid/src/components/navigation/elm-bookmark.tsx
+++ b/packages/solid/src/components/navigation/elm-bookmark.tsx
@@ -77,7 +77,7 @@ export const ElmBookmark = (props: ElmBookmarkProps) => {
               <ElmInlineIcon src={local.favicon} />
             ) : (
               <ElmMdiIcon
-                d={mdiLinkVariant}
+                path={mdiLinkVariant}
                 color="var(--elmethis-color-accent-info)"
               />
             )}

--- a/packages/solid/src/components/navigation/elm-breadcrumb.tsx
+++ b/packages/solid/src/components/navigation/elm-breadcrumb.tsx
@@ -31,7 +31,7 @@ export const ElmBreadcrumb = (props: ElmBreadcrumbProps) => {
             <span class={styles["link-container"]} onClick={link.onClick}>
               <ElmMdiIcon
                 class={styles.icon}
-                d={
+                path={
                   index() === 0
                     ? mdiHome
                     : index() === local.links.length - 1
@@ -47,7 +47,7 @@ export const ElmBreadcrumb = (props: ElmBreadcrumbProps) => {
             {local.links.length !== index() + 1 && (
               <ElmMdiIcon
                 class={styles.chevron}
-                d={mdiChevronRight}
+                path={mdiChevronRight}
                 size="1rem"
               />
             )}

--- a/packages/solid/src/components/navigation/elm-page-top.module.css
+++ b/packages/solid/src/components/navigation/elm-page-top.module.css
@@ -62,7 +62,7 @@
       top: 0;
       height: 100%;
       width: 50%;
-      background-color: light-dark(#494f59, #bec2ca);
+      background-color: var(--elmethis-color-neutral);
     }
 
     &::before {
@@ -87,18 +87,7 @@
     font-size: 12px;
     white-space: nowrap;
     user-select: none;
-    color: light-dark(
-      var(--elmethis-scoped-color, #606875),
-      var(--elmethis-scoped-color, #b0b5be)
-    );
-
-    &::selection {
-      color: light-dark(#cccfd5, #3e434b);
-      background-color: light-dark(
-        var(--elmethis-scoped-color, #3e434b),
-        var(--elmethis-scoped-color, #cccfd5)
-      );
-    }
+    color: var(--elmethis-color-neutral);
   }
 }
 

--- a/packages/solid/src/components/others/elm-color-primitive-sample.tsx
+++ b/packages/solid/src/components/others/elm-color-primitive-sample.tsx
@@ -48,7 +48,7 @@ export const ElmColorPrimitiveSample = (
         >
           <ElmMdiIcon
             class={styles["mode-toggle-icon"]}
-            d={
+            path={
               copy.copyMode() === "hex"
                 ? HEXADECIMAL_PATH
                 : FORMAT_COLOR_FILL_PATH

--- a/packages/solid/src/components/others/elm-color-semantic-sample.tsx
+++ b/packages/solid/src/components/others/elm-color-semantic-sample.tsx
@@ -218,7 +218,7 @@ export const ElmColorSemanticSample = (props: ElmColorSemanticSampleProps) => {
         >
           <ElmMdiIcon
             class={styles["mode-toggle-icon"]}
-            d={
+            path={
               copy.copyMode() === "hex"
                 ? HEXADECIMAL_PATH
                 : FORMAT_COLOR_FILL_PATH

--- a/packages/solid/src/components/others/use-wordle.browser.spec.tsx
+++ b/packages/solid/src/components/others/use-wordle.browser.spec.tsx
@@ -34,7 +34,7 @@ describe("[Browser] useWordle", () => {
       expect(
         getComputedStyle(rendered.getByRole("button", { name: "C" }))
           .backgroundColor,
-      ).toBe("rgb(83, 141, 78)"),
+      ).toBe("rgb(101, 152, 120)"),
     );
   });
 

--- a/packages/solid/src/components/others/use-wordle.module.css
+++ b/packages/solid/src/components/others/use-wordle.module.css
@@ -23,14 +23,14 @@
     color 0.15s ease;
 
   &.error {
-    background-color: #1a1a1b;
-    color: #fff;
+    background-color: var(--elmethis-color-accent-error);
+    color: contrast-color(var(--elmethis-color-accent-error));
     animation: fade-in 0.15s ease;
   }
 
   &.status {
-    background-color: #538d4e;
-    color: #fff;
+    background-color: var(--elmethis-color-accent-success);
+    color: contrast-color(var(--elmethis-color-accent-success));
     font-size: 1rem;
     animation: fade-in 0.15s ease;
   }
@@ -64,33 +64,33 @@
     border-color 0.2s ease;
 
   &.empty {
-    border-color: gray;
+    border-color: var(--elmethis-color-neutral-weak);
     background-color: transparent;
     color: transparent;
   }
 
   &.tbd {
-    border-color: #565758;
+    border-color: var(--elmethis-color-neutral);
     background-color: transparent;
-    color: #6c7483;
+    color: var(--elmethis-color-neutral);
   }
 
   &.correct {
-    background-color: #538d4e;
-    border-color: #538d4e;
-    color: #fff;
+    background-color: var(--elmethis-color-accent-success);
+    border-color: var(--elmethis-color-accent-success);
+    color: contrast-color(var(--elmethis-color-accent-success));
   }
 
   &.present {
-    background-color: #b59f3b;
-    border-color: #b59f3b;
-    color: #fff;
+    background-color: var(--elmethis-color-accent-warning);
+    border-color: var(--elmethis-color-accent-warning);
+    color: contrast-color(var(--elmethis-color-accent-warning));
   }
 
   &.absent {
-    background-color: #3a3a3c;
-    border-color: #3a3a3c;
-    color: #fff;
+    background-color: var(--elmethis-color-surface-sunken);
+    border-color: var(--elmethis-color-surface-sunken);
+    color: contrast-color(var(--elmethis-color-surface-sunken));
   }
 }
 
@@ -114,8 +114,8 @@
   padding: 0 0.25rem;
   border: none;
   border-radius: 0.25rem;
-  background-color: #818384;
-  color: #fff;
+  background-color: var(--elmethis-color-neutral);
+  color: contrast-color(var(--elmethis-color-neutral));
   font-size: 0.8125rem;
   font-weight: bold;
   cursor: pointer;
@@ -137,15 +137,18 @@
   }
 
   &.correct {
-    background-color: #538d4e;
+    background-color: var(--elmethis-color-accent-success);
+    color: contrast-color(var(--elmethis-color-accent-success));
   }
 
   &.present {
-    background-color: #b59f3b;
+    background-color: var(--elmethis-color-accent-warning);
+    color: contrast-color(var(--elmethis-color-accent-warning));
   }
 
   &.absent {
-    background-color: #3a3a3c;
+    background-color: var(--elmethis-color-surface-sunken);
+    color: contrast-color(var(--elmethis-color-surface-sunken));
   }
 }
 
@@ -161,8 +164,8 @@
   padding: 0.625rem 1.5rem;
   border: none;
   border-radius: 0.25rem;
-  background-color: #538d4e;
-  color: #fff;
+  background-color: var(--elmethis-color-accent-success);
+  color: contrast-color(var(--elmethis-color-accent-success));
   font-size: 1rem;
   font-weight: bold;
   cursor: pointer;
@@ -171,7 +174,9 @@
     transform 0.05s ease;
 
   &:hover {
-    background-color: #6aaa64;
+    background-color: oklch(
+      from var(--elmethis-color-accent-success) calc(l + 0.08) c h
+    );
   }
 
   &:active {

--- a/packages/solid/src/components/table/elm-table.module.css
+++ b/packages/solid/src/components/table/elm-table.module.css
@@ -57,7 +57,7 @@
 .elm-table {
   border-collapse: collapse;
   border-spacing: 0;
-  box-shadow: 0 0 0.125rem rgb(0 0 0 / 20%);
+  box-shadow: 0 0 0.125rem var(--elmethis-box-shadow-color);
 }
 
 .caption {
@@ -80,7 +80,7 @@
 .spacing {
   flex-grow: 1;
   height: 1px;
-  background-color: rgb(128 128 128 / 20%);
+  background-color: var(--elmethis-color-divider);
 }
 
 .sticky-row-header :where(thead, tbody) tr > :first-child {

--- a/packages/solid/src/components/typography/elm-block-quote.tsx
+++ b/packages/solid/src/components/typography/elm-block-quote.tsx
@@ -21,13 +21,13 @@ export const ElmBlockQuote = (props: ElmBlockQuoteProps) => {
       class={clsx(styles["elm-block-quote"], textStyles.text, local.class)}
     >
       <div class={clsx(styles.icon, styles["icon-top-left"])}>
-        <ElmMdiIcon d={FORMAT_QUOTE_OPEN} />
+        <ElmMdiIcon path={FORMAT_QUOTE_OPEN} />
       </div>
 
       <div class={styles.body}>{local.children}</div>
 
       <div class={clsx(styles.icon, styles["icon-bottom-right"])}>
-        <ElmMdiIcon d={FORMAT_QUOTE_CLOSE} />
+        <ElmMdiIcon path={FORMAT_QUOTE_CLOSE} />
       </div>
     </blockquote>
   );

--- a/packages/solid/src/components/typography/elm-callout.tsx
+++ b/packages/solid/src/components/typography/elm-callout.tsx
@@ -33,7 +33,7 @@ export const ElmCallout = (props: ElmCalloutProps) => {
       <div class={styles.header}>
         <ElmMdiIcon
           class={styles.icon}
-          d={ICON_MAP[local.type]}
+          path={ICON_MAP[local.type]}
           size="1.25rem"
         />
         <span>{local.type}</span>

--- a/packages/solid/src/components/typography/elm-inline-text.module.css
+++ b/packages/solid/src/components/typography/elm-inline-text.module.css
@@ -72,7 +72,7 @@
     opacity 200ms;
 
   &:hover {
-    background-color: oklch(from #6987b8 l c h / 20%);
+    background-color: var(--elmethis-color-accent-link-surface);
   }
 
   &:active {

--- a/packages/solid/stylelint.config.mjs
+++ b/packages/solid/stylelint.config.mjs
@@ -8,6 +8,31 @@ export default {
   extends: ["stylelint-config-standard", "stylelint-config-css-modules"],
   plugins: ["stylelint-value-no-unknown-custom-properties"],
   rules: {
+    "color-no-hex": [
+      true,
+      {
+        message: "Use an Elmethis color token instead of a hex color",
+        severity: "warning",
+      },
+    ],
+    "color-named": [
+      "never",
+      {
+        message: "Use an Elmethis color token instead of a named color",
+        severity: "warning",
+      },
+    ],
+    "declaration-property-value-disallowed-list": [
+      {
+        "/.*/": [
+          "/(?<![-\\w])(?:rgb|rgba|hsl|hsla|hwb|lab|lch|oklab|oklch|color)\\((?!\\s*from\\b)/i",
+        ],
+      },
+      {
+        message: "Use an Elmethis color token instead of a color function",
+        severity: "warning",
+      },
+    ],
     "csstools/value-no-unknown-custom-properties": [
       true,
       {
@@ -32,5 +57,7 @@ export default {
     "lib-types/**",
     "storybook-static/**",
     "node_modules/**",
+    "./src/components/others/elm-color-primitive-sample.module.css",
+    "./src/components/others/elm-color-semantic-sample.module.css",
   ],
 };

--- a/packages/vue/.storybook/sb.css
+++ b/packages/vue/.storybook/sb.css
@@ -5,5 +5,5 @@ html {
 body,
 .docs-story {
   transition: background-color 200ms;
-  background-color: light-dark(#efecea, #393e46);
+  background-color: var(--elmethis-color-surface-base);
 }

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elmethis/vue",
-  "version": "0.19.1",
+  "version": "0.20.0",
   "description": "Vue 3 component library for elmethis.",
   "publishConfig": {
     "access": "public"

--- a/packages/vue/src/components/a2ui/elm-a2ui.module.css
+++ b/packages/vue/src/components/a2ui/elm-a2ui.module.css
@@ -94,11 +94,11 @@
 /* ---- card ---- */
 
 .card {
-  border: 1px solid #e0e0e0;
+  border: 1px solid var(--elmethis-color-divider);
   border-radius: 8px;
   padding: 16px;
-  background: #fff;
-  box-shadow: 0 1px 3px rgb(0 0 0 / 8%);
+  background: var(--elmethis-color-surface-raised);
+  box-shadow: 0 1px 3px var(--elmethis-box-shadow-color);
 }
 
 /* ---- button ---- */
@@ -109,7 +109,7 @@
   justify-content: center;
   gap: 4px;
   padding: 8px 16px;
-  border: 1px solid #ccc;
+  border: 1px solid var(--elmethis-color-divider);
   border-radius: 4px;
   background: transparent;
   cursor: pointer;
@@ -119,17 +119,20 @@
 }
 
 .button:hover {
-  background: rgb(0 0 0 / 5%);
+  background: var(--elmethis-color-primary-hover);
 }
 
 .button-primary {
-  background: var(--a2ui-primary, #1976d2);
+  background: var(--a2ui-primary, var(--elmethis-color-primary));
   border-color: transparent;
-  color: #fff;
+  color: oklch(
+    from contrast-color(var(--a2ui-primary, var(--elmethis-color-primary))) l c
+      h / 65%
+  );
 }
 
 .button-primary:hover {
-  background: var(--a2ui-primary-hover, #1565c0);
+  background: var(--a2ui-primary-hover, var(--elmethis-color-primary-strong));
 }
 
 /* ---- image ---- */
@@ -153,13 +156,13 @@
 
 .divider {
   border: none;
-  border-top: 1px solid #e0e0e0;
+  border-top: 1px solid var(--elmethis-color-divider);
   margin: 8px 0;
 }
 
 .divider-vertical {
   border-top: none;
-  border-left: 1px solid #e0e0e0;
+  border-left: 1px solid var(--elmethis-color-divider);
   margin: 0 8px;
   align-self: stretch;
   width: 0;
@@ -176,12 +179,12 @@
 .label {
   font-size: 0.75rem;
   font-weight: 500;
-  color: #555;
+  color: var(--elmethis-color-neutral-strong);
 }
 
 .input {
   padding: 8px 10px;
-  border: 1px solid #ccc;
+  border: 1px solid var(--elmethis-color-divider);
   border-radius: 4px;
   font-size: 0.875rem;
   outline: none;
@@ -189,7 +192,7 @@
 }
 
 .input:focus {
-  border-color: var(--a2ui-primary, #1976d2);
+  border-color: var(--a2ui-primary, var(--elmethis-color-primary));
 }
 
 .checkbox {
@@ -238,7 +241,7 @@
 .choice-picker-label {
   font-size: 0.75rem;
   font-weight: 500;
-  color: #555;
+  color: var(--elmethis-color-neutral-strong);
 }
 
 .choice-picker-options {

--- a/packages/vue/src/components/code/elm-code-block.module.css
+++ b/packages/vue/src/components/code/elm-code-block.module.css
@@ -33,7 +33,7 @@
   grid-area: divider;
   width: calc(100% - 1rem);
   border: none;
-  border-bottom: solid 1px rgb(128 128 128 / 50%);
+  border-bottom: solid 1px var(--elmethis-color-divider);
 }
 
 .code {

--- a/packages/vue/src/components/code/elm-html-viewer.module.css
+++ b/packages/vue/src/components/code/elm-html-viewer.module.css
@@ -51,7 +51,7 @@
   width: calc(100% - 1rem);
   margin-inline: auto;
   border: none;
-  border-bottom: solid 1px rgb(128 128 128 / 50%);
+  border-bottom: solid 1px var(--elmethis-color-divider);
 }
 
 .content {

--- a/packages/vue/src/components/code/elm-html-viewer.tsx
+++ b/packages/vue/src/components/code/elm-html-viewer.tsx
@@ -162,7 +162,7 @@ export const ElmHtmlViewer = defineComponent({
             onClick={handleDownload}
             aria-label="Download"
           >
-            <ElmMdiIcon d={mdiDownload} size="1.25rem" />
+            <ElmMdiIcon path={mdiDownload} size="1.25rem" />
           </button>
 
           <button
@@ -171,7 +171,7 @@ export const ElmHtmlViewer = defineComponent({
             onClick={handleOpenInNewTab}
             aria-label="Open in new tab"
           >
-            <ElmMdiIcon d={mdiOpenInNew} size="1.25rem" />
+            <ElmMdiIcon path={mdiOpenInNew} size="1.25rem" />
           </button>
         </div>
 

--- a/packages/vue/src/components/code/elm-shiki-highlighter.module.css
+++ b/packages/vue/src/components/code/elm-shiki-highlighter.module.css
@@ -22,7 +22,7 @@
     /* stylelint-enable csstools/value-no-unknown-custom-properties */
 
     &::selection {
-      background-color: oklch(from #cdb57b l c h / 25%);
+      background-color: var(--elmethis-color-selection);
     }
   }
 }

--- a/packages/vue/src/components/containments/elm-modal.module.css
+++ b/packages/vue/src/components/containments/elm-modal.module.css
@@ -27,6 +27,6 @@
     opacity: 0;
     transition: opacity var(--elmethis-scoped-modal-delay, 200ms);
     background-color: transparent;
-    background-color: oklch(from black l c h / 50%);
+    background-color: var(--elmethis-color-modal-backdrop);
   }
 }

--- a/packages/vue/src/components/containments/elm-toggle.module.css
+++ b/packages/vue/src/components/containments/elm-toggle.module.css
@@ -39,7 +39,7 @@
     margin: 0 1rem;
     height: 1px;
     width: 100%;
-    background-color: oklch(from gray l c h / 12.5%);
+    background-color: var(--elmethis-color-divider);
   }
 
   &:hover {
@@ -78,7 +78,7 @@
   width: 1px;
   margin-left: 1rem;
   height: 100%;
-  background-color: oklch(from gray l c h / 12.5%);
+  background-color: var(--elmethis-color-divider);
 }
 
 .content {

--- a/packages/vue/src/components/containments/elm-toggle.tsx
+++ b/packages/vue/src/components/containments/elm-toggle.tsx
@@ -54,7 +54,7 @@ export const ElmToggle = defineComponent({
           <div class={styles["summary-left"]}>
             <span class={clsx(styles.chevron, isOpen.value && styles.open)}>
               <ElmMdiIcon
-                d={mdiChevronRight}
+                path={mdiChevronRight}
                 color={
                   props.monochrome
                     ? "var(--elmethis-color-neutral-weak)"
@@ -76,7 +76,7 @@ export const ElmToggle = defineComponent({
 
           <span class={clsx(styles.cross, isOpen.value && styles.open)}>
             <ElmMdiIcon
-              d={mdiPlus}
+              path={mdiPlus}
               size="1rem"
               color={
                 props.monochrome

--- a/packages/vue/src/components/form/elm-button-dropdown.module.css
+++ b/packages/vue/src/components/form/elm-button-dropdown.module.css
@@ -27,7 +27,7 @@
     border-bottom-left-radius: 0;
     padding-left: 0.75rem;
     padding-right: 0.75rem;
-    border-left: 1px solid light-dark(rgb(0 0 0 / 15%), rgb(255 255 255 / 20%));
+    border-left: 1px solid var(--elmethis-color-divider);
   }
 
   /* Keep the joined control from shifting per-segment on hover/active. */
@@ -45,8 +45,8 @@
     width: max-content;
     min-width: 100%;
     border-radius: 0.25rem;
-    background-color: light-dark(rgb(255 255 255 / 95%), rgb(51 51 51 / 95%));
-    box-shadow: 0 0 0.125rem light-dark(rgb(0 0 0 / 15%), rgb(0 0 0 / 75%));
+    background-color: var(--elmethis-color-surface-raised);
+    box-shadow: 0 0 0.125rem var(--elmethis-box-shadow-color);
 
     .item {
       overflow: hidden;
@@ -62,18 +62,16 @@
       cursor: pointer;
 
       &:hover {
-        background-color: light-dark(
-          rgb(190 194 202 / 30%),
-          rgb(190 194 202 / 20%)
-        );
+        background-color: var(--elmethis-color-surface-sunken);
       }
 
       &.selected {
-        background-color: light-dark(
-          rgb(190 194 202 / 25%),
-          rgb(190 194 202 / 15%)
-        );
+        background-color: var(--elmethis-color-surface-base);
         color: var(--elmethis-color-primary-weak);
+
+        &:hover {
+          background-color: var(--elmethis-color-surface-sunken);
+        }
       }
 
       &.item-disabled {

--- a/packages/vue/src/components/form/elm-button-dropdown.tsx
+++ b/packages/vue/src/components/form/elm-button-dropdown.tsx
@@ -219,7 +219,7 @@ export const ElmButtonDropdown = defineComponent({
           </ElmButton>
 
           <ElmButton {...caretButtonProps}>
-            <ElmMdiIcon d={props.dropdownIcon} size="1.25rem" />
+            <ElmMdiIcon path={props.dropdownIcon} size="1.25rem" />
           </ElmButton>
 
           <ElmCollapse isOpen={isOpen.value} class={styles["menu"]}>
@@ -243,7 +243,7 @@ export const ElmButtonDropdown = defineComponent({
                 }}
               >
                 <ElmMdiIcon
-                  d={mdiChevronRight}
+                  path={mdiChevronRight}
                   color="var(--elmethis-color-primary-weak)"
                   size="0.75em"
                 />

--- a/packages/vue/src/components/form/elm-button.module.css
+++ b/packages/vue/src/components/form/elm-button.module.css
@@ -46,13 +46,13 @@
   &:hover {
     transform: translateX(-1px) translateY(-1px);
     opacity: var(--elmethis-scoped-opacity, 0.7);
-    box-shadow: 0.125rem 0.125rem 0.125rem rgb(128 128 128 / 25%);
+    box-shadow: 0.125rem 0.125rem 0.125rem var(--elmethis-box-shadow-color);
   }
 
   &:active {
     transform: translateX(1px) translateY(1px);
     opacity: var(--elmethis-scoped-opacity, 0.5);
-    box-shadow: -1px -1px 0.125rem rgb(128 128 128 / 25%);
+    box-shadow: -1px -1px 0.125rem var(--elmethis-box-shadow-color);
   }
 }
 
@@ -61,36 +61,4 @@
   justify-content: center;
   align-items: center;
   gap: 0.5rem;
-}
-
-@keyframes button-ripple {
-  0% {
-    transform: scale(0);
-    opacity: 1;
-  }
-
-  50% {
-    transform: scale(1.2);
-    opacity: 1;
-  }
-
-  100% {
-    transform: scale(1.2);
-    opacity: 0;
-  }
-}
-
-.ripple {
-  position: absolute;
-  pointer-events: none;
-  border-radius: 50%;
-  background-color: rgb(205 181 123 / 15%);
-  width: 100%;
-  aspect-ratio: 1 / 1;
-  transition: none;
-  opacity: 0;
-  animation-name: button-ripple;
-  animation-duration: 300ms;
-  animation-fill-mode: both;
-  animation-timing-function: ease-out;
 }

--- a/packages/vue/src/components/form/elm-button.stories.tsx
+++ b/packages/vue/src/components/form/elm-button.stories.tsx
@@ -49,11 +49,11 @@ export const Flex: Story = {
     template: `
       <div style="display: flex; gap: 1rem">
         <ElmButton v-bind="args">
-          <ElmMdiIcon :d="mdiSquareEditOutline" size="1.25rem" />
+          <ElmMdiIcon :path="mdiSquareEditOutline" size="1.25rem" />
           elm-button
         </ElmButton>
         <ElmButton v-bind="args">
-          <ElmMdiIcon :d="mdiSquareEditOutline" size="1.25rem" />
+          <ElmMdiIcon :path="mdiSquareEditOutline" size="1.25rem" />
           elm-button
         </ElmButton>
       </div>
@@ -75,11 +75,11 @@ export const WithPrimary: Story = {
     template: `
       <div style="display: flex; gap: 1rem">
         <ElmButton v-bind="args" primary>
-          <ElmMdiIcon :d="mdiSquareEditOutline" size="1.25rem" />
+          <ElmMdiIcon :path="mdiSquareEditOutline" size="1.25rem" />
           elm-button
         </ElmButton>
         <ElmButton v-bind="args">
-          <ElmMdiIcon :d="mdiSquareEditOutline" size="1.25rem" />
+          <ElmMdiIcon :path="mdiSquareEditOutline" size="1.25rem" />
           elm-button
         </ElmButton>
       </div>

--- a/packages/vue/src/components/form/elm-button.tsx
+++ b/packages/vue/src/components/form/elm-button.tsx
@@ -1,7 +1,5 @@
 import {
   defineComponent,
-  onUnmounted,
-  ref,
   type CSSProperties,
   type HTMLAttributes,
   type StyleValue,
@@ -37,7 +35,7 @@ export interface ElmButtonProps extends HTMLAttributes {
 
 export const ElmButton = defineComponent({
   name: "ElmButton",
-  // The consumer's `onClick` is intercepted (ripple + loading/disabled guard),
+  // The consumer's `onClick` is intercepted for the loading/disabled guard,
   // so attrs are split manually instead of falling through.
   inheritAttrs: false,
   props: {
@@ -48,12 +46,6 @@ export const ElmButton = defineComponent({
     disabled: { type: Boolean, default: undefined },
   },
   setup(props, { attrs, slots }) {
-    const clicked = ref(false);
-    let timer: ReturnType<typeof setTimeout> | undefined;
-
-    // Clear the ripple timer on unmount so it can't write to a destroyed ref.
-    onUnmounted(() => clearTimeout(timer));
-
     return () => {
       const {
         class: className,
@@ -65,9 +57,6 @@ export const ElmButton = defineComponent({
       const handleClick = (event: MouseEvent): void => {
         if (!props.isLoading && !props.disabled) {
           if (typeof onClick === "function") {
-            clicked.value = true;
-            clearTimeout(timer);
-            timer = setTimeout(() => (clicked.value = false), 300);
             (onClick as (event: MouseEvent) => void)(event);
           }
         }
@@ -104,8 +93,6 @@ export const ElmButton = defineComponent({
           }
           {...rest}
         >
-          {clicked.value && <span class={styles.ripple}></span>}
-
           {props.isLoading ? (
             <ElmDotLoadingIcon size="1.5rem" />
           ) : (

--- a/packages/vue/src/components/form/elm-checkbox.module.css
+++ b/packages/vue/src/components/form/elm-checkbox.module.css
@@ -20,7 +20,7 @@
 }
 
 .checkbox {
-  stroke: light-dark(rgb(0 0 0 / 80%), rgb(255 255 255 / 80%));
+  stroke: var(--elmethis-color-neutral-strong);
   fill: transparent;
 }
 
@@ -32,13 +32,13 @@
   }
 
   &.checked {
-    fill: light-dark(rgb(0 0 0 / 80%), rgb(255 255 255 / 80%));
+    fill: var(--elmethis-color-neutral-strong);
   }
 }
 
 .loading-dot {
   transition: opacity 200ms;
-  fill: light-dark(rgb(0 0 0 / 70%), rgb(255 255 255 / 70%));
+  fill: var(--elmethis-color-neutral-strong);
 }
 
 @keyframes elmethis-checkbox-check-line {
@@ -59,5 +59,5 @@
   animation-delay: 0.1s;
   animation-fill-mode: both;
   transform-origin: center;
-  stroke: light-dark(rgb(255 255 255 / 90%), rgb(0 0 0 / 90%));
+  stroke: contrast-color(var(--elmethis-color-neutral-strong));
 }

--- a/packages/vue/src/components/form/elm-select.module.css
+++ b/packages/vue/src/components/form/elm-select.module.css
@@ -80,8 +80,8 @@
       width: max-content;
       padding: 0;
       border-radius: 0.25rem;
-      background-color: light-dark(rgb(255 255 255 / 95%), rgb(51 51 51 / 95%));
-      box-shadow: 0 0 0.125rem light-dark(rgb(0 0 0 / 15%), rgb(0 0 0 / 75%));
+      background-color: var(--elmethis-color-surface-raised);
+      box-shadow: 0 0 0.125rem var(--elmethis-box-shadow-color);
 
       .option {
         overflow: hidden;
@@ -97,10 +97,7 @@
         cursor: pointer;
 
         &:hover {
-          background-color: light-dark(
-            rgb(190 194 202 / 30%),
-            rgb(190 194 202 / 20%)
-          );
+          background-color: var(--elmethis-color-surface-sunken);
         }
       }
     }

--- a/packages/vue/src/components/form/elm-select.stories.tsx
+++ b/packages/vue/src/components/form/elm-select.stories.tsx
@@ -55,7 +55,7 @@ export const WithIcon: Story = {
     },
     template: `
       <ElmSelect v-bind="args">
-        <template #icon><ElmMdiIcon :d="mdiAccountOutline" /></template>
+        <template #icon><ElmMdiIcon :path="mdiAccountOutline" /></template>
       </ElmSelect>
     `,
   }),

--- a/packages/vue/src/components/form/elm-select.tsx
+++ b/packages/vue/src/components/form/elm-select.tsx
@@ -137,7 +137,7 @@ export const ElmSelect = defineComponent({
             )}
           >
             {slots.icon?.() ?? (
-              <ElmMdiIcon d={mdiArrowDownDropCircleOutline} size="0.75rem" />
+              <ElmMdiIcon path={mdiArrowDownDropCircleOutline} size="0.75rem" />
             )}
             {props.label}
           </span>
@@ -158,7 +158,7 @@ export const ElmSelect = defineComponent({
               )}
             </div>
 
-            <ElmMdiIcon d={mdiMenuDown} size="1.5rem" />
+            <ElmMdiIcon path={mdiMenuDown} size="1.5rem" />
 
             <ElmCollapse isOpen={isOpen.value} class={styles["pulldown"]}>
               {props.options.map((option) => (
@@ -172,7 +172,7 @@ export const ElmSelect = defineComponent({
                   }}
                 >
                   <ElmMdiIcon
-                    d={mdiChevronRight}
+                    path={mdiChevronRight}
                     color="var(--elmethis-color-primary-weak)"
                     size="0.75em"
                   />

--- a/packages/vue/src/components/form/elm-switch.module.css
+++ b/packages/vue/src/components/form/elm-switch.module.css
@@ -12,11 +12,11 @@
   );
   position: relative;
   cursor: pointer;
-  box-shadow: 0 0 2px rgb(0 0 0 / 10%);
+  box-shadow: 0 0 2px var(--elmethis-box-shadow-color);
   transition:
     opacity 300ms,
     background-color 300ms;
-  background-color: rgb(128 128 128 / 25%);
+  background-color: var(--elmethis-color-surface-sunken);
 
   &.checked {
     background-color: var(--elmethis-scoped-color);
@@ -40,7 +40,7 @@
     transform 300ms,
     opacity 300ms,
     background-color 300ms;
-  background-color: rgb(255 255 255 / 90%);
+  background-color: var(--elmethis-color-surface-raised);
 
   &.checked {
     transform: translateX(
@@ -50,7 +50,7 @@
 
   &.disabled {
     opacity: 0.5;
-    background-color: rgb(128 128 128 / 100%);
+    background-color: var(--elmethis-color-neutral-weak);
   }
 
   &:hover {

--- a/packages/vue/src/components/form/elm-text-area.module.css
+++ b/packages/vue/src/components/form/elm-text-area.module.css
@@ -53,12 +53,8 @@
   border-style: solid;
   border-width: 1px;
   border-color: transparent;
-  background-color: light-dark(
-    var(--elmethis-color-surface-raised),
-    oklch(from #393e46 calc(l * 0.9) c h)
-  );
-  box-shadow: 0 0 0.125rem
-    light-dark(var(--elmethis-box-shadow-color), rgb(0 0 0 / 75%));
+  background-color: var(--elmethis-color-surface-raised);
+  box-shadow: 0 0 0.125rem var(--elmethis-box-shadow-color);
 
   &.disabled {
     background-color: var(--elmethis-color-surface-sunken);
@@ -106,10 +102,7 @@
   min-height: 1.5rem;
   font-family: inherit;
   line-height: 1.4;
-  color: light-dark(
-    var(--elmethis-color-neutral),
-    oklch(from white l c h / 70%)
-  );
+  color: var(--elmethis-color-neutral);
   caret-color: var(--highlight-color);
   resize: vertical;
 
@@ -123,13 +116,10 @@
   }
 
   &::selection {
-    color: light-dark(
-      var(--elmethis-color-surface-raised),
-      oklch(from black l c h / 70%)
-    );
-    background-color: light-dark(
-      var(--elmethis-scoped-color, var(--elmethis-color-neutral)),
-      oklch(from white l c h / 70%)
+    color: var(--elmethis-color-surface-raised);
+    background-color: var(
+      --elmethis-scoped-color,
+      var(--elmethis-color-neutral)
     );
   }
 }

--- a/packages/vue/src/components/form/elm-text-area.stories.tsx
+++ b/packages/vue/src/components/form/elm-text-area.stories.tsx
@@ -54,7 +54,7 @@ export const WithIcon: Story = {
     template: `
       <div>
         <ElmTextArea label="Comment" placeholder="Leave a comment" v-model:value="text" :rows="5">
-          <template #icon><ElmMdiIcon :d="mdiCommentTextOutline" size="0.75rem" color="gray" /></template>
+          <template #icon><ElmMdiIcon :path="mdiCommentTextOutline" size="0.75rem" color="gray" /></template>
         </ElmTextArea>
         <ElmInlineText>{{ text }}</ElmInlineText>
       </div>

--- a/packages/vue/src/components/form/elm-text-area.tsx
+++ b/packages/vue/src/components/form/elm-text-area.tsx
@@ -99,7 +99,7 @@ export const ElmTextArea = defineComponent({
               isFocused.value && styles["label-active"],
             )}
           >
-            {slots.icon?.() ?? <ElmMdiIcon d={mdiTextLong} size="0.75rem" />}
+            {slots.icon?.() ?? <ElmMdiIcon path={mdiTextLong} size="0.75rem" />}
             <span>
               {props.label}
               {props.required && <span class={styles.requierd}>*</span>}

--- a/packages/vue/src/components/form/elm-text-field.module.css
+++ b/packages/vue/src/components/form/elm-text-field.module.css
@@ -134,7 +134,7 @@
     cursor: pointer;
 
     &:hover {
-      background-color: rgb(128 128 128 / 20%);
+      background-color: var(--elmethis-color-surface-sunken);
     }
   }
 }
@@ -145,5 +145,5 @@
   font-size: 0.85em;
   user-select: none;
   transition: color 200ms;
-  color: light-dark(rgb(0 0 0 / 65%), rgb(255 255 255 / 65%));
+  color: var(--elmethis-color-neutral-weak);
 }

--- a/packages/vue/src/components/form/elm-text-field.stories.tsx
+++ b/packages/vue/src/components/form/elm-text-field.stories.tsx
@@ -56,7 +56,7 @@ export const WithIcon: Story = {
     template: `
       <div>
         <ElmTextField label="Email" placeholder="Enter your email" v-model:value="text">
-          <template #icon><ElmMdiIcon :d="mdiEmail" size=".75rem" color="gray" /></template>
+          <template #icon><ElmMdiIcon :path="mdiEmail" size=".75rem" color="gray" /></template>
         </ElmTextField>
         <ElmInlineText>{{ text }}</ElmInlineText>
       </div>

--- a/packages/vue/src/components/form/elm-text-field.tsx
+++ b/packages/vue/src/components/form/elm-text-field.tsx
@@ -98,7 +98,7 @@ export const ElmTextField = defineComponent({
               isFocused.value && styles["label-active"],
             )}
           >
-            {slots.icon?.() ?? <ElmMdiIcon d={mdiText} size="0.75rem" />}
+            {slots.icon?.() ?? <ElmMdiIcon path={mdiText} size="0.75rem" />}
             <span>
               {props.label}
               {props.required && <span class={styles.requierd}>*</span>}
@@ -169,7 +169,7 @@ export const ElmTextField = defineComponent({
                 }}
               >
                 <ElmMdiIcon
-                  d={
+                  path={
                     inputType.value === "text"
                       ? mdiEyeOutline
                       : mdiEyeOffOutline
@@ -188,7 +188,7 @@ export const ElmTextField = defineComponent({
                 }}
               >
                 <ElmMdiIcon
-                  d={mdiTrashCanOutline}
+                  path={mdiTrashCanOutline}
                   size="1.25rem"
                   color="gray"
                 />

--- a/packages/vue/src/components/form/elm-validation.tsx
+++ b/packages/vue/src/components/form/elm-validation.tsx
@@ -35,7 +35,7 @@ export const ElmValidation = defineComponent({
         }
       >
         <ElmMdiIcon
-          d={props.isValid ? mdiCheckCircle : mdiCheckCircleOutline}
+          path={props.isValid ? mdiCheckCircle : mdiCheckCircleOutline}
           color={props.isValid ? props.validColor : undefined}
         />
         <ElmInlineText color={props.isValid ? props.validColor : undefined}>

--- a/packages/vue/src/components/icon/elm-inline-icon.module.css
+++ b/packages/vue/src/components/icon/elm-inline-icon.module.css
@@ -9,15 +9,11 @@
   /* Light inherits the surrounding text color; dark lightens the glyph. */
   color: light-dark(
     currentcolor,
-    var(--elmethis-scoped-color, rgb(255 255 255 / 70%))
+    var(--elmethis-scoped-color, var(--elmethis-color-neutral))
   );
 
   &::selection {
-    color: light-dark(currentcolor, rgb(0 0 0 / 70%));
-    background-color: light-dark(
-      var(--elmethis-scoped-color, rgb(0 0 0 / 25%)),
-      var(--elmethis-scoped-color, rgb(255 255 255 / 25%))
-    );
+    background-color: var(--elmethis-color-selection);
 
     /* `filter` is not a <color>, so it can't use light-dark(): the OS default
        is the media query; an explicit pin overrides it below. */

--- a/packages/vue/src/components/icon/elm-language-icon.tsx
+++ b/packages/vue/src/components/icon/elm-language-icon.tsx
@@ -37,7 +37,7 @@ export const ElmLanguageIcon = defineComponent({
       const normalized = normalizeLanguage(props.language);
 
       if (normalized === "file") {
-        return <ElmMdiIcon d={mdiCodeTags} size={String(props.size)} />;
+        return <ElmMdiIcon path={mdiCodeTags} size={String(props.size)} />;
       }
 
       return h(LanguageGlyph, {

--- a/packages/vue/src/components/icon/elm-mdi-icon.module.css
+++ b/packages/vue/src/components/icon/elm-mdi-icon.module.css
@@ -1,7 +1,3 @@
 .elm-mdi-icon {
-  fill: light-dark(
-    var(--elmethis-scoped-color-light, var(--elmethis-color-neutral)),
-    var(--elmethis-scoped-color-dark, var(--elmethis-color-neutral))
-  );
   transition: fill 200ms;
 }

--- a/packages/vue/src/components/icon/elm-mdi-icon.module.css
+++ b/packages/vue/src/components/icon/elm-mdi-icon.module.css
@@ -1,7 +1,7 @@
 .elm-mdi-icon {
   fill: light-dark(
-    var(--elmethis-scoped-color, #555b67),
-    var(--dark-color, #b0b5be)
+    var(--elmethis-scoped-color-light, var(--elmethis-color-neutral)),
+    var(--elmethis-scoped-color-dark, var(--elmethis-color-neutral))
   );
   transition: fill 200ms;
 }

--- a/packages/vue/src/components/icon/elm-mdi-icon.spec.tsx
+++ b/packages/vue/src/components/icon/elm-mdi-icon.spec.tsx
@@ -31,11 +31,13 @@ describe("[CSR] ElmMdiIcon", () => {
     });
     const svg = wrapper.find("svg").element as SVGElement;
     expect(svg.getAttribute("fill")).toBe("#ff0000");
-    // Both --elmethis-scoped-color and --dark-color fall back to `color`.
-    expect(svg.style.getPropertyValue("--elmethis-scoped-color")).toBe(
+    // Both scoped color variables fall back to `color`.
+    expect(svg.style.getPropertyValue("--elmethis-scoped-color-light")).toBe(
       "#ff0000",
     );
-    expect(svg.style.getPropertyValue("--dark-color")).toBe("#ff0000");
+    expect(svg.style.getPropertyValue("--elmethis-scoped-color-dark")).toBe(
+      "#ff0000",
+    );
   });
 
   it("lightColor / darkColor override the scoped color vars independently", () => {
@@ -43,8 +45,12 @@ describe("[CSR] ElmMdiIcon", () => {
       props: { d: mdiCodeTags, lightColor: "#111", darkColor: "#eee" },
     });
     const svg = wrapper.find("svg").element as SVGElement;
-    expect(svg.style.getPropertyValue("--elmethis-scoped-color")).toBe("#111");
-    expect(svg.style.getPropertyValue("--dark-color")).toBe("#eee");
+    expect(svg.style.getPropertyValue("--elmethis-scoped-color-light")).toBe(
+      "#111",
+    );
+    expect(svg.style.getPropertyValue("--elmethis-scoped-color-dark")).toBe(
+      "#eee",
+    );
   });
 
   it("merges a passthrough class onto the root", () => {

--- a/packages/vue/src/components/icon/elm-mdi-icon.spec.tsx
+++ b/packages/vue/src/components/icon/elm-mdi-icon.spec.tsx
@@ -7,55 +7,60 @@ import { mdiCodeTags } from "@mdi/js";
 import { ElmMdiIcon } from "./elm-mdi-icon";
 
 describe("[CSR] ElmMdiIcon", () => {
-  it("renders an <svg role='img'> with the given path", () => {
-    const wrapper = mount(ElmMdiIcon, { props: { d: mdiCodeTags } });
+  it("renders a decorative currentColor SVG with the given path", () => {
+    const wrapper = mount(ElmMdiIcon, { props: { path: mdiCodeTags } });
     const svg = wrapper.find("svg");
-    expect(svg.exists()).toBe(true);
-    expect(svg.attributes("role")).toBe("img");
-    // The `d` prop must reach the inner <path>.
+    expect(svg.attributes("aria-hidden")).toBe("true");
+    expect(svg.attributes("role")).toBeUndefined();
+    expect(svg.attributes("focusable")).toBe("false");
+    expect(svg.attributes("fill")).toBe("currentColor");
     expect(wrapper.find("path").attributes("d")).toBe(mdiCodeTags);
+  });
+
+  it("exposes a labeled icon as an image", () => {
+    const wrapper = mount(ElmMdiIcon, {
+      props: { path: mdiCodeTags, label: "Code" },
+    });
+    const svg = wrapper.find("svg");
+    expect(svg.attributes("role")).toBe("img");
+    expect(svg.attributes("aria-hidden")).toBeUndefined();
+    expect(wrapper.find("title").text()).toBe("Code");
   });
 
   it("size prop drives both width and height", () => {
     const wrapper = mount(ElmMdiIcon, {
-      props: { d: mdiCodeTags, size: "32px" },
+      props: { path: mdiCodeTags, size: 32 },
     });
     const svg = wrapper.find("svg");
-    expect(svg.attributes("width")).toBe("32px");
-    expect(svg.attributes("height")).toBe("32px");
+    expect(svg.attributes("width")).toBe("32");
+    expect(svg.attributes("height")).toBe("32");
   });
 
-  it("color prop feeds the svg fill and the scoped light color var", () => {
+  it("color prop sets the currentColor source", () => {
     const wrapper = mount(ElmMdiIcon, {
-      props: { d: mdiCodeTags, color: "#ff0000" },
+      props: {
+        path: mdiCodeTags,
+        color: "var(--elmethis-color-primary)",
+      },
     });
-    const svg = wrapper.find("svg").element as SVGElement;
-    expect(svg.getAttribute("fill")).toBe("#ff0000");
-    // Both scoped color variables fall back to `color`.
-    expect(svg.style.getPropertyValue("--elmethis-scoped-color-light")).toBe(
-      "#ff0000",
-    );
-    expect(svg.style.getPropertyValue("--elmethis-scoped-color-dark")).toBe(
-      "#ff0000",
-    );
+    const svg = wrapper.find("svg");
+    expect(svg.attributes("color")).toBe("var(--elmethis-color-primary)");
+    expect(svg.attributes("fill")).toBe("currentColor");
   });
 
-  it("lightColor / darkColor override the scoped color vars independently", () => {
+  it("uses native ARIA naming when provided", () => {
     const wrapper = mount(ElmMdiIcon, {
-      props: { d: mdiCodeTags, lightColor: "#111", darkColor: "#eee" },
+      props: { path: mdiCodeTags },
+      attrs: { "aria-label": "Code" },
     });
-    const svg = wrapper.find("svg").element as SVGElement;
-    expect(svg.style.getPropertyValue("--elmethis-scoped-color-light")).toBe(
-      "#111",
-    );
-    expect(svg.style.getPropertyValue("--elmethis-scoped-color-dark")).toBe(
-      "#eee",
-    );
+    const svg = wrapper.find("svg");
+    expect(svg.attributes("role")).toBe("img");
+    expect(svg.attributes("aria-hidden")).toBeUndefined();
   });
 
   it("merges a passthrough class onto the root", () => {
     const wrapper = mount(ElmMdiIcon, {
-      props: { d: mdiCodeTags },
+      props: { path: mdiCodeTags },
       attrs: { class: "custom-class" },
     });
     expect(wrapper.find("svg").classes()).toContain("custom-class");
@@ -63,14 +68,17 @@ describe("[CSR] ElmMdiIcon", () => {
 });
 
 describe("[SSR] ElmMdiIcon", () => {
-  it("renders the svg shell with the path", async () => {
+  it("renders the labeled svg shell with the path", async () => {
     const html = (
       await renderToString(
-        createSSRApp({ render: () => h(ElmMdiIcon, { d: mdiCodeTags }) }),
+        createSSRApp({
+          render: () => h(ElmMdiIcon, { path: mdiCodeTags, label: "Code" }),
+        }),
       )
     ).toLowerCase();
     expect(html).toContain("<svg");
     expect(html).toContain('role="img"');
+    expect(html).toContain("<title>code</title>");
     expect(html).toContain(`d="${mdiCodeTags.toLowerCase()}"`);
   });
 });

--- a/packages/vue/src/components/icon/elm-mdi-icon.stories.tsx
+++ b/packages/vue/src/components/icon/elm-mdi-icon.stories.tsx
@@ -10,8 +10,10 @@ const meta = {
   args: {},
   argTypes: {
     color: { control: "color" },
-    lightColor: { control: "color" },
-    darkColor: { control: "color" },
+    label: {
+      control: "text",
+      description: "Accessible label. Omit for decorative icons.",
+    },
   },
 } satisfies Meta<typeof ElmMdiIcon>;
 
@@ -21,6 +23,7 @@ type Story = StoryObj<typeof meta>;
 export const Primary: Story = {
   args: {
     size: "1.25rem",
-    d: mdiTag,
+    path: mdiTag,
+    label: "Tag",
   },
 };

--- a/packages/vue/src/components/icon/elm-mdi-icon.tsx
+++ b/packages/vue/src/components/icon/elm-mdi-icon.tsx
@@ -1,50 +1,38 @@
-import {
-  defineComponent,
-  type CSSProperties,
-  type SVGAttributes,
-  type StyleValue,
-} from "vue";
+import { defineComponent, type SVGAttributes, type StyleValue } from "vue";
 import { clsx } from "clsx";
 
 import styles from "./elm-mdi-icon.module.css";
 
-export interface ElmMdiIconProps extends SVGAttributes {
+export type ElmMdiIconProps = Omit<SVGAttributes, "children"> & {
   /**
-   * The SVG path data (the `d` attribute) — typically an `@mdi/js` icon.
+   * The SVG path data, typically imported from `@mdi/js`.
    */
-  d: string;
+  path: string;
 
   /**
    * The width/height of the icon (both axes). Defaults to `1em`.
    */
-  size?: string;
+  size?: string | number;
 
   /**
-   * The fill color. Seeds both the light and dark scoped color vars unless
-   * `lightColor` / `darkColor` override them.
+   * The CSS color used by the icon's `currentColor` fill.
    */
   color?: string;
 
   /**
-   * Overrides the fill in the light color scheme.
+   * The accessible label. Omit it for decorative icons.
    */
-  lightColor?: string;
-
-  /**
-   * Overrides the fill in the dark color scheme.
-   */
-  darkColor?: string;
-}
+  label?: string;
+};
 
 export const ElmMdiIcon = defineComponent({
   name: "ElmMdiIcon",
   inheritAttrs: false,
   props: {
-    d: { type: String, required: true },
-    size: { type: String, default: "1em" },
+    path: { type: String, required: true },
+    size: { type: [String, Number], default: "1em" },
     color: { type: String, default: undefined },
-    lightColor: { type: String, default: undefined },
-    darkColor: { type: String, default: undefined },
+    label: { type: String, default: undefined },
   },
   setup(props, { attrs }) {
     return () => {
@@ -53,32 +41,27 @@ export const ElmMdiIcon = defineComponent({
         style,
         ...rest
       } = attrs as Record<string, unknown>;
+      const hasAccessibleName = Boolean(
+        props.label || rest["aria-label"] || rest["aria-labelledby"],
+      );
 
       return (
         <svg
           class={clsx(styles["elm-mdi-icon"], className as string | undefined)}
-          style={
-            [
-              {
-                "--elmethis-scoped-color-light":
-                  props.lightColor ?? props.color,
-                "--elmethis-scoped-color-dark": props.darkColor ?? props.color,
-              } as CSSProperties,
-              // Incoming style wins over the scoped vars, matching the qwik/
-              // react spread order.
-              style as StyleValue,
-            ] as StyleValue
-          }
+          style={style as StyleValue}
           width={props.size}
           height={props.size}
           viewBox="0 0 24 24"
-          fill={props.color}
+          color={props.color}
+          fill="currentColor"
           xmlns="http://www.w3.org/2000/svg"
           focusable="false"
-          role="img"
+          aria-hidden={hasAccessibleName ? undefined : "true"}
+          role={hasAccessibleName ? "img" : undefined}
           {...rest}
         >
-          <path d={props.d} />
+          {props.label && <title>{props.label}</title>}
+          <path d={props.path} />
         </svg>
       );
     };

--- a/packages/vue/src/components/icon/elm-mdi-icon.tsx
+++ b/packages/vue/src/components/icon/elm-mdi-icon.tsx
@@ -20,8 +20,8 @@ export interface ElmMdiIconProps extends SVGAttributes {
   size?: string;
 
   /**
-   * The fill color. Defaults to `currentColor`. Seeds both the light and dark
-   * scoped color vars unless `lightColor` / `darkColor` override them.
+   * The fill color. Seeds both the light and dark scoped color vars unless
+   * `lightColor` / `darkColor` override them.
    */
   color?: string;
 
@@ -42,7 +42,7 @@ export const ElmMdiIcon = defineComponent({
   props: {
     d: { type: String, required: true },
     size: { type: String, default: "1em" },
-    color: { type: String, default: "currentColor" },
+    color: { type: String, default: undefined },
     lightColor: { type: String, default: undefined },
     darkColor: { type: String, default: undefined },
   },
@@ -60,8 +60,9 @@ export const ElmMdiIcon = defineComponent({
           style={
             [
               {
-                "--elmethis-scoped-color": props.lightColor ?? props.color,
-                "--dark-color": props.darkColor ?? props.color,
+                "--elmethis-scoped-color-light":
+                  props.lightColor ?? props.color,
+                "--elmethis-scoped-color-dark": props.darkColor ?? props.color,
               } as CSSProperties,
               // Incoming style wins over the scoped vars, matching the qwik/
               // react spread order.

--- a/packages/vue/src/components/icon/elm-toggle-theme.module.css
+++ b/packages/vue/src/components/icon/elm-toggle-theme.module.css
@@ -2,9 +2,14 @@
   display: block; /* Ensure it behaves like a block/inline-block */
   box-sizing: border-box;
   padding: 0.25rem;
-  color: light-dark(#555b67, #b0b5be);
+  color: var(--elmethis-color-neutral);
   border-radius: 50%;
   cursor: pointer;
-  box-shadow: 0 0 0.125rem light-dark(rgb(0 0 0 / 30%), rgb(0 0 0 / 60%));
-  background-color: light-dark(rgb(255 255 255 / 20%), rgb(0 0 0 / 20%));
+  box-shadow: 0 0 0.125rem var(--elmethis-box-shadow-color);
+  background-color: var(--elmethis-color-surface-raised);
+  transition: background-color 100ms;
+
+  &:hover {
+    background-color: var(--elmethis-color-surface-sunken);
+  }
 }

--- a/packages/vue/src/components/media/elm-audio-player.tsx
+++ b/packages/vue/src/components/media/elm-audio-player.tsx
@@ -304,7 +304,7 @@ export const ElmAudioPlayer = defineComponent({
             aria-hidden="true"
           >
             <ElmMdiIcon
-              d={hasError.value ? mdiAlertCircleOutline : mdiMusicNote}
+              path={hasError.value ? mdiAlertCircleOutline : mdiMusicNote}
               size="1.25rem"
             />
           </span>
@@ -327,7 +327,7 @@ export const ElmAudioPlayer = defineComponent({
 
         {hasError.value ? (
           <div class={styles["error-notice"]} role="alert">
-            <ElmMdiIcon d={mdiAlertCircleOutline} size="1.25rem" />
+            <ElmMdiIcon path={mdiAlertCircleOutline} size="1.25rem" />
             <span class={styles["error-message"]}>{props.errorMessage}</span>
           </div>
         ) : (
@@ -370,7 +370,7 @@ export const ElmAudioPlayer = defineComponent({
                   onClick={() => seekTo(currentTime.value - props.seekStep)}
                   aria-label={`Back ${props.seekStep} seconds`}
                 >
-                  <ElmMdiIcon d={mdiRewind10} size="1.25rem" />
+                  <ElmMdiIcon path={mdiRewind10} size="1.25rem" />
                 </button>
 
                 <button
@@ -381,7 +381,7 @@ export const ElmAudioPlayer = defineComponent({
                   aria-pressed={isPlaying.value}
                 >
                   <ElmMdiIcon
-                    d={isPlaying.value ? mdiPause : mdiPlay}
+                    path={isPlaying.value ? mdiPause : mdiPlay}
                     size="1.5rem"
                   />
                 </button>
@@ -392,7 +392,7 @@ export const ElmAudioPlayer = defineComponent({
                   onClick={() => seekTo(currentTime.value + props.seekStep)}
                   aria-label={`Forward ${props.seekStep} seconds`}
                 >
-                  <ElmMdiIcon d={mdiFastForward10} size="1.25rem" />
+                  <ElmMdiIcon path={mdiFastForward10} size="1.25rem" />
                 </button>
               </div>
 
@@ -404,7 +404,7 @@ export const ElmAudioPlayer = defineComponent({
                   aria-label={isMuted.value ? "Unmute" : "Mute"}
                   aria-pressed={isMuted.value}
                 >
-                  <ElmMdiIcon d={volumeIcon.value} size="1.25rem" />
+                  <ElmMdiIcon path={volumeIcon.value} size="1.25rem" />
                 </button>
                 <input
                   class={styles["volume-slider"]}

--- a/packages/vue/src/components/media/elm-block-image.module.css
+++ b/packages/vue/src/components/media/elm-block-image.module.css
@@ -24,7 +24,7 @@
   height: auto;
   object-fit: contain;
   border-radius: 0.25rem;
-  box-shadow: 0 0 0.125rem rgb(0 0 0 / 10%);
+  box-shadow: 0 0 0.125rem var(--elmethis-box-shadow-color);
   user-select: none;
   aspect-ratio: var(--aspect-ratio, auto);
   cursor: var(--elmethis-scoped-cursor);

--- a/packages/vue/src/components/media/elm-block-image.tsx
+++ b/packages/vue/src/components/media/elm-block-image.tsx
@@ -111,7 +111,7 @@ export const ElmBlockImage = defineComponent({
         {props.caption && (
           <figcaption class={styles["caption-box"]}>
             <span class={styles["caption-icon"]}>
-              <ElmMdiIcon d={mdiMessageImageOutline} size="1.25rem" />
+              <ElmMdiIcon path={mdiMessageImageOutline} size="1.25rem" />
             </span>
             <ElmInlineText size="1rem">{props.caption}</ElmInlineText>
           </figcaption>

--- a/packages/vue/src/components/media/elm-file.module.css
+++ b/packages/vue/src/components/media/elm-file.module.css
@@ -4,9 +4,9 @@
   grid-template-columns: 1.5rem 1fr 1fr 1.5rem;
   gap: 1rem;
   align-items: center;
-  box-shadow: 0 0 0.125rem rgb(0 0 0 / 20%);
+  box-shadow: 0 0 0.125rem var(--elmethis-box-shadow-color);
   border-radius: 0.25rem;
-  background-color: light-dark(rgb(255 255 255 / 20%), rgb(0 0 0 / 20%));
+  background-color: var(--elmethis-color-surface-raised);
 }
 
 .file-size {
@@ -28,6 +28,6 @@
     background-color 200ms;
 
   &:hover {
-    background-color: light-dark(rgb(0 0 0 / 10%), rgb(255 255 255 / 10%));
+    background-color: var(--elmethis-color-surface-sunken);
   }
 }

--- a/packages/vue/src/components/media/elm-file.tsx
+++ b/packages/vue/src/components/media/elm-file.tsx
@@ -65,7 +65,7 @@ export const ElmFile = defineComponent({
     return () => (
       <div class={clsx(styles["elm-file"])}>
         <div>
-          <ElmMdiIcon d={mdiFile} size="1.25rem" />
+          <ElmMdiIcon path={mdiFile} size="1.25rem" />
         </div>
 
         <div>
@@ -79,7 +79,7 @@ export const ElmFile = defineComponent({
         </div>
 
         <div class={styles["download-icon"]} onClick={downloadFile}>
-          <ElmMdiIcon d={mdiDownload} size="1.25rem" />
+          <ElmMdiIcon path={mdiDownload} size="1.25rem" />
         </div>
       </div>
     );

--- a/packages/vue/src/components/navigation/elm-bookmark.module.css
+++ b/packages/vue/src/components/navigation/elm-bookmark.module.css
@@ -3,19 +3,19 @@
   display: block;
   container-type: inline-size;
   border-radius: 0.25rem;
-  box-shadow: 0 0 0.125rem rgb(0 0 0 / 10%);
+  box-shadow: 0 0 0.125rem var(--elmethis-box-shadow-color);
   overflow: hidden;
+  background-color: var(--elmethis-color-surface-raised);
   transition:
     background-color 200ms,
     transform 200ms;
 
   &:hover {
-    background-color: rgb(105 135 184 / 10%);
-    transform: translateX(-0.125rem) translateY(-0.125rem);
+    background-color: var(--elmethis-color-surface-sunken);
+    transform: translateX(-2px) translateY(-2px);
   }
 
   &:active {
-    background-color: rgb(89 181 124 / 10%);
     transform: translateX(0) translateY(0);
   }
 }
@@ -61,8 +61,6 @@
   flex-direction: column;
   gap: 0.5rem;
   justify-content: space-between;
-  transition: background-color 200ms;
-  background-color: light-dark(rgb(255 255 255 / 40%), rgb(0 0 0 / 20%));
 
   @container (max-width: 700px) {
     width: 100%;

--- a/packages/vue/src/components/navigation/elm-bookmark.tsx
+++ b/packages/vue/src/components/navigation/elm-bookmark.tsx
@@ -90,7 +90,7 @@ export const ElmBookmark = defineComponent({
                 <ElmInlineIcon src={props.favicon} />
               ) : (
                 <ElmMdiIcon
-                  d={mdiLinkVariant}
+                  path={mdiLinkVariant}
                   color="var(--elmethis-color-accent-info)"
                 />
               )}

--- a/packages/vue/src/components/navigation/elm-breadcrumb.tsx
+++ b/packages/vue/src/components/navigation/elm-breadcrumb.tsx
@@ -40,7 +40,7 @@ export const ElmBreadcrumb = defineComponent({
             <span class={styles["link-container"]} onClick={link.onClick}>
               <ElmMdiIcon
                 class={styles.icon}
-                d={
+                path={
                   index === 0
                     ? mdiHome
                     : index === props.links.length - 1
@@ -56,7 +56,7 @@ export const ElmBreadcrumb = defineComponent({
             {props.links.length !== index + 1 && (
               <ElmMdiIcon
                 class={styles.chevron}
-                d={mdiChevronRight}
+                path={mdiChevronRight}
                 size="1rem"
               />
             )}

--- a/packages/vue/src/components/navigation/elm-page-top.module.css
+++ b/packages/vue/src/components/navigation/elm-page-top.module.css
@@ -57,7 +57,7 @@
       top: 0;
       height: 100%;
       width: 50%;
-      background-color: light-dark(#494f59, #bec2ca);
+      background-color: var(--elmethis-color-neutral);
     }
 
     &::before {
@@ -82,20 +82,7 @@
     font-size: 12px;
     white-space: nowrap;
     user-select: none;
-
-    /* From text.scoped.scss */
-    color: light-dark(
-      var(--elmethis-scoped-color, #606875),
-      var(--elmethis-scoped-color, #b0b5be)
-    );
-
-    &::selection {
-      color: light-dark(#cccfd5, #3e434b);
-      background-color: light-dark(
-        var(--elmethis-scoped-color, #3e434b),
-        var(--elmethis-scoped-color, #cccfd5)
-      );
-    }
+    color: var(--elmethis-color-neutral);
   }
 }
 

--- a/packages/vue/src/components/others/elm-color-primitive-sample.tsx
+++ b/packages/vue/src/components/others/elm-color-primitive-sample.tsx
@@ -106,7 +106,9 @@ export const ElmColorPrimitiveSample = defineComponent({
           >
             <ElmMdiIcon
               class={styles["mode-toggle-icon"]}
-              d={copyMode.value === "hex" ? mdiHexadecimal : mdiFormatColorFill}
+              path={
+                copyMode.value === "hex" ? mdiHexadecimal : mdiFormatColorFill
+              }
               size="1.25rem"
             />
             Copy: {copyMode.value === "hex" ? "hex value" : "variable name"}

--- a/packages/vue/src/components/others/elm-color-semantic-sample.tsx
+++ b/packages/vue/src/components/others/elm-color-semantic-sample.tsx
@@ -273,7 +273,9 @@ export const ElmColorSemanticSample = defineComponent({
           >
             <ElmMdiIcon
               class={styles["mode-toggle-icon"]}
-              d={copyMode.value === "hex" ? mdiHexadecimal : mdiFormatColorFill}
+              path={
+                copyMode.value === "hex" ? mdiHexadecimal : mdiFormatColorFill
+              }
               size="1.25rem"
             />
             Copy: {copyMode.value === "hex" ? "hex value" : "variable name"}

--- a/packages/vue/src/components/others/use-wordle.module.css
+++ b/packages/vue/src/components/others/use-wordle.module.css
@@ -24,14 +24,14 @@
     color 0.15s ease;
 
   &.error {
-    background-color: #1a1a1b;
-    color: #fff;
+    background-color: var(--elmethis-color-accent-error);
+    color: contrast-color(var(--elmethis-color-accent-error));
     animation: fade-in 0.15s ease;
   }
 
   &.status {
-    background-color: #538d4e;
-    color: #fff;
+    background-color: var(--elmethis-color-accent-success);
+    color: contrast-color(var(--elmethis-color-accent-success));
     font-size: 1rem;
     animation: fade-in 0.15s ease;
   }
@@ -66,33 +66,33 @@
     border-color 0.2s ease;
 
   &.empty {
-    border-color: gray;
+    border-color: var(--elmethis-color-neutral-weak);
     background-color: transparent;
     color: transparent;
   }
 
   &.tbd {
-    border-color: #565758;
+    border-color: var(--elmethis-color-neutral);
     background-color: transparent;
-    color: #6c7483;
+    color: var(--elmethis-color-neutral);
   }
 
   &.correct {
-    background-color: #538d4e;
-    border-color: #538d4e;
-    color: #fff;
+    background-color: var(--elmethis-color-accent-success);
+    border-color: var(--elmethis-color-accent-success);
+    color: contrast-color(var(--elmethis-color-accent-success));
   }
 
   &.present {
-    background-color: #b59f3b;
-    border-color: #b59f3b;
-    color: #fff;
+    background-color: var(--elmethis-color-accent-warning);
+    border-color: var(--elmethis-color-accent-warning);
+    color: contrast-color(var(--elmethis-color-accent-warning));
   }
 
   &.absent {
-    background-color: #3a3a3c;
-    border-color: #3a3a3c;
-    color: #fff;
+    background-color: var(--elmethis-color-surface-sunken);
+    border-color: var(--elmethis-color-surface-sunken);
+    color: contrast-color(var(--elmethis-color-surface-sunken));
   }
 }
 
@@ -117,8 +117,8 @@
   padding: 0 0.25rem;
   border: none;
   border-radius: 0.25rem;
-  background-color: #818384;
-  color: #fff;
+  background-color: var(--elmethis-color-neutral);
+  color: contrast-color(var(--elmethis-color-neutral));
   font-size: 0.8125rem;
   font-weight: bold;
   cursor: pointer;
@@ -140,15 +140,18 @@
   }
 
   &.correct {
-    background-color: #538d4e;
+    background-color: var(--elmethis-color-accent-success);
+    color: contrast-color(var(--elmethis-color-accent-success));
   }
 
   &.present {
-    background-color: #b59f3b;
+    background-color: var(--elmethis-color-accent-warning);
+    color: contrast-color(var(--elmethis-color-accent-warning));
   }
 
   &.absent {
-    background-color: #3a3a3c;
+    background-color: var(--elmethis-color-surface-sunken);
+    color: contrast-color(var(--elmethis-color-surface-sunken));
   }
 }
 
@@ -165,8 +168,8 @@
   padding: 0.625rem 1.5rem;
   border: none;
   border-radius: 0.25rem;
-  background-color: #538d4e;
-  color: #fff;
+  background-color: var(--elmethis-color-accent-success);
+  color: contrast-color(var(--elmethis-color-accent-success));
   font-size: 1rem;
   font-weight: bold;
   cursor: pointer;
@@ -175,7 +178,9 @@
     transform 0.05s ease;
 
   &:hover {
-    background-color: #6aaa64;
+    background-color: oklch(
+      from var(--elmethis-color-accent-success) calc(l + 0.08) c h
+    );
   }
 
   &:active {

--- a/packages/vue/src/components/table/elm-table.module.css
+++ b/packages/vue/src/components/table/elm-table.module.css
@@ -61,7 +61,7 @@
 .elm-table {
   border-collapse: collapse;
   border-spacing: 0;
-  box-shadow: 0 0 0.125rem rgb(0 0 0 / 20%);
+  box-shadow: 0 0 0.125rem var(--elmethis-box-shadow-color);
 }
 
 .caption {
@@ -84,7 +84,7 @@
 .spacing {
   flex-grow: 1;
   height: 1px;
-  background-color: rgb(128 128 128 / 20%);
+  background-color: var(--elmethis-color-divider);
 }
 
 /* Sticky label column. When the first column holds row headers, pin it so the

--- a/packages/vue/src/components/typography/elm-block-quote.tsx
+++ b/packages/vue/src/components/typography/elm-block-quote.tsx
@@ -15,13 +15,13 @@ export const ElmBlockQuote = defineComponent({
     return () => (
       <blockquote class={clsx(styles["elm-block-quote"], textStyles.text)}>
         <div class={clsx(styles.icon, styles["icon-top-left"])}>
-          <ElmMdiIcon d={mdiFormatQuoteOpen} />
+          <ElmMdiIcon path={mdiFormatQuoteOpen} />
         </div>
 
         <div class={styles.body}>{slots.default?.()}</div>
 
         <div class={clsx(styles.icon, styles["icon-bottom-right"])}>
-          <ElmMdiIcon d={mdiFormatQuoteClose} />
+          <ElmMdiIcon path={mdiFormatQuoteClose} />
         </div>
       </blockquote>
     );

--- a/packages/vue/src/components/typography/elm-callout.tsx
+++ b/packages/vue/src/components/typography/elm-callout.tsx
@@ -40,7 +40,7 @@ export const ElmCallout = defineComponent({
         <div class={styles.header}>
           <ElmMdiIcon
             class={styles.icon}
-            d={ICON_MAP[props.type]}
+            path={ICON_MAP[props.type]}
             size="1.25rem"
           />
           <span>{props.type}</span>

--- a/packages/vue/src/components/typography/elm-inline-text.module.css
+++ b/packages/vue/src/components/typography/elm-inline-text.module.css
@@ -72,7 +72,7 @@
     opacity 200ms;
 
   &:hover {
-    background-color: oklch(from #6987b8 l c h / 20%);
+    background-color: var(--elmethis-color-accent-link-surface);
   }
 
   &:active {

--- a/packages/vue/src/hooks/use-clipboard.tsx
+++ b/packages/vue/src/hooks/use-clipboard.tsx
@@ -70,7 +70,7 @@ export const useClipboard = (
         >
           <ElmMdiIcon
             class={clsx(copied.value && styles["use-clipboard-icon-copied"])}
-            d={copied.value ? mdiClipboardCheckOutline : mdiClipboardOutline}
+            path={copied.value ? mdiClipboardCheckOutline : mdiClipboardOutline}
             size="1.25rem"
           />
         </span>

--- a/packages/vue/stylelint.config.mjs
+++ b/packages/vue/stylelint.config.mjs
@@ -10,6 +10,31 @@ export default {
   extends: ["stylelint-config-standard", "stylelint-config-css-modules"],
   plugins: ["stylelint-value-no-unknown-custom-properties"],
   rules: {
+    "color-no-hex": [
+      true,
+      {
+        message: "Use an Elmethis color token instead of a hex color",
+        severity: "warning",
+      },
+    ],
+    "color-named": [
+      "never",
+      {
+        message: "Use an Elmethis color token instead of a named color",
+        severity: "warning",
+      },
+    ],
+    "declaration-property-value-disallowed-list": [
+      {
+        "/.*/": [
+          "/(?<![-\\w])(?:rgb|rgba|hsl|hsla|hwb|lab|lch|oklab|oklch|color)\\((?!\\s*from\\b)/i",
+        ],
+      },
+      {
+        message: "Use an Elmethis color token instead of a color function",
+        severity: "warning",
+      },
+    ],
     "csstools/value-no-unknown-custom-properties": [
       true,
       {
@@ -33,5 +58,7 @@ export default {
     "lib-types/**",
     "storybook-static/**",
     "node_modules/**",
+    "./src/components/others/elm-color-primitive-sample.module.css",
+    "./src/components/others/elm-color-semantic-sample.module.css",
   ],
 };


### PR DESCRIPTION
## Summary

- add divider, selection, modal backdrop, and accent-link surface semantic tokens
- enforce Elmethis color-token usage through Stylelint across Qwik, React, Solid, and Vue
- replace direct colors and color functions with semantic tokens throughout framework components
- simplify `ElmMdiIcon` around `path`, `currentColor`, numeric or CSS sizes, and accessible labeling
- update framework package versions for the breaking release

## Breaking changes

- rename `ElmMdiIcon.d` to `path`
- remove `lightColor` and `darkColor`; use adaptive semantic tokens through `color`
- make unlabeled icons decorative by default and expose labeled icons with `role="img"` and an SVG title

## Testing

- framework `check` commands for Qwik, React, Solid, and Vue
- unit and SSR suites: 1,933 tests passed
- Chromium browser suites: 320 tests passed
- framework style self-containment verification
- `git diff --check`