### PR TITLE
feat(drawio): add Elmethis style presets

### DIFF
--- a/packages/drawio/README.md
+++ b/packages/drawio/README.md
@@ -29,6 +29,7 @@ The generated JSON is available from the package root or the explicit
 import config from "@elmethis/draw.io" with { type: "json" };
 ```
 
-The package intentionally does not set `override`, editor layout, libraries, or
+The package includes matching Elmethis document and selected-element style
+presets. It intentionally does not set `override`, editor layout, libraries, or
 keyboard behavior. Those are user and deployment preferences rather than
 Elmethis design tokens.

--- a/packages/drawio/package.json
+++ b/packages/drawio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elmethis/draw.io",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": {
     "name": "Ikuma Yamashita",
     "url": "https://www.ikuma.cloud/"

--- a/packages/drawio/scripts/build-drawio-config.ts
+++ b/packages/drawio/scripts/build-drawio-config.ts
@@ -121,6 +121,8 @@ const fontDefinitions = webFontFamilies.map((fontFamily) => ({
 }));
 const defaultFontSource = encodeURIComponent(fontDefinitions[0].fontUrl);
 const neutralColor = semanticColor("color-neutral");
+const primaryColor = semanticColor("color-primary");
+const raisedSurfaceColor = semanticColor("color-surface-raised");
 const defaultTextStyle = [
   "text",
   "html=1",
@@ -145,6 +147,15 @@ const config = {
   version: "elmethis-1",
   defaultAdaptiveColors: "simple",
   embedSvgFonts: true,
+  styles: [
+    {
+      commonStyle: {
+        fontColor: neutralColor,
+        strokeColor: primaryColor,
+        fillColor: raisedSurfaceColor,
+      },
+    },
+  ],
   customColorSchemes: [
     [
       ...displayColors.map(([name, label]) => {
@@ -165,6 +176,12 @@ const config = {
           font: base,
         };
       }),
+      {
+        title: "Elmethis",
+        fill: raisedSurfaceColor,
+        stroke: primaryColor,
+        font: neutralColor,
+      },
     ],
   ],
   presetColors: [


### PR DESCRIPTION
## Summary

- add an Elmethis document-level preset to the diagrams.net Style gallery
- add a matching Elmethis option at the end of the selected-element color schemes
- derive both presets from shared semantic color tokens

## Testing

- `pnpm --filter @elmethis/draw.io run check`
- repository-wide pre-commit check
- live diagrams.net document Style gallery smoke test