### PR TITLE
chore: consolidate package CI checks

### DIFF
--- a/.github/workflows/ag-ui-stub.yml
+++ b/.github/workflows/ag-ui-stub.yml
@@ -11,8 +11,8 @@ env:
   NODE_VERSION: 22.x
 
 jobs:
-  lint:
-    name: Lint (@elmethis/ag-ui-stub)
+  check:
+    name: Check (@elmethis/ag-ui-stub)
     runs-on: ubuntu-latest
 
     steps:
@@ -33,112 +33,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Lint
-        run: pnpm run lint
-        working-directory: packages/ag-ui-stub
-
-  format-check:
-    name: Format Check (@elmethis/ag-ui-stub)
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          registry-url: "https://registry.npmjs.org"
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Format Check
-        run: pnpm run fmt.check
-        working-directory: packages/ag-ui-stub
-
-  type-check:
-    name: Type Check (@elmethis/ag-ui-stub)
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          registry-url: "https://registry.npmjs.org"
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Type Check
-        run: pnpm run build.types
-        working-directory: packages/ag-ui-stub
-
-  build:
-    name: Build (@elmethis/ag-ui-stub)
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          registry-url: "https://registry.npmjs.org"
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Build
-        run: pnpm run build
-        working-directory: packages/ag-ui-stub
-
-  test-unit:
-    name: Test Unit (@elmethis/ag-ui-stub)
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          registry-url: "https://registry.npmjs.org"
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Test Unit (with coverage)
-        run: pnpm run test.coverage
+      - name: Check
+        run: pnpm run check.ci
         working-directory: packages/ag-ui-stub
 
       # Visibility only — never fails the build.

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -11,8 +11,8 @@ env:
   NODE_VERSION: 22.x
 
 jobs:
-  lint:
-    name: Lint (@elmethis/core)
+  check:
+    name: Check (@elmethis/core)
     runs-on: ubuntu-latest
 
     steps:
@@ -33,86 +33,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Lint
-        run: pnpm run lint
-        working-directory: packages/core
-
-  format-check:
-    name: Format Check (@elmethis/core)
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          registry-url: "https://registry.npmjs.org"
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Format Check
-        run: pnpm run fmt.check
-        working-directory: packages/core
-
-  build:
-    name: Build (@elmethis/core)
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          registry-url: "https://registry.npmjs.org"
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Build
-        run: pnpm run build
-        working-directory: packages/core
-
-  test-unit:
-    name: Test Unit (@elmethis/core)
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          registry-url: "https://registry.npmjs.org"
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Test Unit (with coverage)
-        run: pnpm run test.coverage
+      - name: Check
+        run: pnpm run check.ci
         working-directory: packages/core
 
       # Visibility only — never fails the build.

--- a/.github/workflows/ikuma-theme.yml
+++ b/.github/workflows/ikuma-theme.yml
@@ -34,5 +34,5 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Check
-        run: pnpm run check
+        run: pnpm run check.ci
         working-directory: packages/ikuma-theme

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -11,198 +11,8 @@ env:
   NODE_VERSION: 22.x
 
 jobs:
-  lint:
-    name: Lint (@elmethis/react)
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          registry-url: "https://registry.npmjs.org"
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Build @elmethis/core
-        run: pnpm run build
-        working-directory: packages/core
-
-      - name: Lint
-        run: pnpm run lint
-        working-directory: packages/react
-
-  lint-css:
-    name: Lint CSS (@elmethis/react)
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          registry-url: "https://registry.npmjs.org"
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Build @elmethis/core
-        run: pnpm run build
-        working-directory: packages/core
-
-      - name: Lint CSS
-        run: pnpm run lint.css
-        working-directory: packages/react
-
-  format-check:
-    name: Format Check (@elmethis/react)
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          registry-url: "https://registry.npmjs.org"
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Format Check
-        run: pnpm run fmt.check
-        working-directory: packages/react
-
-  build:
-    name: Build (@elmethis/react)
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          registry-url: "https://registry.npmjs.org"
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Build @elmethis/core
-        run: pnpm run build
-        working-directory: packages/core
-
-      - name: Build
-        run: pnpm run build
-        working-directory: packages/react
-
-      - name: Test style artifact
-        run: pnpm run test.style
-        working-directory: packages/react
-
-  build-storybook:
-    name: Build Storybook (@elmethis/react)
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          registry-url: "https://registry.npmjs.org"
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Build @elmethis/core
-        run: pnpm run build
-        working-directory: packages/core
-
-      - name: Build Storybook
-        run: pnpm run build-storybook
-        working-directory: packages/react
-
-  test-unit:
-    name: Test Unit (@elmethis/react)
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          registry-url: "https://registry.npmjs.org"
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Build @elmethis/core
-        run: pnpm run build
-        working-directory: packages/core
-
-      - name: Test Unit (with coverage)
-        run: pnpm run test.coverage
-        working-directory: packages/react
-
-      # Visibility only — never fails the build. Merged with the browser layer
-      # server-side via the react-unit / react-browser Codecov flags.
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: packages/react/coverage/lcov.info
-          flags: react-unit
-          fail_ci_if_error: false
-
-  test-browser:
-    name: Test Browser (@elmethis/react)
+  check:
+    name: Check (@elmethis/react)
     runs-on: ubuntu-latest
 
     steps:
@@ -231,15 +41,23 @@ jobs:
         run: pnpm run build
         working-directory: packages/core
 
-      - name: Test Browser (with coverage)
-        run: pnpm run test.coverage.browser
+      - name: Check
+        run: pnpm run check.ci
         working-directory: packages/react
 
-      # Uploaded under the react-browser flag; Codecov merges it with react-unit.
-      - name: Upload coverage to Codecov
+      # Visibility only - never fails the build. Codecov merges both flags.
+      - name: Upload unit coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: packages/react/coverage/lcov.info
+          flags: react-unit
+          fail_ci_if_error: false
+
+      - name: Upload browser coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: packages/react/coverage/browser/lcov.info
           flags: react-browser
           fail_ci_if_error: false

--- a/.github/workflows/solid.yml
+++ b/.github/workflows/solid.yml
@@ -11,204 +11,8 @@ env:
   NODE_VERSION: 22.x
 
 jobs:
-  lint:
-    name: Lint (@elmethis/solid)
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          registry-url: "https://registry.npmjs.org"
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Build @elmethis/core
-        run: pnpm run build
-        working-directory: packages/core
-
-      - name: Lint
-        run: pnpm run lint
-        working-directory: packages/solid
-
-  lint-css:
-    name: Lint CSS (@elmethis/solid)
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          registry-url: "https://registry.npmjs.org"
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Build @elmethis/core
-        run: pnpm run build
-        working-directory: packages/core
-
-      - name: Lint CSS
-        run: pnpm run lint.css
-        working-directory: packages/solid
-
-  format-check:
-    name: Format Check (@elmethis/solid)
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          registry-url: "https://registry.npmjs.org"
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Format Check
-        run: pnpm run fmt.check
-        working-directory: packages/solid
-
-  build:
-    name: Build (@elmethis/solid)
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          registry-url: "https://registry.npmjs.org"
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Build @elmethis/core
-        run: pnpm run build
-        working-directory: packages/core
-
-      - name: Build
-        run: pnpm run build
-        working-directory: packages/solid
-
-      - name: Test package exports
-        run: pnpm run test.package
-        working-directory: packages/solid
-
-  build-storybook:
-    name: Build Storybook (@elmethis/solid)
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          registry-url: "https://registry.npmjs.org"
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Build @elmethis/core
-        run: pnpm run build
-        working-directory: packages/core
-
-      - name: Build @elmethis/ag-ui-stub
-        run: pnpm run build
-        working-directory: packages/ag-ui-stub
-
-      - name: Build Storybook
-        run: pnpm run build-storybook
-        working-directory: packages/solid
-
-  test-unit:
-    name: Test Unit (@elmethis/solid)
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          registry-url: "https://registry.npmjs.org"
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Build @elmethis/core
-        run: pnpm run build
-        working-directory: packages/core
-
-      - name: Build @elmethis/ag-ui-stub
-        run: pnpm run build
-        working-directory: packages/ag-ui-stub
-
-      - name: Test Unit (with coverage)
-        run: pnpm run test.coverage
-        working-directory: packages/solid
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: packages/solid/coverage/lcov.info
-          flags: solid-unit
-          fail_ci_if_error: false
-
-  test-browser:
-    name: Test Browser (@elmethis/solid)
+  check:
+    name: Check (@elmethis/solid)
     runs-on: ubuntu-latest
 
     steps:
@@ -241,14 +45,23 @@ jobs:
         run: pnpm run build
         working-directory: packages/ag-ui-stub
 
-      - name: Test Browser (with coverage)
-        run: pnpm run test.coverage.browser
+      - name: Check
+        run: pnpm run check.ci
         working-directory: packages/solid
 
-      - name: Upload coverage to Codecov
+      # Visibility only - never fails the build. Codecov merges both flags.
+      - name: Upload unit coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: packages/solid/coverage/lcov.info
+          flags: solid-unit
+          fail_ci_if_error: false
+
+      - name: Upload browser coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: packages/solid/coverage/browser/lcov.info
           flags: solid-browser
           fail_ci_if_error: false

--- a/.github/workflows/vue.yml
+++ b/.github/workflows/vue.yml
@@ -11,198 +11,8 @@ env:
   NODE_VERSION: 22.x
 
 jobs:
-  lint:
-    name: Lint (@elmethis/vue)
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          registry-url: "https://registry.npmjs.org"
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Build @elmethis/core
-        run: pnpm run build
-        working-directory: packages/core
-
-      - name: Lint
-        run: pnpm run lint
-        working-directory: packages/vue
-
-  lint-css:
-    name: Lint CSS (@elmethis/vue)
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          registry-url: "https://registry.npmjs.org"
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Build @elmethis/core
-        run: pnpm run build
-        working-directory: packages/core
-
-      - name: Lint CSS
-        run: pnpm run lint.css
-        working-directory: packages/vue
-
-  format-check:
-    name: Format Check (@elmethis/vue)
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          registry-url: "https://registry.npmjs.org"
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Format Check
-        run: pnpm run fmt.check
-        working-directory: packages/vue
-
-  build:
-    name: Build (@elmethis/vue)
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          registry-url: "https://registry.npmjs.org"
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Build @elmethis/core
-        run: pnpm run build
-        working-directory: packages/core
-
-      - name: Build
-        run: pnpm run build
-        working-directory: packages/vue
-
-      - name: Test style artifact
-        run: pnpm run test.style
-        working-directory: packages/vue
-
-  build-storybook:
-    name: Build Storybook (@elmethis/vue)
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          registry-url: "https://registry.npmjs.org"
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Build @elmethis/core
-        run: pnpm run build
-        working-directory: packages/core
-
-      - name: Build Storybook
-        run: pnpm run build-storybook
-        working-directory: packages/vue
-
-  test-unit:
-    name: Test Unit (@elmethis/vue)
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          registry-url: "https://registry.npmjs.org"
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Build @elmethis/core
-        run: pnpm run build
-        working-directory: packages/core
-
-      - name: Test Unit (with coverage)
-        run: pnpm run test.coverage
-        working-directory: packages/vue
-
-      # Visibility only — never fails the build. Merged with the browser layer
-      # server-side via the vue-unit / vue-browser Codecov flags.
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: packages/vue/coverage/lcov.info
-          flags: vue-unit
-          fail_ci_if_error: false
-
-  test-browser:
-    name: Test Browser (@elmethis/vue)
+  check:
+    name: Check (@elmethis/vue)
     runs-on: ubuntu-latest
 
     steps:
@@ -231,15 +41,23 @@ jobs:
         run: pnpm run build
         working-directory: packages/core
 
-      - name: Test Browser (with coverage)
-        run: pnpm run test.coverage.browser
+      - name: Check
+        run: pnpm run check.ci
         working-directory: packages/vue
 
-      # Uploaded under the vue-browser flag; Codecov merges it with vue-unit.
-      - name: Upload coverage to Codecov
+      # Visibility only - never fails the build. Codecov merges both flags.
+      - name: Upload unit coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: packages/vue/coverage/lcov.info
+          flags: vue-unit
+          fail_ci_if_error: false
+
+      - name: Upload browser coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: packages/vue/coverage/browser/lcov.info
           flags: vue-browser
           fail_ci_if_error: false

--- a/packages/ag-ui-stub/package.json
+++ b/packages/ag-ui-stub/package.json
@@ -42,7 +42,7 @@
     "test.unit": "vitest --run",
     "test.coverage": "vitest --run --coverage",
     "check": "concurrently -g \"pnpm:fmt.check\" \"pnpm:lint\" \"pnpm:build.types\"",
-    "check.ci": "concurrently -g \"pnpm:check\" \"pnpm:build\" \"pnpm:test.unit\""
+    "check.ci": "pnpm run check && pnpm run build && pnpm run test.coverage"
   },
   "dependencies": {
     "@ag-ui/client": "0.0.57",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -46,7 +46,7 @@
     "test.coverage": "vitest --run --coverage",
     "prepublishOnly": "pnpm run build",
     "check": "concurrently -g \"pnpm:fmt.check\" \"pnpm:lint\" \"pnpm:build.types\"",
-    "check.ci": "concurrently -g \"pnpm:check\" \"pnpm:build\" \"pnpm:test.unit\""
+    "check.ci": "pnpm run check && pnpm run build && pnpm run test.coverage"
   },
   "peerDependencies": {
     "@a2ui/web_core": ">=0.10.0",

--- a/packages/ikuma-theme/package.json
+++ b/packages/ikuma-theme/package.json
@@ -29,6 +29,7 @@
     "fmt": "prettier --write ./scripts",
     "fmt.check": "prettier --check ./scripts",
     "check": "pnpm run fmt.check && pnpm run build.types && pnpm run build",
+    "check.ci": "pnpm run check",
     "prepublish:npm": "pnpm run build:npm",
     "publish:npm": "pnpm publish dist/npm",
     "dev": "node --watch --watch-path=scripts scripts/index.ts"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -55,7 +55,7 @@
     "test.style": "node ../../scripts/verify-framework-style.mjs .",
     "test.build": "pnpm run build && pnpm run build-storybook",
     "check": "concurrently -g \"pnpm:fmt.check\" \"pnpm:lint\" \"pnpm:lint.css\" \"pnpm:build.types\"",
-    "check.ci": "concurrently -g \"pnpm:check\" \"pnpm:test.build\" \"pnpm:test.unit\" \"pnpm:test.browser\"",
+    "check.ci": "pnpm run check && pnpm run test.build && pnpm run test.style && pnpm run test.coverage && pnpm run test.coverage.browser",
     "prepublishOnly": "pnpm run build"
   },
   "peerDependencies": {

--- a/packages/react/vitest.browser.config.ts
+++ b/packages/react/vitest.browser.config.ts
@@ -29,7 +29,7 @@ export default defineConfig({
         "src/index.ts",
       ],
       reporter: ["text", "html", "lcov"],
-      reportsDirectory: "coverage",
+      reportsDirectory: "coverage/browser",
     },
     browser: {
       enabled: true,

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -64,7 +64,7 @@
     "test.package": "node scripts/test-package.mjs",
     "test.build": "pnpm run build && pnpm run build-storybook",
     "check": "concurrently -g \"pnpm:fmt.check\" \"pnpm:lint\" \"pnpm:lint.css\" \"pnpm:build.types\"",
-    "check.ci": "concurrently -g \"pnpm:check\" \"pnpm:test.build\" \"pnpm:test.unit\" \"pnpm:test.browser\"",
+    "check.ci": "pnpm run check && pnpm run test.build && pnpm run test.package && pnpm run test.coverage && pnpm run test.coverage.browser",
     "prepublishOnly": "pnpm run build"
   },
   "peerDependencies": {

--- a/packages/solid/vitest.browser.config.ts
+++ b/packages/solid/vitest.browser.config.ts
@@ -28,7 +28,7 @@ export default defineConfig({
         "src/index.ts",
       ],
       reporter: ["text", "html", "lcov"],
-      reportsDirectory: "coverage",
+      reportsDirectory: "coverage/browser",
     },
     browser: {
       enabled: true,

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -60,7 +60,7 @@
     "test.style": "node ../../scripts/verify-framework-style.mjs .",
     "test.build": "pnpm run build && pnpm run build-storybook",
     "check": "concurrently -g \"pnpm:fmt.check\" \"pnpm:lint\" \"pnpm:lint.css\" \"pnpm:build.types\"",
-    "check.ci": "concurrently -g \"pnpm:check\" \"pnpm:test.build\" \"pnpm:test.unit\" \"pnpm:test.browser\"",
+    "check.ci": "pnpm run check && pnpm run test.build && pnpm run test.style && pnpm run test.coverage && pnpm run test.coverage.browser",
     "prepublishOnly": "pnpm run build"
   },
   "peerDependencies": {

--- a/packages/vue/vitest.browser.config.ts
+++ b/packages/vue/vitest.browser.config.ts
@@ -36,7 +36,7 @@ export default defineConfig({
         "src/index.ts",
       ],
       reporter: ["text", "html", "lcov"],
-      reportsDirectory: "coverage",
+      reportsDirectory: "coverage/browser",
     },
     browser: {
       enabled: true,


### PR DESCRIPTION
## Summary
- consolidate each package workflow into one `check.ci` job
- make package-level `check.ci` scripts cover builds, artifact checks, and coverage tests
- keep unit and browser Codecov reports separate in consolidated framework jobs

## Validation
- `pnpm run check.ci` in core, AG-UI Stub, React, Solid, Vue, and Ikuma Theme
- Prettier validation for changed workflows, manifests, and Vitest configs
- `git diff --check`