### PR TITLE
refactor: standardize box shadow tokens

### DIFF
--- a/packages/core/src/style/token-vars.spec.ts
+++ b/packages/core/src/style/token-vars.spec.ts
@@ -28,6 +28,15 @@ describe("tokenVars", () => {
   it("prefixes the flat semantic key with --elmethis-", () => {
     expect(tokenVars["--elmethis-color-accent-link-visited"]).toBeDefined();
     expect(tokenVars["--elmethis-stack-gap"]).toBe("2rem");
+    expect(tokenVars["--elmethis-box-shadow-small"]).toBe(
+      "0 0 1px var(--elmethis-color-box-shadow)",
+    );
+    expect(tokenVars["--elmethis-box-shadow-medium"]).toBe(
+      "0 0 2px var(--elmethis-color-box-shadow)",
+    );
+    expect(tokenVars["--elmethis-box-shadow-large"]).toBe(
+      "0 0 4px var(--elmethis-color-box-shadow)",
+    );
   });
 
   it("emits the font-family stacks (DM Sans / DM Mono primary)", () => {

--- a/packages/core/src/style/token.ts
+++ b/packages/core/src/style/token.ts
@@ -137,6 +137,10 @@ export const semanticTokens = {
    */
   "stack-gap": common("2rem"),
 
+  "box-shadow-small": common("0 0 1px var(--elmethis-color-box-shadow)"),
+  "box-shadow-medium": common("0 0 2px var(--elmethis-color-box-shadow)"),
+  "box-shadow-large": common("0 0 4px var(--elmethis-color-box-shadow)"),
+
   "font-family-sans": common(font.family.sans),
   "font-family-monospace": common(font.family.monospace),
 

--- a/packages/react/src/components/code/elm-code-block.module.css
+++ b/packages/react/src/components/code/elm-code-block.module.css
@@ -10,7 +10,7 @@
   padding: 0.25rem;
   border-radius: 0.25rem;
   background-color: var(--elmethis-color-surface-raised);
-  box-shadow: 0 0 0.125rem var(--elmethis-color-box-shadow);
+  box-shadow: var(--elmethis-box-shadow-medium);
 }
 
 .language-icon {

--- a/packages/react/src/components/code/elm-html-viewer.module.css
+++ b/packages/react/src/components/code/elm-html-viewer.module.css
@@ -9,7 +9,7 @@
   padding: 0.25rem;
   border-radius: 0.25rem;
   background-color: var(--elmethis-color-surface-raised);
-  box-shadow: 0 0 0.125rem var(--elmethis-color-box-shadow);
+  box-shadow: var(--elmethis-box-shadow-medium);
 }
 
 .header {

--- a/packages/react/src/components/containments/elm-tabs.module.css
+++ b/packages/react/src/components/containments/elm-tabs.module.css
@@ -5,7 +5,7 @@
   width: 100%;
   border: solid 1px oklch(from var(--elmethis-color-primary) l c h / 10%);
   border-radius: 0.25rem;
-  box-shadow: 0 0 0.125rem var(--elmethis-color-box-shadow);
+  box-shadow: var(--elmethis-box-shadow-medium);
   overflow: hidden;
   background-color: var(--elmethis-color-surface-raised);
 }

--- a/packages/react/src/components/form/elm-button-dropdown.module.css
+++ b/packages/react/src/components/form/elm-button-dropdown.module.css
@@ -46,7 +46,7 @@
     min-width: 100%;
     border-radius: 0.25rem;
     background-color: var(--elmethis-color-surface-raised);
-    box-shadow: 0 0 0.125rem var(--elmethis-color-box-shadow);
+    box-shadow: var(--elmethis-box-shadow-medium);
 
     .item {
       overflow: hidden;

--- a/packages/react/src/components/form/elm-button.module.css
+++ b/packages/react/src/components/form/elm-button.module.css
@@ -16,7 +16,7 @@
     opacity 200ms,
     transform 200ms;
   opacity: var(--elmethis-scoped-opacity);
-  box-shadow: 0 0 0.125rem var(--elmethis-color-box-shadow);
+  box-shadow: var(--elmethis-box-shadow-medium);
 }
 
 .normal {
@@ -46,13 +46,13 @@
   &:hover {
     transform: translateX(-1px) translateY(-1px);
     opacity: var(--elmethis-scoped-opacity, 0.7);
-    box-shadow: 0.125rem 0.125rem 0.125rem var(--elmethis-color-box-shadow);
+    box-shadow: var(--elmethis-box-shadow-medium);
   }
 
   &:active {
     transform: translateX(1px) translateY(1px);
     opacity: var(--elmethis-scoped-opacity, 0.5);
-    box-shadow: -1px -1px 0.125rem var(--elmethis-color-box-shadow);
+    box-shadow: var(--elmethis-box-shadow-medium);
   }
 }
 

--- a/packages/react/src/components/form/elm-select.module.css
+++ b/packages/react/src/components/form/elm-select.module.css
@@ -17,7 +17,7 @@
     border-color 200ms,
     background-color 200ms;
   background-color: var(--elmethis-color-surface-raised);
-  box-shadow: 0 0 0.125rem var(--elmethis-color-box-shadow);
+  box-shadow: var(--elmethis-box-shadow-medium);
   cursor: pointer;
 
   &.disabled {
@@ -81,7 +81,7 @@
       padding: 0;
       border-radius: 0.25rem;
       background-color: var(--elmethis-color-surface-raised);
-      box-shadow: 0 0 0.125rem var(--elmethis-color-box-shadow);
+      box-shadow: var(--elmethis-box-shadow-medium);
 
       .option {
         overflow: hidden;

--- a/packages/react/src/components/form/elm-slider.module.css
+++ b/packages/react/src/components/form/elm-slider.module.css
@@ -134,7 +134,7 @@
   height: 0.875rem;
   border-radius: 50%;
   background-color: var(--elmethis-color-primary-strong);
-  box-shadow: 0 0.125rem 0.375rem -0.0625rem var(--elmethis-color-box-shadow);
+  box-shadow: var(--elmethis-box-shadow-medium);
   transform: translate(-50%, -50%);
   transition: transform 140ms cubic-bezier(0.34, 1.56, 0.64, 1);
   pointer-events: none;

--- a/packages/react/src/components/form/elm-switch.module.css
+++ b/packages/react/src/components/form/elm-switch.module.css
@@ -12,7 +12,7 @@
   );
   position: relative;
   cursor: pointer;
-  box-shadow: 0 0 2px var(--elmethis-color-box-shadow);
+  box-shadow: var(--elmethis-box-shadow-medium);
   transition:
     opacity 300ms,
     background-color 300ms;

--- a/packages/react/src/components/form/elm-text-area.module.css
+++ b/packages/react/src/components/form/elm-text-area.module.css
@@ -54,7 +54,7 @@
   border-width: 1px;
   border-color: transparent;
   background-color: var(--elmethis-color-surface-raised);
-  box-shadow: 0 0 0.125rem var(--elmethis-color-box-shadow);
+  box-shadow: var(--elmethis-box-shadow-medium);
 
   &.disabled {
     background-color: var(--elmethis-color-surface-sunken);

--- a/packages/react/src/components/form/elm-text-field.module.css
+++ b/packages/react/src/components/form/elm-text-field.module.css
@@ -54,7 +54,7 @@
   border-width: 1px;
   border-color: transparent;
   background-color: var(--elmethis-color-surface-raised);
-  box-shadow: 0 0 0.125rem var(--elmethis-color-box-shadow);
+  box-shadow: var(--elmethis-box-shadow-medium);
 
   &.disabled {
     background-color: var(--elmethis-color-surface-sunken);

--- a/packages/react/src/components/icon/elm-toggle-theme.module.css
+++ b/packages/react/src/components/icon/elm-toggle-theme.module.css
@@ -5,7 +5,7 @@
   color: var(--elmethis-color-neutral);
   border-radius: 50%;
   cursor: pointer;
-  box-shadow: 0 0 0.125rem var(--elmethis-color-box-shadow);
+  box-shadow: var(--elmethis-box-shadow-medium);
   background-color: var(--elmethis-color-surface-raised);
   transition: background-color 100ms;
 

--- a/packages/react/src/components/media/elm-audio-player.module.css
+++ b/packages/react/src/components/media/elm-audio-player.module.css
@@ -55,7 +55,7 @@
     var(--elmethis-color-primary-strong),
     var(--elmethis-color-primary)
   );
-  box-shadow: 0 0.25rem 0.5rem -0.25rem var(--elmethis-color-box-shadow);
+  box-shadow: var(--elmethis-box-shadow-medium);
 }
 
 /* Error: the artwork tile turns into a red alert badge. */
@@ -181,7 +181,7 @@
 }
 
 .playing .fill {
-  box-shadow: 0 0 0.375rem 0 var(--elmethis-color-primary);
+  box-shadow: var(--elmethis-box-shadow-medium);
 }
 
 /* Draggable handle, parked at the play position. */
@@ -193,7 +193,7 @@
   height: 0.75rem;
   border-radius: 50%;
   background-color: var(--elmethis-color-primary-strong);
-  box-shadow: 0 0.125rem 0.375rem -0.0625rem var(--elmethis-color-box-shadow);
+  box-shadow: var(--elmethis-box-shadow-medium);
   transform: translate(-50%, -50%);
   transition: transform 140ms cubic-bezier(0.34, 1.56, 0.64, 1);
   pointer-events: none;
@@ -323,9 +323,7 @@
     var(--elmethis-color-primary)
   );
   cursor: pointer;
-  box-shadow:
-    0 0 0 1px color-mix(in srgb, var(--elmethis-color-primary) 40%, transparent),
-    0 0.375rem 0.875rem -0.375rem var(--elmethis-color-primary);
+  box-shadow: var(--elmethis-box-shadow-medium);
   transition:
     transform 140ms cubic-bezier(0.34, 1.56, 0.64, 1),
     box-shadow 160ms ease;
@@ -333,9 +331,7 @@
 
 .play-button:hover {
   transform: scale(1.06);
-  box-shadow:
-    0 0 0 1px color-mix(in srgb, var(--elmethis-color-primary) 60%, transparent),
-    0 0.5rem 1.25rem -0.375rem var(--elmethis-color-primary);
+  box-shadow: var(--elmethis-box-shadow-medium);
 }
 
 .play-button:active {
@@ -348,9 +344,7 @@
 }
 
 .playing .play-button {
-  box-shadow:
-    0 0 0 1px color-mix(in srgb, var(--elmethis-color-primary) 50%, transparent),
-    0 0 0 6px var(--elmethis-color-primary-hover);
+  box-shadow: var(--elmethis-box-shadow-medium);
 }
 
 /* ---- Volume ------------------------------------------------------------- */
@@ -395,7 +389,7 @@
   border: none;
   border-radius: 50%;
   background-color: var(--elmethis-color-primary-strong);
-  box-shadow: 0 0.125rem 0.25rem -0.0625rem var(--elmethis-color-box-shadow);
+  box-shadow: var(--elmethis-box-shadow-medium);
 }
 
 .volume-slider::-moz-range-thumb {

--- a/packages/react/src/components/media/elm-block-image.module.css
+++ b/packages/react/src/components/media/elm-block-image.module.css
@@ -24,7 +24,7 @@
   height: auto;
   object-fit: contain;
   border-radius: 0.25rem;
-  box-shadow: 0 0 0.125rem var(--elmethis-color-box-shadow);
+  box-shadow: var(--elmethis-box-shadow-medium);
   user-select: none;
   aspect-ratio: var(--elmethis-scoped-aspect-ratio, auto);
   cursor: var(--elmethis-scoped-cursor);

--- a/packages/react/src/components/media/elm-file.module.css
+++ b/packages/react/src/components/media/elm-file.module.css
@@ -4,7 +4,7 @@
   grid-template-columns: 1.5rem 1fr 1fr 1.5rem;
   gap: 1rem;
   align-items: center;
-  box-shadow: 0 0 0.125rem var(--elmethis-color-box-shadow);
+  box-shadow: var(--elmethis-box-shadow-medium);
   border-radius: 0.25rem;
   background-color: var(--elmethis-color-surface-raised);
 }

--- a/packages/react/src/components/navigation/elm-bookmark.module.css
+++ b/packages/react/src/components/navigation/elm-bookmark.module.css
@@ -3,7 +3,7 @@
   display: block;
   container-type: inline-size;
   border-radius: 0.25rem;
-  box-shadow: 0 0 0.125rem var(--elmethis-color-box-shadow);
+  box-shadow: var(--elmethis-box-shadow-medium);
   overflow: hidden;
   background-color: var(--elmethis-color-surface-raised);
   transition:

--- a/packages/react/src/components/table/elm-table.module.css
+++ b/packages/react/src/components/table/elm-table.module.css
@@ -61,7 +61,7 @@
 .elm-table {
   border-collapse: collapse;
   border-spacing: 0;
-  box-shadow: 0 0 0.125rem var(--elmethis-color-box-shadow);
+  box-shadow: var(--elmethis-box-shadow-medium);
 }
 
 .caption {
@@ -96,7 +96,7 @@
   position: sticky;
   inset-inline-start: 0;
   z-index: 1;
-  box-shadow: 1px 0 0 oklch(from var(--elmethis-color-primary-weak) l c h / 50%);
+  box-shadow: var(--elmethis-box-shadow-medium);
 }
 
 .sticky-row-header thead tr > :first-child {

--- a/packages/react/src/components/typography/elm-inline-text.module.css
+++ b/packages/react/src/components/typography/elm-inline-text.module.css
@@ -97,7 +97,7 @@
   gap: 0.25rem;
   overflow: hidden;
   border-radius: 0.25rem;
-  box-shadow: 0 0 0.125rem var(--elmethis-color-box-shadow);
+  box-shadow: var(--elmethis-box-shadow-medium);
   background-color: var(--elmethis-color-surface-raised);
 }
 

--- a/packages/react/stylelint.config.mjs
+++ b/packages/react/stylelint.config.mjs
@@ -35,6 +35,20 @@ export default {
         severity: "error",
       },
     ],
+    "declaration-property-value-allowed-list": [
+      {
+        "box-shadow": [
+          "var(--elmethis-box-shadow-small)",
+          "var(--elmethis-box-shadow-medium)",
+          "var(--elmethis-box-shadow-large)",
+          "none",
+        ],
+      },
+      {
+        message: "Use an Elmethis box-shadow token",
+        severity: "error",
+      },
+    ],
     "csstools/value-no-unknown-custom-properties": [
       true,
       {

--- a/packages/solid/src/components/a2ui/elm-a2ui.module.css
+++ b/packages/solid/src/components/a2ui/elm-a2ui.module.css
@@ -51,7 +51,7 @@
   border-radius: 8px;
   padding: 16px;
   background: var(--elmethis-color-surface-raised);
-  box-shadow: 0 1px 3px var(--elmethis-color-box-shadow);
+  box-shadow: var(--elmethis-box-shadow-medium);
 }
 
 .button {

--- a/packages/solid/src/components/ag-ui-client/components/elm-ag-ui-agent.module.css
+++ b/packages/solid/src/components/ag-ui-client/components/elm-ag-ui-agent.module.css
@@ -65,7 +65,7 @@
           padding: 0.25rem 0.5rem;
           border-radius: 0.25rem;
           background-color: var(--elmethis-color-surface-raised);
-          box-shadow: 0 0 0.25rem var(--elmethis-color-box-shadow);
+          box-shadow: var(--elmethis-box-shadow-medium);
           opacity: 0.85;
 
           .queue-item-icon {
@@ -117,7 +117,7 @@
           border: 0;
           cursor: pointer;
           gap: 0.5rem;
-          box-shadow: 0 0 0.25rem var(--elmethis-color-box-shadow);
+          box-shadow: var(--elmethis-box-shadow-medium);
           color: inherit;
           background-color: var(--elmethis-color-surface-raised);
           border-radius: 1rem;

--- a/packages/solid/src/components/ag-ui-client/components/elm-ag-ui-input.module.css
+++ b/packages/solid/src/components/ag-ui-client/components/elm-ag-ui-input.module.css
@@ -20,7 +20,7 @@
   flex-direction: column;
   gap: 0.5rem;
   background-color: var(--elmethis-color-surface-raised);
-  box-shadow: 0 0 2px var(--elmethis-color-box-shadow);
+  box-shadow: var(--elmethis-box-shadow-medium);
 
   .input {
     display: block;

--- a/packages/solid/src/components/ag-ui-client/components/elm-ag-ui-prompt-picker.module.css
+++ b/packages/solid/src/components/ag-ui-client/components/elm-ag-ui-prompt-picker.module.css
@@ -70,7 +70,7 @@
   color: var(--elmethis-color-neutral);
   background-color: var(--elmethis-color-surface-raised);
   border-radius: 0.5rem;
-  box-shadow: 0 0 0.125rem var(--elmethis-color-box-shadow);
+  box-shadow: var(--elmethis-box-shadow-medium);
   padding: 1rem;
   display: flex;
   flex-direction: column;

--- a/packages/solid/src/components/code/elm-code-block.module.css
+++ b/packages/solid/src/components/code/elm-code-block.module.css
@@ -10,7 +10,7 @@
   padding: 0.25rem;
   border-radius: 0.25rem;
   background-color: var(--elmethis-color-surface-raised);
-  box-shadow: 0 0 0.125rem var(--elmethis-color-box-shadow);
+  box-shadow: var(--elmethis-box-shadow-medium);
 }
 
 .language-icon {

--- a/packages/solid/src/components/code/elm-html-viewer.module.css
+++ b/packages/solid/src/components/code/elm-html-viewer.module.css
@@ -9,7 +9,7 @@
   padding: 0.25rem;
   border-radius: 0.25rem;
   background-color: var(--elmethis-color-surface-raised);
-  box-shadow: 0 0 0.125rem var(--elmethis-color-box-shadow);
+  box-shadow: var(--elmethis-box-shadow-medium);
 }
 
 .header {

--- a/packages/solid/src/components/containments/elm-tabs.module.css
+++ b/packages/solid/src/components/containments/elm-tabs.module.css
@@ -5,7 +5,7 @@
   width: 100%;
   border: solid 1px oklch(from var(--elmethis-color-primary) l c h / 10%);
   border-radius: 0.25rem;
-  box-shadow: 0 0 0.125rem var(--elmethis-color-box-shadow);
+  box-shadow: var(--elmethis-box-shadow-medium);
   overflow: hidden;
   background-color: var(--elmethis-color-surface-raised);
 }

--- a/packages/solid/src/components/form/elm-button-dropdown.module.css
+++ b/packages/solid/src/components/form/elm-button-dropdown.module.css
@@ -43,7 +43,7 @@
     min-width: 100%;
     border-radius: 0.25rem;
     background-color: var(--elmethis-color-surface-raised);
-    box-shadow: 0 0 0.125rem var(--elmethis-color-box-shadow);
+    box-shadow: var(--elmethis-box-shadow-medium);
 
     .item {
       overflow: hidden;

--- a/packages/solid/src/components/form/elm-button.module.css
+++ b/packages/solid/src/components/form/elm-button.module.css
@@ -16,7 +16,7 @@
     opacity 200ms,
     transform 200ms;
   opacity: var(--elmethis-scoped-opacity);
-  box-shadow: 0 0 0.125rem var(--elmethis-color-box-shadow);
+  box-shadow: var(--elmethis-box-shadow-medium);
 }
 
 .normal {
@@ -46,13 +46,13 @@
   &:hover {
     transform: translateX(-1px) translateY(-1px);
     opacity: var(--elmethis-scoped-opacity, 0.7);
-    box-shadow: 0.125rem 0.125rem 0.125rem var(--elmethis-color-box-shadow);
+    box-shadow: var(--elmethis-box-shadow-medium);
   }
 
   &:active {
     transform: translateX(1px) translateY(1px);
     opacity: var(--elmethis-scoped-opacity, 0.5);
-    box-shadow: -1px -1px 0.125rem var(--elmethis-color-box-shadow);
+    box-shadow: var(--elmethis-box-shadow-medium);
   }
 }
 

--- a/packages/solid/src/components/form/elm-select.module.css
+++ b/packages/solid/src/components/form/elm-select.module.css
@@ -17,7 +17,7 @@
     border-color 200ms,
     background-color 200ms;
   background-color: var(--elmethis-color-surface-raised);
-  box-shadow: 0 0 0.125rem var(--elmethis-color-box-shadow);
+  box-shadow: var(--elmethis-box-shadow-medium);
   cursor: pointer;
 
   &.disabled {
@@ -81,7 +81,7 @@
       padding: 0;
       border-radius: 0.25rem;
       background-color: var(--elmethis-color-surface-raised);
-      box-shadow: 0 0 0.125rem var(--elmethis-color-box-shadow);
+      box-shadow: var(--elmethis-box-shadow-medium);
 
       .option {
         overflow: hidden;

--- a/packages/solid/src/components/form/elm-slider.module.css
+++ b/packages/solid/src/components/form/elm-slider.module.css
@@ -117,7 +117,7 @@
   height: 0.875rem;
   border-radius: 50%;
   background-color: var(--elmethis-color-primary-strong);
-  box-shadow: 0 0.125rem 0.375rem -0.0625rem var(--elmethis-color-box-shadow);
+  box-shadow: var(--elmethis-box-shadow-medium);
   transform: translate(-50%, -50%);
   transition: transform 140ms cubic-bezier(0.34, 1.56, 0.64, 1);
   pointer-events: none;

--- a/packages/solid/src/components/form/elm-switch.module.css
+++ b/packages/solid/src/components/form/elm-switch.module.css
@@ -12,7 +12,7 @@
   );
   position: relative;
   cursor: pointer;
-  box-shadow: 0 0 2px var(--elmethis-color-box-shadow);
+  box-shadow: var(--elmethis-box-shadow-medium);
   transition:
     opacity 300ms,
     background-color 300ms;

--- a/packages/solid/src/components/form/elm-text-area.module.css
+++ b/packages/solid/src/components/form/elm-text-area.module.css
@@ -54,7 +54,7 @@
   border-width: 1px;
   border-color: transparent;
   background-color: var(--elmethis-color-surface-raised);
-  box-shadow: 0 0 0.125rem var(--elmethis-color-box-shadow);
+  box-shadow: var(--elmethis-box-shadow-medium);
 
   &.disabled {
     background-color: var(--elmethis-color-surface-sunken);

--- a/packages/solid/src/components/form/elm-text-field.module.css
+++ b/packages/solid/src/components/form/elm-text-field.module.css
@@ -54,7 +54,7 @@
   border-width: 1px;
   border-color: transparent;
   background-color: var(--elmethis-color-surface-raised);
-  box-shadow: 0 0 0.125rem var(--elmethis-color-box-shadow);
+  box-shadow: var(--elmethis-box-shadow-medium);
 
   &.disabled {
     background-color: var(--elmethis-color-surface-sunken);

--- a/packages/solid/src/components/icon/elm-toggle-theme.module.css
+++ b/packages/solid/src/components/icon/elm-toggle-theme.module.css
@@ -5,7 +5,7 @@
   color: var(--elmethis-color-neutral);
   border-radius: 50%;
   cursor: pointer;
-  box-shadow: 0 0 0.125rem var(--elmethis-color-box-shadow);
+  box-shadow: var(--elmethis-box-shadow-medium);
   background-color: var(--elmethis-color-surface-raised);
   transition: background-color 100ms;
 

--- a/packages/solid/src/components/media/elm-audio-player.module.css
+++ b/packages/solid/src/components/media/elm-audio-player.module.css
@@ -56,7 +56,7 @@
     var(--elmethis-color-primary-strong),
     var(--elmethis-color-primary)
   );
-  box-shadow: 0 0.25rem 0.5rem -0.25rem var(--elmethis-color-box-shadow);
+  box-shadow: var(--elmethis-box-shadow-medium);
 }
 
 .artwork-error {
@@ -177,7 +177,7 @@
 }
 
 .playing .fill {
-  box-shadow: 0 0 0.375rem 0 var(--elmethis-color-primary);
+  box-shadow: var(--elmethis-box-shadow-medium);
 }
 
 .thumb {
@@ -188,7 +188,7 @@
   height: 0.75rem;
   border-radius: 50%;
   background-color: var(--elmethis-color-primary-strong);
-  box-shadow: 0 0.125rem 0.375rem -0.0625rem var(--elmethis-color-box-shadow);
+  box-shadow: var(--elmethis-box-shadow-medium);
   transform: translate(-50%, -50%);
   transition: transform 140ms cubic-bezier(0.34, 1.56, 0.64, 1);
   pointer-events: none;
@@ -315,9 +315,7 @@
     var(--elmethis-color-primary)
   );
   cursor: pointer;
-  box-shadow:
-    0 0 0 1px color-mix(in srgb, var(--elmethis-color-primary) 40%, transparent),
-    0 0.375rem 0.875rem -0.375rem var(--elmethis-color-primary);
+  box-shadow: var(--elmethis-box-shadow-medium);
   transition:
     transform 140ms cubic-bezier(0.34, 1.56, 0.64, 1),
     box-shadow 160ms ease;
@@ -325,9 +323,7 @@
 
 .play-button:hover {
   transform: scale(1.06);
-  box-shadow:
-    0 0 0 1px color-mix(in srgb, var(--elmethis-color-primary) 60%, transparent),
-    0 0.5rem 1.25rem -0.375rem var(--elmethis-color-primary);
+  box-shadow: var(--elmethis-box-shadow-medium);
 }
 
 .play-button:active {
@@ -340,9 +336,7 @@
 }
 
 .playing .play-button {
-  box-shadow:
-    0 0 0 1px color-mix(in srgb, var(--elmethis-color-primary) 50%, transparent),
-    0 0 0 6px var(--elmethis-color-primary-hover);
+  box-shadow: var(--elmethis-box-shadow-medium);
 }
 
 .volume {
@@ -385,7 +379,7 @@
   border: none;
   border-radius: 50%;
   background-color: var(--elmethis-color-primary-strong);
-  box-shadow: 0 0.125rem 0.25rem -0.0625rem var(--elmethis-color-box-shadow);
+  box-shadow: var(--elmethis-box-shadow-medium);
 }
 
 .volume-slider::-moz-range-thumb {

--- a/packages/solid/src/components/media/elm-block-image.module.css
+++ b/packages/solid/src/components/media/elm-block-image.module.css
@@ -24,7 +24,7 @@
   height: auto;
   object-fit: contain;
   border-radius: 0.25rem;
-  box-shadow: 0 0 0.125rem var(--elmethis-color-box-shadow);
+  box-shadow: var(--elmethis-box-shadow-medium);
   user-select: none;
   aspect-ratio: var(--elmethis-scoped-aspect-ratio, auto);
   cursor: var(--elmethis-scoped-cursor);

--- a/packages/solid/src/components/media/elm-file.module.css
+++ b/packages/solid/src/components/media/elm-file.module.css
@@ -4,7 +4,7 @@
   grid-template-columns: 1.5rem 1fr 1fr 1.5rem;
   gap: 1rem;
   align-items: center;
-  box-shadow: 0 0 0.125rem var(--elmethis-color-box-shadow);
+  box-shadow: var(--elmethis-box-shadow-medium);
   border-radius: 0.25rem;
   background-color: var(--elmethis-color-surface-raised);
 }

--- a/packages/solid/src/components/navigation/elm-bookmark.module.css
+++ b/packages/solid/src/components/navigation/elm-bookmark.module.css
@@ -3,7 +3,7 @@
   display: block;
   container-type: inline-size;
   border-radius: 0.25rem;
-  box-shadow: 0 0 0.125rem var(--elmethis-color-box-shadow);
+  box-shadow: var(--elmethis-box-shadow-medium);
   overflow: hidden;
   background-color: var(--elmethis-color-surface-raised);
   transition:

--- a/packages/solid/src/components/table/elm-table.module.css
+++ b/packages/solid/src/components/table/elm-table.module.css
@@ -57,7 +57,7 @@
 .elm-table {
   border-collapse: collapse;
   border-spacing: 0;
-  box-shadow: 0 0 0.125rem var(--elmethis-color-box-shadow);
+  box-shadow: var(--elmethis-box-shadow-medium);
 }
 
 .caption {
@@ -87,7 +87,7 @@
   position: sticky;
   inset-inline-start: 0;
   z-index: 1;
-  box-shadow: 1px 0 0 oklch(from var(--elmethis-color-primary-weak) l c h / 50%);
+  box-shadow: var(--elmethis-box-shadow-medium);
 }
 
 .sticky-row-header thead tr > :first-child {

--- a/packages/solid/src/components/typography/elm-inline-text.module.css
+++ b/packages/solid/src/components/typography/elm-inline-text.module.css
@@ -97,7 +97,7 @@
   gap: 0.25rem;
   overflow: hidden;
   border-radius: 0.25rem;
-  box-shadow: 0 0 0.125rem var(--elmethis-color-box-shadow);
+  box-shadow: var(--elmethis-box-shadow-medium);
   background-color: var(--elmethis-color-surface-raised);
 }
 

--- a/packages/solid/stylelint.config.mjs
+++ b/packages/solid/stylelint.config.mjs
@@ -33,6 +33,20 @@ export default {
         severity: "error",
       },
     ],
+    "declaration-property-value-allowed-list": [
+      {
+        "box-shadow": [
+          "var(--elmethis-box-shadow-small)",
+          "var(--elmethis-box-shadow-medium)",
+          "var(--elmethis-box-shadow-large)",
+          "none",
+        ],
+      },
+      {
+        message: "Use an Elmethis box-shadow token",
+        severity: "error",
+      },
+    ],
     "csstools/value-no-unknown-custom-properties": [
       true,
       {

--- a/packages/vue/src/components/a2ui/elm-a2ui.module.css
+++ b/packages/vue/src/components/a2ui/elm-a2ui.module.css
@@ -98,7 +98,7 @@
   border-radius: 8px;
   padding: 16px;
   background: var(--elmethis-color-surface-raised);
-  box-shadow: 0 1px 3px var(--elmethis-color-box-shadow);
+  box-shadow: var(--elmethis-box-shadow-medium);
 }
 
 /* ---- button ---- */

--- a/packages/vue/src/components/code/elm-code-block.module.css
+++ b/packages/vue/src/components/code/elm-code-block.module.css
@@ -10,7 +10,7 @@
   padding: 0.25rem;
   border-radius: 0.25rem;
   background-color: var(--elmethis-color-surface-raised);
-  box-shadow: 0 0 0.125rem var(--elmethis-color-box-shadow);
+  box-shadow: var(--elmethis-box-shadow-medium);
 }
 
 .language-icon {

--- a/packages/vue/src/components/code/elm-html-viewer.module.css
+++ b/packages/vue/src/components/code/elm-html-viewer.module.css
@@ -9,7 +9,7 @@
   padding: 0.25rem;
   border-radius: 0.25rem;
   background-color: var(--elmethis-color-surface-raised);
-  box-shadow: 0 0 0.125rem var(--elmethis-color-box-shadow);
+  box-shadow: var(--elmethis-box-shadow-medium);
 }
 
 .header {

--- a/packages/vue/src/components/containments/elm-tabs.module.css
+++ b/packages/vue/src/components/containments/elm-tabs.module.css
@@ -5,7 +5,7 @@
   width: 100%;
   border: solid 1px oklch(from var(--elmethis-color-primary) l c h / 10%);
   border-radius: 0.25rem;
-  box-shadow: 0 0 0.125rem var(--elmethis-color-box-shadow);
+  box-shadow: var(--elmethis-box-shadow-medium);
   overflow: hidden;
   background-color: var(--elmethis-color-surface-raised);
 }

--- a/packages/vue/src/components/form/elm-button-dropdown.module.css
+++ b/packages/vue/src/components/form/elm-button-dropdown.module.css
@@ -46,7 +46,7 @@
     min-width: 100%;
     border-radius: 0.25rem;
     background-color: var(--elmethis-color-surface-raised);
-    box-shadow: 0 0 0.125rem var(--elmethis-color-box-shadow);
+    box-shadow: var(--elmethis-box-shadow-medium);
 
     .item {
       overflow: hidden;

--- a/packages/vue/src/components/form/elm-button.module.css
+++ b/packages/vue/src/components/form/elm-button.module.css
@@ -16,7 +16,7 @@
     opacity 200ms,
     transform 200ms;
   opacity: var(--elmethis-scoped-opacity);
-  box-shadow: 0 0 0.125rem var(--elmethis-color-box-shadow);
+  box-shadow: var(--elmethis-box-shadow-medium);
 }
 
 .normal {
@@ -46,13 +46,13 @@
   &:hover {
     transform: translateX(-1px) translateY(-1px);
     opacity: var(--elmethis-scoped-opacity, 0.7);
-    box-shadow: 0.125rem 0.125rem 0.125rem var(--elmethis-color-box-shadow);
+    box-shadow: var(--elmethis-box-shadow-medium);
   }
 
   &:active {
     transform: translateX(1px) translateY(1px);
     opacity: var(--elmethis-scoped-opacity, 0.5);
-    box-shadow: -1px -1px 0.125rem var(--elmethis-color-box-shadow);
+    box-shadow: var(--elmethis-box-shadow-medium);
   }
 }
 

--- a/packages/vue/src/components/form/elm-select.module.css
+++ b/packages/vue/src/components/form/elm-select.module.css
@@ -17,7 +17,7 @@
     border-color 200ms,
     background-color 200ms;
   background-color: var(--elmethis-color-surface-raised);
-  box-shadow: 0 0 0.125rem var(--elmethis-color-box-shadow);
+  box-shadow: var(--elmethis-box-shadow-medium);
   cursor: pointer;
 
   &.disabled {
@@ -81,7 +81,7 @@
       padding: 0;
       border-radius: 0.25rem;
       background-color: var(--elmethis-color-surface-raised);
-      box-shadow: 0 0 0.125rem var(--elmethis-color-box-shadow);
+      box-shadow: var(--elmethis-box-shadow-medium);
 
       .option {
         overflow: hidden;

--- a/packages/vue/src/components/form/elm-slider.module.css
+++ b/packages/vue/src/components/form/elm-slider.module.css
@@ -134,7 +134,7 @@
   height: 0.875rem;
   border-radius: 50%;
   background-color: var(--elmethis-color-primary-strong);
-  box-shadow: 0 0.125rem 0.375rem -0.0625rem var(--elmethis-color-box-shadow);
+  box-shadow: var(--elmethis-box-shadow-medium);
   transform: translate(-50%, -50%);
   transition: transform 140ms cubic-bezier(0.34, 1.56, 0.64, 1);
   pointer-events: none;

--- a/packages/vue/src/components/form/elm-switch.module.css
+++ b/packages/vue/src/components/form/elm-switch.module.css
@@ -12,7 +12,7 @@
   );
   position: relative;
   cursor: pointer;
-  box-shadow: 0 0 2px var(--elmethis-color-box-shadow);
+  box-shadow: var(--elmethis-box-shadow-medium);
   transition:
     opacity 300ms,
     background-color 300ms;

--- a/packages/vue/src/components/form/elm-text-area.module.css
+++ b/packages/vue/src/components/form/elm-text-area.module.css
@@ -54,7 +54,7 @@
   border-width: 1px;
   border-color: transparent;
   background-color: var(--elmethis-color-surface-raised);
-  box-shadow: 0 0 0.125rem var(--elmethis-color-box-shadow);
+  box-shadow: var(--elmethis-box-shadow-medium);
 
   &.disabled {
     background-color: var(--elmethis-color-surface-sunken);

--- a/packages/vue/src/components/form/elm-text-field.module.css
+++ b/packages/vue/src/components/form/elm-text-field.module.css
@@ -54,7 +54,7 @@
   border-width: 1px;
   border-color: transparent;
   background-color: var(--elmethis-color-surface-raised);
-  box-shadow: 0 0 0.125rem var(--elmethis-color-box-shadow);
+  box-shadow: var(--elmethis-box-shadow-medium);
 
   &.disabled {
     background-color: var(--elmethis-color-surface-sunken);

--- a/packages/vue/src/components/icon/elm-toggle-theme.module.css
+++ b/packages/vue/src/components/icon/elm-toggle-theme.module.css
@@ -5,7 +5,7 @@
   color: var(--elmethis-color-neutral);
   border-radius: 50%;
   cursor: pointer;
-  box-shadow: 0 0 0.125rem var(--elmethis-color-box-shadow);
+  box-shadow: var(--elmethis-box-shadow-medium);
   background-color: var(--elmethis-color-surface-raised);
   transition: background-color 100ms;
 

--- a/packages/vue/src/components/media/elm-audio-player.module.css
+++ b/packages/vue/src/components/media/elm-audio-player.module.css
@@ -55,7 +55,7 @@
     var(--elmethis-color-primary-strong),
     var(--elmethis-color-primary)
   );
-  box-shadow: 0 0.25rem 0.5rem -0.25rem var(--elmethis-color-box-shadow);
+  box-shadow: var(--elmethis-box-shadow-medium);
 }
 
 /* Error: the artwork tile turns into a red alert badge. */
@@ -181,7 +181,7 @@
 }
 
 .playing .fill {
-  box-shadow: 0 0 0.375rem 0 var(--elmethis-color-primary);
+  box-shadow: var(--elmethis-box-shadow-medium);
 }
 
 /* Draggable handle, parked at the play position. */
@@ -193,7 +193,7 @@
   height: 0.75rem;
   border-radius: 50%;
   background-color: var(--elmethis-color-primary-strong);
-  box-shadow: 0 0.125rem 0.375rem -0.0625rem var(--elmethis-color-box-shadow);
+  box-shadow: var(--elmethis-box-shadow-medium);
   transform: translate(-50%, -50%);
   transition: transform 140ms cubic-bezier(0.34, 1.56, 0.64, 1);
   pointer-events: none;
@@ -323,9 +323,7 @@
     var(--elmethis-color-primary)
   );
   cursor: pointer;
-  box-shadow:
-    0 0 0 1px color-mix(in srgb, var(--elmethis-color-primary) 40%, transparent),
-    0 0.375rem 0.875rem -0.375rem var(--elmethis-color-primary);
+  box-shadow: var(--elmethis-box-shadow-medium);
   transition:
     transform 140ms cubic-bezier(0.34, 1.56, 0.64, 1),
     box-shadow 160ms ease;
@@ -333,9 +331,7 @@
 
 .play-button:hover {
   transform: scale(1.06);
-  box-shadow:
-    0 0 0 1px color-mix(in srgb, var(--elmethis-color-primary) 60%, transparent),
-    0 0.5rem 1.25rem -0.375rem var(--elmethis-color-primary);
+  box-shadow: var(--elmethis-box-shadow-medium);
 }
 
 .play-button:active {
@@ -348,9 +344,7 @@
 }
 
 .playing .play-button {
-  box-shadow:
-    0 0 0 1px color-mix(in srgb, var(--elmethis-color-primary) 50%, transparent),
-    0 0 0 6px var(--elmethis-color-primary-hover);
+  box-shadow: var(--elmethis-box-shadow-medium);
 }
 
 /* ---- Volume ------------------------------------------------------------- */
@@ -395,7 +389,7 @@
   border: none;
   border-radius: 50%;
   background-color: var(--elmethis-color-primary-strong);
-  box-shadow: 0 0.125rem 0.25rem -0.0625rem var(--elmethis-color-box-shadow);
+  box-shadow: var(--elmethis-box-shadow-medium);
 }
 
 .volume-slider::-moz-range-thumb {

--- a/packages/vue/src/components/media/elm-block-image.module.css
+++ b/packages/vue/src/components/media/elm-block-image.module.css
@@ -24,7 +24,7 @@
   height: auto;
   object-fit: contain;
   border-radius: 0.25rem;
-  box-shadow: 0 0 0.125rem var(--elmethis-color-box-shadow);
+  box-shadow: var(--elmethis-box-shadow-medium);
   user-select: none;
   aspect-ratio: var(--aspect-ratio, auto);
   cursor: var(--elmethis-scoped-cursor);

--- a/packages/vue/src/components/media/elm-file.module.css
+++ b/packages/vue/src/components/media/elm-file.module.css
@@ -4,7 +4,7 @@
   grid-template-columns: 1.5rem 1fr 1fr 1.5rem;
   gap: 1rem;
   align-items: center;
-  box-shadow: 0 0 0.125rem var(--elmethis-color-box-shadow);
+  box-shadow: var(--elmethis-box-shadow-medium);
   border-radius: 0.25rem;
   background-color: var(--elmethis-color-surface-raised);
 }

--- a/packages/vue/src/components/navigation/elm-bookmark.module.css
+++ b/packages/vue/src/components/navigation/elm-bookmark.module.css
@@ -3,7 +3,7 @@
   display: block;
   container-type: inline-size;
   border-radius: 0.25rem;
-  box-shadow: 0 0 0.125rem var(--elmethis-color-box-shadow);
+  box-shadow: var(--elmethis-box-shadow-medium);
   overflow: hidden;
   background-color: var(--elmethis-color-surface-raised);
   transition:

--- a/packages/vue/src/components/table/elm-table.module.css
+++ b/packages/vue/src/components/table/elm-table.module.css
@@ -61,7 +61,7 @@
 .elm-table {
   border-collapse: collapse;
   border-spacing: 0;
-  box-shadow: 0 0 0.125rem var(--elmethis-color-box-shadow);
+  box-shadow: var(--elmethis-box-shadow-medium);
 }
 
 .caption {
@@ -96,7 +96,7 @@
   position: sticky;
   inset-inline-start: 0;
   z-index: 1;
-  box-shadow: 1px 0 0 oklch(from var(--elmethis-color-primary-weak) l c h / 50%);
+  box-shadow: var(--elmethis-box-shadow-medium);
 }
 
 .sticky-row-header thead tr > :first-child {

--- a/packages/vue/src/components/typography/elm-inline-text.module.css
+++ b/packages/vue/src/components/typography/elm-inline-text.module.css
@@ -97,7 +97,7 @@
   gap: 0.25rem;
   overflow: hidden;
   border-radius: 0.25rem;
-  box-shadow: 0 0 0.125rem var(--elmethis-color-box-shadow);
+  box-shadow: var(--elmethis-box-shadow-medium);
   background-color: var(--elmethis-color-surface-raised);
 }
 

--- a/packages/vue/stylelint.config.mjs
+++ b/packages/vue/stylelint.config.mjs
@@ -35,6 +35,20 @@ export default {
         severity: "error",
       },
     ],
+    "declaration-property-value-allowed-list": [
+      {
+        "box-shadow": [
+          "var(--elmethis-box-shadow-small)",
+          "var(--elmethis-box-shadow-medium)",
+          "var(--elmethis-box-shadow-large)",
+          "none",
+        ],
+      },
+      {
+        message: "Use an Elmethis box-shadow token",
+        severity: "error",
+      },
+    ],
     "csstools/value-no-unknown-custom-properties": [
       true,
       {


### PR DESCRIPTION
## Summary
- add small, medium, and large semantic box-shadow tokens in core
- replace framework box-shadow declarations with the medium token
- enforce the supported token scale through Stylelint in React, Solid, and Vue

## Testing
- `pnpm --filter @elmethis/core run build`
- `pnpm --filter @elmethis/core exec vitest run src/style/token-vars.spec.ts`
- `pnpm --filter @elmethis/react run lint.css`
- `pnpm --filter @elmethis/solid run lint.css`
- `pnpm --filter @elmethis/vue run lint.css`
- `pnpm exec prettier --check packages/core/src/style/token.ts packages/core/src/style/token-vars.spec.ts "packages/{react,solid,vue}/{src,.storybook}/**/*.css" packages/react/stylelint.config.mjs packages/solid/stylelint.config.mjs packages/vue/stylelint.config.mjs`