### PR TITLE
fix(config): type-check ESLint configurations

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Check shared configuration
+        run: pnpm run check.configs
+
       - name: Check
         run: pnpm run check.ci
         working-directory: packages/core

--- a/.prettierignore
+++ b/.prettierignore
@@ -18,9 +18,3 @@ storybook-static
 pnpm-lock.yaml
 package-lock.json
 package.json
-tsconfig.json
-tsconfig.*.json
-
-# Config files
-eslint.config.ts
-prettier.config.js

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -7,6 +7,8 @@ pre-commit:
   jobs:
     - name: check
       run: pnpm run --recursive check
+    - name: configs
+      run: pnpm run check.configs
 
 fmt:
   parallel: true
@@ -29,6 +31,9 @@ check:
     # repo-root-relative path; `**` matches one-or-more dirs deep, so
     # `packages/<pkg>/**` covers everything under the package (e.g. src/) while
     # skipping top-level package config files.
+
+    - name: configs
+      run: pnpm run check.configs
 
     - name: eslint-core
       root: "packages/core/"

--- a/package.json
+++ b/package.json
@@ -5,9 +5,16 @@
     "url": "git@github.com:46ki75/elmethis.git"
   },
   "homepage": "https://46ki75.github.io/elmethis",
+  "scripts": {
+    "check.configs": "pnpm run fmt.configs && pnpm run lint.configs && pnpm run typecheck.configs",
+    "fmt.configs": "prettier --check \"**/tsconfig*.json\" \"**/eslint.config.ts\"",
+    "lint.configs": "pnpm --recursive exec eslint eslint.config.ts",
+    "typecheck.configs": "tsc --project tsconfig.eslint.json"
+  },
   "devDependencies": {
     "@types/node": "^26.1.2",
     "lefthook": "^2.1.10",
+    "prettier": "3.9.6",
     "stylelint": "^17.14.1",
     "typescript": "~6.0.3"
   },

--- a/packages/ag-ui-stub/eslint.config.ts
+++ b/packages/ag-ui-stub/eslint.config.ts
@@ -1,3 +1,6 @@
+/// <reference types="node" />
+
+import { fileURLToPath } from "node:url";
 import js from "@eslint/js";
 import vitest from "@vitest/eslint-plugin";
 import globals from "globals";
@@ -8,6 +11,8 @@ import {
   strictRules,
   typedTestRules,
 } from "../../eslint.strict.ts";
+
+const tsconfigRootDir = fileURLToPath(new URL(".", import.meta.url));
 
 export default defineConfig([
   globalIgnores(["dist", "node_modules"]),
@@ -23,7 +28,7 @@ export default defineConfig([
       },
       parserOptions: {
         projectService: true,
-        tsconfigRootDir: import.meta.dirname,
+        tsconfigRootDir,
       },
     },
     rules: {
@@ -44,5 +49,16 @@ export default defineConfig([
     files: ["**/*.spec.{ts,tsx}", "**/*.browser.spec.{ts,tsx}"],
     extends: [vitest.configs.recommended],
     rules: typedTestRules,
+  },
+  {
+    files: ["eslint.config.ts"],
+    languageOptions: {
+      globals: globals.node,
+      parserOptions: {
+        projectService: false,
+        project: "../../tsconfig.eslint.json",
+        tsconfigRootDir,
+      },
+    },
   },
 ]);

--- a/packages/ag-ui-stub/package.json
+++ b/packages/ag-ui-stub/package.json
@@ -37,7 +37,7 @@
     "dev": "tsdown --watch",
     "fmt": "prettier --write ./src",
     "fmt.check": "prettier --check ./src",
-    "lint": "eslint \"src/**/*.ts*\"",
+    "lint": "eslint \"src/**/*.ts*\" eslint.config.ts",
     "build.types": "tsc --noEmit -p tsconfig.json",
     "test.unit": "vitest --run",
     "test.coverage": "vitest --run --coverage",

--- a/packages/copilotkit/eslint.config.ts
+++ b/packages/copilotkit/eslint.config.ts
@@ -1,8 +1,13 @@
+/// <reference types="node" />
+
+import { fileURLToPath } from "node:url";
 import js from "@eslint/js";
 import globals from "globals";
 import tseslint from "typescript-eslint";
 import { defineConfig, globalIgnores } from "eslint/config";
 import { strictLinterOptions, strictRules } from "../../eslint.strict.ts";
+
+const tsconfigRootDir = fileURLToPath(new URL(".", import.meta.url));
 
 export default defineConfig([
   globalIgnores(["dist", "node_modules"]),
@@ -14,9 +19,19 @@ export default defineConfig([
       globals: globals.node,
       parserOptions: {
         projectService: true,
-        tsconfigRootDir: import.meta.dirname,
+        tsconfigRootDir,
       },
     },
     rules: strictRules,
+  },
+  {
+    files: ["eslint.config.ts"],
+    languageOptions: {
+      parserOptions: {
+        projectService: false,
+        project: "../../tsconfig.eslint.json",
+        tsconfigRootDir,
+      },
+    },
   },
 ]);

--- a/packages/copilotkit/package.json
+++ b/packages/copilotkit/package.json
@@ -9,7 +9,7 @@
         "prestart": "pnpm run build",
         "start": "node ./dist/index.mjs",
         "build": "node build.ts",
-        "lint": "eslint \"src/**/*.ts\" build.ts",
+        "lint": "eslint \"src/**/*.ts\" build.ts eslint.config.ts",
         "check": "pnpm run lint && tsc --noEmit",
         "prebuild:container": "pnpm run build",
         "build:container": "docker buildx build -t copilotkit-minimal --platform linux/arm64 ."

--- a/packages/copilotkit/tsconfig.build.json
+++ b/packages/copilotkit/tsconfig.build.json
@@ -1,9 +1,9 @@
 {
-    "extends": "./tsconfig.json",
-    "compilerOptions": {
-        "rewriteRelativeImportExtensions": true,
-        "allowImportingTsExtensions": false,
-        "noEmit": false,
-        "rootDir": "src",
-    }
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rewriteRelativeImportExtensions": true,
+    "allowImportingTsExtensions": false,
+    "noEmit": false,
+    "rootDir": "src"
+  }
 }

--- a/packages/copilotkit/tsconfig.json
+++ b/packages/copilotkit/tsconfig.json
@@ -1,21 +1,16 @@
 {
-    "compilerOptions": {
-        "target": "esnext",
-        "module": "NodeNext",
-        "moduleResolution": "NodeNext",
-        "esModuleInterop": true,
-        "strict": true,
-        "skipLibCheck": true,
-        "forceConsistentCasingInFileNames": true,
-        "outDir": "dist",
-        "allowImportingTsExtensions": true,
-        "noEmit": true
-    },
-    "include": [
-        "src/**/*",
-        "build.ts"
-    ],
-    "exclude": [
-        "node_modules"
-    ]
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist",
+    "allowImportingTsExtensions": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*", "build.ts"],
+  "exclude": ["node_modules"]
 }

--- a/packages/core/eslint.config.ts
+++ b/packages/core/eslint.config.ts
@@ -1,3 +1,6 @@
+/// <reference types="node" />
+
+import { fileURLToPath } from "node:url";
 import js from "@eslint/js";
 import vitest from "@vitest/eslint-plugin";
 import globals from "globals";
@@ -8,6 +11,8 @@ import {
   strictRules,
   typedTestRules,
 } from "../../eslint.strict.ts";
+
+const tsconfigRootDir = fileURLToPath(new URL(".", import.meta.url));
 
 export default defineConfig([
   globalIgnores(["dist", "node_modules"]),
@@ -20,7 +25,7 @@ export default defineConfig([
       globals: globals.browser,
       parserOptions: {
         projectService: true,
-        tsconfigRootDir: import.meta.dirname,
+        tsconfigRootDir,
       },
     },
     rules: {
@@ -41,5 +46,16 @@ export default defineConfig([
     files: ["**/*.spec.{ts,tsx}", "**/*.browser.spec.{ts,tsx}"],
     extends: [vitest.configs.recommended],
     rules: typedTestRules,
+  },
+  {
+    files: ["eslint.config.ts"],
+    languageOptions: {
+      globals: globals.node,
+      parserOptions: {
+        projectService: false,
+        project: "../../tsconfig.eslint.json",
+        tsconfigRootDir,
+      },
+    },
   },
 ]);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -61,7 +61,7 @@
     "dev": "tsdown --watch",
     "fmt": "prettier --write ./src",
     "fmt.check": "prettier --check ./src",
-    "lint": "eslint \"src/**/*.ts*\"",
+    "lint": "eslint \"src/**/*.ts*\" eslint.config.ts",
     "test.unit": "vitest --run",
     "test.coverage": "vitest --run --coverage",
     "prepublishOnly": "pnpm run build",

--- a/packages/drawio/eslint.config.ts
+++ b/packages/drawio/eslint.config.ts
@@ -1,8 +1,13 @@
+/// <reference types="node" />
+
+import { fileURLToPath } from "node:url";
 import js from "@eslint/js";
 import globals from "globals";
 import tseslint from "typescript-eslint";
 import { defineConfig, globalIgnores } from "eslint/config";
 import { strictLinterOptions, strictRules } from "../../eslint.strict.ts";
+
+const tsconfigRootDir = fileURLToPath(new URL(".", import.meta.url));
 
 export default defineConfig([
   globalIgnores(["dist", "node_modules"]),
@@ -14,9 +19,19 @@ export default defineConfig([
       globals: globals.node,
       parserOptions: {
         projectService: true,
-        tsconfigRootDir: import.meta.dirname,
+        tsconfigRootDir,
       },
     },
     rules: strictRules,
+  },
+  {
+    files: ["eslint.config.ts"],
+    languageOptions: {
+      parserOptions: {
+        projectService: false,
+        project: "../../tsconfig.eslint.json",
+        tsconfigRootDir,
+      },
+    },
   },
 ]);

--- a/packages/drawio/package.json
+++ b/packages/drawio/package.json
@@ -37,7 +37,7 @@
     "build.types": "tsc --noEmit",
     "fmt": "prettier --write ./scripts ./README.md",
     "fmt.check": "prettier --check ./scripts ./README.md",
-    "lint": "eslint \"scripts/**/*.ts\"",
+    "lint": "eslint \"scripts/**/*.ts\" eslint.config.ts",
     "check": "pnpm run fmt.check && pnpm run lint && pnpm run build.types && pnpm run build",
     "check.ci": "pnpm run check",
     "prepublishOnly": "pnpm run check"

--- a/packages/ikuma-theme/eslint.config.ts
+++ b/packages/ikuma-theme/eslint.config.ts
@@ -1,8 +1,13 @@
+/// <reference types="node" />
+
+import { fileURLToPath } from "node:url";
 import js from "@eslint/js";
 import globals from "globals";
 import tseslint from "typescript-eslint";
 import { defineConfig, globalIgnores } from "eslint/config";
 import { strictLinterOptions, strictRules } from "../../eslint.strict.ts";
+
+const tsconfigRootDir = fileURLToPath(new URL(".", import.meta.url));
 
 export default defineConfig([
   globalIgnores(["dist", "node_modules"]),
@@ -14,9 +19,19 @@ export default defineConfig([
       globals: globals.node,
       parserOptions: {
         projectService: true,
-        tsconfigRootDir: import.meta.dirname,
+        tsconfigRootDir,
       },
     },
     rules: strictRules,
+  },
+  {
+    files: ["eslint.config.ts"],
+    languageOptions: {
+      parserOptions: {
+        projectService: false,
+        project: "../../tsconfig.eslint.json",
+        tsconfigRootDir,
+      },
+    },
   },
 ]);

--- a/packages/ikuma-theme/package.json
+++ b/packages/ikuma-theme/package.json
@@ -28,7 +28,7 @@
     "build.types": "tsc --noEmit",
     "fmt": "prettier --write ./scripts",
     "fmt.check": "prettier --check ./scripts",
-    "lint": "eslint \"scripts/**/*.ts\"",
+    "lint": "eslint \"scripts/**/*.ts\" eslint.config.ts",
     "check": "pnpm run fmt.check && pnpm run lint && pnpm run build.types && pnpm run build",
     "check.ci": "pnpm run check",
     "prepublish:npm": "pnpm run build:npm",

--- a/packages/react/eslint.config.ts
+++ b/packages/react/eslint.config.ts
@@ -1,3 +1,6 @@
+/// <reference types="node" />
+
+import { fileURLToPath } from "node:url";
 import js from "@eslint/js";
 import vitest from "@vitest/eslint-plugin";
 import globals from "globals";
@@ -10,6 +13,8 @@ import {
   strictRules,
   typedTestRules,
 } from "../../eslint.strict.ts";
+
+const tsconfigRootDir = fileURLToPath(new URL(".", import.meta.url));
 
 export default defineConfig([
   globalIgnores([
@@ -35,7 +40,7 @@ export default defineConfig([
       globals: globals.browser,
       parserOptions: {
         projectService: true,
-        tsconfigRootDir: import.meta.dirname,
+        tsconfigRootDir,
       },
     },
     rules: {
@@ -56,5 +61,16 @@ export default defineConfig([
     files: ["**/*.spec.{ts,tsx}", "**/*.browser.spec.{ts,tsx}"],
     extends: [vitest.configs.recommended],
     rules: typedTestRules,
+  },
+  {
+    files: ["eslint.config.ts"],
+    languageOptions: {
+      globals: globals.node,
+      parserOptions: {
+        projectService: false,
+        project: "../../tsconfig.eslint.json",
+        tsconfigRootDir,
+      },
+    },
   },
 ]);

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -45,7 +45,7 @@
     "dev": "storybook dev -p 19221 --no-open",
     "fmt": "prettier --write ./src",
     "fmt.check": "prettier --check ./src",
-    "lint": "eslint \"src/**/*.ts*\"",
+    "lint": "eslint \"src/**/*.ts*\" eslint.config.ts",
     "lint.css": "stylelint \"{src,.storybook}/**/*.css\"",
     "test": "pnpm run test.unit && pnpm run test.browser",
     "test.unit": "vitest --run",

--- a/packages/react/tsconfig.app.json
+++ b/packages/react/tsconfig.app.json
@@ -2,17 +2,9 @@
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "target": "es2023",
-    "lib": [
-      "ES2023",
-      "DOM",
-      "DOM.Iterable"
-    ],
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
     "module": "esnext",
-    "types": [
-      "vite/client",
-      "vitest/globals",
-      "@testing-library/jest-dom"
-    ],
+    "types": ["vite/client", "vitest/globals", "@testing-library/jest-dom"],
     "skipLibCheck": true,
     /* Bundler mode */
     "moduleResolution": "bundler",
@@ -28,7 +20,5 @@
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }

--- a/packages/react/tsconfig.lib.json
+++ b/packages/react/tsconfig.lib.json
@@ -7,9 +7,7 @@
     "outDir": "lib-types",
     "rootDir": "src"
   },
-  "include": [
-    "src"
-  ],
+  "include": ["src"],
   "exclude": [
     "src/**/*.spec.ts",
     "src/**/*.spec.tsx",

--- a/packages/react/tsconfig.node.json
+++ b/packages/react/tsconfig.node.json
@@ -2,13 +2,9 @@
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
     "target": "es2023",
-    "lib": [
-      "ES2023"
-    ],
+    "lib": ["ES2023"],
     "module": "esnext",
-    "types": [
-      "node"
-    ],
+    "types": ["node"],
     "skipLibCheck": true,
     /* Bundler mode */
     "moduleResolution": "bundler",
@@ -23,9 +19,5 @@
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": [
-    "vite.config.ts",
-    "vitest.browser.config.ts",
-    "vitest.setup.ts"
-  ]
+  "include": ["vite.config.ts", "vitest.browser.config.ts", "vitest.setup.ts"]
 }

--- a/packages/solid/eslint.config.ts
+++ b/packages/solid/eslint.config.ts
@@ -1,3 +1,6 @@
+/// <reference types="node" />
+
+import { fileURLToPath } from "node:url";
 import js from "@eslint/js";
 import vitest from "@vitest/eslint-plugin";
 import solid from "eslint-plugin-solid/configs/typescript";
@@ -9,6 +12,8 @@ import {
   strictRules,
   typedTestRules,
 } from "../../eslint.strict.ts";
+
+const tsconfigRootDir = fileURLToPath(new URL(".", import.meta.url));
 
 export default defineConfig([
   globalIgnores([
@@ -36,7 +41,7 @@ export default defineConfig([
       globals: globals.browser,
       parserOptions: {
         projectService: true,
-        tsconfigRootDir: import.meta.dirname,
+        tsconfigRootDir,
       },
     },
     rules: {
@@ -57,5 +62,16 @@ export default defineConfig([
     files: ["**/*.spec.{ts,tsx}", "**/*.browser.spec.{ts,tsx}"],
     extends: [vitest.configs.recommended],
     rules: typedTestRules,
+  },
+  {
+    files: ["eslint.config.ts"],
+    languageOptions: {
+      globals: globals.node,
+      parserOptions: {
+        projectService: false,
+        project: "../../tsconfig.eslint.json",
+        tsconfigRootDir,
+      },
+    },
   },
 ]);

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -54,7 +54,7 @@
     "dev.lib": "vite build --watch",
     "fmt": "prettier --write ./src",
     "fmt.check": "prettier --check ./src",
-    "lint": "eslint \"src/**/*.ts*\"",
+    "lint": "eslint \"src/**/*.ts*\" eslint.config.ts",
     "lint.css": "stylelint \"{src,.storybook}/**/*.css\"",
     "test": "pnpm run test.unit && pnpm run test.browser",
     "test.unit": "vitest --run && vitest --run --config vitest.ssr.config.ts",

--- a/packages/solid/tsconfig.app.json
+++ b/packages/solid/tsconfig.app.json
@@ -2,17 +2,9 @@
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "target": "es2023",
-    "lib": [
-      "ES2023",
-      "DOM",
-      "DOM.Iterable"
-    ],
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
     "module": "esnext",
-    "types": [
-      "vite/client",
-      "vitest/globals",
-      "@testing-library/jest-dom"
-    ],
+    "types": ["vite/client", "vitest/globals", "@testing-library/jest-dom"],
     "skipLibCheck": true,
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": false,
@@ -27,7 +19,5 @@
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }

--- a/packages/solid/tsconfig.lib.json
+++ b/packages/solid/tsconfig.lib.json
@@ -7,9 +7,7 @@
     "outDir": "lib-types",
     "rootDir": "src"
   },
-  "include": [
-    "src"
-  ],
+  "include": ["src"],
   "exclude": [
     "src/**/*.spec.ts",
     "src/**/*.spec.tsx",

--- a/packages/solid/tsconfig.node.json
+++ b/packages/solid/tsconfig.node.json
@@ -2,15 +2,9 @@
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
     "target": "es2023",
-    "lib": [
-      "ES2023",
-      "DOM"
-    ],
+    "lib": ["ES2023", "DOM"],
     "module": "esnext",
-    "types": [
-      "node",
-      "vite/client"
-    ],
+    "types": ["node", "vite/client"],
     "skipLibCheck": true,
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,

--- a/packages/solid/tsconfig.solid.json
+++ b/packages/solid/tsconfig.solid.json
@@ -6,9 +6,7 @@
     "rootDir": "src",
     "sourceMap": true
   },
-  "include": [
-    "src"
-  ],
+  "include": ["src"],
   "exclude": [
     "src/**/*.spec.ts",
     "src/**/*.spec.tsx",

--- a/packages/vue/eslint.config.ts
+++ b/packages/vue/eslint.config.ts
@@ -1,3 +1,6 @@
+/// <reference types="node" />
+
+import { fileURLToPath } from "node:url";
 import js from "@eslint/js";
 import vitest from "@vitest/eslint-plugin";
 import globals from "globals";
@@ -8,6 +11,8 @@ import {
   strictRules,
   typedTestRules,
 } from "../../eslint.strict.ts";
+
+const tsconfigRootDir = fileURLToPath(new URL(".", import.meta.url));
 
 export default defineConfig([
   globalIgnores([
@@ -28,7 +33,7 @@ export default defineConfig([
       globals: globals.browser,
       parserOptions: {
         projectService: true,
-        tsconfigRootDir: import.meta.dirname,
+        tsconfigRootDir,
       },
     },
     rules: {
@@ -49,5 +54,16 @@ export default defineConfig([
     files: ["**/*.spec.{ts,tsx}", "**/*.browser.spec.{ts,tsx}"],
     extends: [vitest.configs.recommended],
     rules: typedTestRules,
+  },
+  {
+    files: ["eslint.config.ts"],
+    languageOptions: {
+      globals: globals.node,
+      parserOptions: {
+        projectService: false,
+        project: "../../tsconfig.eslint.json",
+        tsconfigRootDir,
+      },
+    },
   },
 ]);

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -50,7 +50,7 @@
     "dev": "storybook dev -p 19231 --no-open",
     "fmt": "prettier --write ./src",
     "fmt.check": "prettier --check ./src",
-    "lint": "eslint \"src/**/*.ts*\"",
+    "lint": "eslint \"src/**/*.ts*\" eslint.config.ts",
     "lint.css": "stylelint \"{src,.storybook}/**/*.css\"",
     "test": "pnpm run test.unit && pnpm run test.browser",
     "test.unit": "vitest --run",

--- a/packages/vue/tsconfig.app.json
+++ b/packages/vue/tsconfig.app.json
@@ -2,16 +2,9 @@
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "target": "es2023",
-    "lib": [
-      "ES2023",
-      "DOM",
-      "DOM.Iterable"
-    ],
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
     "module": "esnext",
-    "types": [
-      "vite/client",
-      "vitest/globals"
-    ],
+    "types": ["vite/client", "vitest/globals"],
     "skipLibCheck": true,
     /* Bundler mode */
     "moduleResolution": "bundler",
@@ -30,7 +23,5 @@
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }

--- a/packages/vue/tsconfig.lib.json
+++ b/packages/vue/tsconfig.lib.json
@@ -7,9 +7,7 @@
     "outDir": "lib-types",
     "rootDir": "src"
   },
-  "include": [
-    "src"
-  ],
+  "include": ["src"],
   "exclude": [
     "src/**/*.spec.ts",
     "src/**/*.spec.tsx",

--- a/packages/vue/tsconfig.node.json
+++ b/packages/vue/tsconfig.node.json
@@ -2,13 +2,9 @@
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
     "target": "es2023",
-    "lib": [
-      "ES2023"
-    ],
+    "lib": ["ES2023"],
     "module": "esnext",
-    "types": [
-      "node"
-    ],
+    "types": ["node"],
     "skipLibCheck": true,
     /* Bundler mode */
     "moduleResolution": "bundler",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       lefthook:
         specifier: ^2.1.10
         version: 2.1.10
+      prettier:
+        specifier: 3.9.6
+        version: 3.9.6
       stylelint:
         specifier: ^17.14.1
         version: 17.14.1(typescript@6.0.3)

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "types": ["node"],
+    "skipLibCheck": true,
+    "rootDir": "."
+  },
+  "files": [
+    "eslint.strict.ts",
+    "packages/ag-ui-stub/eslint.config.ts",
+    "packages/copilotkit/eslint.config.ts",
+    "packages/core/eslint.config.ts",
+    "packages/drawio/eslint.config.ts",
+    "packages/ikuma-theme/eslint.config.ts",
+    "packages/react/eslint.config.ts",
+    "packages/solid/eslint.config.ts",
+    "packages/vue/eslint.config.ts"
+  ]
+}


### PR DESCRIPTION
## Summary

- add a no-emit root TypeScript project for the shared ESLint rules and all package ESLint configs
- keep project-service linting for package sources while type-checking each ESLint config against the dedicated project
- include package configs in lint scripts and enforce config formatting, linting, and type-checking in Lefthook and Core CI
- format existing TSConfig and ESLint configuration files with Prettier

## Testing

- `pnpm run check.configs`
- `pnpm --filter @elmethis/core run build`
- `pnpm run --recursive check`
- `pnpm exec tsc --project tsconfig.node.json --noEmit --pretty false` in React, Solid, and Vue
- pre-commit hooks (`configs`, `check`) passed during commit