### PR TITLE
feat(core): generate theme DESIGN.md files

### DIFF
--- a/.claude/rules/core.md
+++ b/.claude/rules/core.md
@@ -8,8 +8,10 @@ paths:
 - Framework-agnostic only — no Qwik/React/Vue imports. Everything here is consumed by all three libs.
 - **Design tokens**: authored in `src/style/token.ts`; `scripts/build-tokens.ts` emits
   `dist/tokens.css`. Edit the source, never `dist/`.
+- **DESIGN.md guides**: `scripts/build-design-md.ts` resolves semantic tokens into
+  `dist/design/{light,dark}/DESIGN.md` and validates them with `@google/design.md`.
 - **A2UI catalogs**: `src/a2ui/` + `scripts/emit-catalog.ts` produce
   `dist/a2ui/v0_9/notion_block_catalog.json` (published to Pages).
 - **Language icons**: registered in `src/icon/languages/registry.ts`.
-- Build = `tsdown && tsx scripts/emit-catalog.ts && tsx scripts/build-tokens.ts`. Rebuild after
-  changes so downstream libs pick them up.
+- Build = `tsdown`, then the catalog, tokens.css, and DESIGN.md emitters. Rebuild after changes so
+  downstream libs pick them up.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ built output and emitted `tokens.css`.
 | Command                                          | Description                                                             |
 | ------------------------------------------------ | ----------------------------------------------------------------------- |
 | `pnpm install`                                   | Install all workspace deps                                              |
-| `pnpm --filter @elmethis/core run build`         | Build core (tsdown + tokens.css + catalog JSON) — do this first         |
+| `pnpm --filter @elmethis/core run build`         | Build core (tsdown + tokens.css + DESIGN.md + catalog JSON) first       |
 | `pnpm --filter @elmethis/draw.io run build`      | Generate the diagrams.net configuration from core tokens                |
 | `pnpm --filter @elmethis/ag-ui-stub run build`   | Build the in-process AG-UI test agent used by Solid tests and Storybook |
 | `pnpm --filter ikuma-theme run build`            | Build VS Code, Shiki, Windows Terminal, and VSIX artifacts              |
@@ -57,8 +57,9 @@ runs eslint / stylelint / vitest-related per package.
 ## Architecture
 
 - **core is the single source of truth.** Design tokens (`src/style/token.ts` → emitted
-  `tokens.css`), A2UI Notion block catalogs, JSON schemas, and language-icon registries live here and
-  are consumed by all three framework libs — defined once, mirrored everywhere.
+  `tokens.css` and light/dark `DESIGN.md` files), A2UI Notion block catalogs, JSON schemas, and
+  language-icon registries live here and are consumed by all three framework libs — defined once,
+  mirrored everywhere.
 - **draw.io is a generated artifact package.** `@elmethis/draw.io` consumes the public
   `@elmethis/core/tokens` entry point and emits `dist/draw.io-config.json`; build core first.
 - **Component leadership is per-feature, not fixed to one framework.** The mature implementations
@@ -78,8 +79,8 @@ runs eslint / stylelint / vitest-related per package.
 
 ## Gotchas
 
-- Build `@elmethis/core` before working on draw.io/react/solid/vue, or their imports and `tokens.css` resolve
-  to stale/missing output.
+- Build `@elmethis/core` before working on draw.io/react/solid/vue, or their imports and `tokens.css`
+  resolve to stale/missing output. The same build refreshes the generated design artifacts.
 - Build `@elmethis/ag-ui-stub` before Solid AG-UI tests or Storybook; its workspace package exports built
   output from `dist`.
 - Theme outputs are generated under `packages/ikuma-theme/dist` and ignored by Git. Build the theme

--- a/README.md
+++ b/README.md
@@ -2,19 +2,19 @@
 
 Elmethis is a multi-framework component library and design system. The
 framework-neutral `@elmethis/core` package supplies shared schemas, design
-tokens, A2UI catalogs, and language metadata to React, Solid, and Vue
+tokens, generated DESIGN.md guides, A2UI catalogs, and language metadata to React, Solid, and Vue
 implementations.
 
-| Package             | Purpose                                          |
-| ------------------- | ------------------------------------------------ |
-| `@elmethis/core`    | Shared tokens, schemas, catalogs, and registries |
-| `@elmethis/draw.io` | diagrams.net configuration generated from tokens |
-| `@elmethis/react`   | React 19 components and hooks                    |
-| `@elmethis/solid`   | SolidJS components and reactive primitives       |
-| `@elmethis/vue`     | Vue 3 components authored in TSX                 |
+| Package             | Purpose                                                        |
+| ------------------- | -------------------------------------------------------------- |
+| `@elmethis/core`    | Shared tokens, DESIGN.md guides, schemas, catalogs, registries |
+| `@elmethis/draw.io` | diagrams.net configuration generated from tokens               |
+| `@elmethis/react`   | React 19 components and hooks                                  |
+| `@elmethis/solid`   | SolidJS components and reactive primitives                     |
+| `@elmethis/vue`     | Vue 3 components authored in TSX                               |
 
-Build core before packages that consume it because they import its built output
-and emitted `tokens.css`:
+Build core before packages that consume it. The build emits its compiled modules,
+`tokens.css`, catalogs, and generated design guides:
 
 ```sh
 pnpm install

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -44,7 +44,9 @@
         "default": "./dist/stylelint.cjs"
       }
     },
-    "./tokens.css": "./dist/tokens.css"
+    "./tokens.css": "./dist/tokens.css",
+    "./design/light/DESIGN.md": "./dist/design/light/DESIGN.md",
+    "./design/dark/DESIGN.md": "./dist/design/dark/DESIGN.md"
   },
   "files": [
     "dist"
@@ -56,7 +58,8 @@
     "**/*.css"
   ],
   "scripts": {
-    "build": "tsdown && tsx scripts/emit-catalog.ts && tsx scripts/build-tokens.ts",
+    "build": "tsdown && tsx scripts/emit-catalog.ts && tsx scripts/build-tokens.ts && tsx scripts/build-design-md.ts",
+    "build.design": "tsx scripts/build-design-md.ts",
     "build.types": "exit 0",
     "dev": "tsdown --watch",
     "fmt": "prettier --write ./src",
@@ -81,15 +84,16 @@
   "devDependencies": {
     "@a2ui/web_core": "^0.10.5",
     "@eslint/js": "latest",
+    "@google/design.md": "0.4.0",
     "@types/node": "26.1.2",
     "@vanilla-extract/css": "^1.21.2",
     "@vanilla-extract/esbuild-plugin": "^2.3.22",
     "@vitest/coverage-v8": "^4.1.10",
+    "@vitest/eslint-plugin": "1.6.24",
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",
     "concurrently": "^10.0.4",
     "esbuild": "^0.28.1",
-    "@vitest/eslint-plugin": "1.6.24",
     "eslint": "^10.8.0",
     "globals": "^17.8.0",
     "jiti": "2.7.0",
@@ -99,6 +103,7 @@
     "typescript": "5.9.3",
     "typescript-eslint": "^8.65.0",
     "vitest": "^4.1.10",
+    "yaml": "2.8.3",
     "zod": "^3"
   }
 }

--- a/packages/core/scripts/build-design-md.ts
+++ b/packages/core/scripts/build-design-md.ts
@@ -1,0 +1,39 @@
+import { lint } from "@google/design.md/linter";
+import prettier from "prettier";
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { generateDesignMd, type DesignTheme } from "../src/style/design-md";
+
+const themes = ["light", "dark"] as const satisfies readonly DesignTheme[];
+const here = dirname(fileURLToPath(import.meta.url));
+
+for (const theme of themes) {
+  const outPath = resolve(here, "..", "dist", "design", theme, "DESIGN.md");
+  const config = await prettier.resolveConfig(outPath);
+  const output = await prettier.format(generateDesignMd(theme), {
+    ...config,
+    parser: "markdown",
+  });
+  const report = lint(output);
+  const blockingFindings = report.findings.filter(
+    ({ severity }) => severity === "error" || severity === "warning",
+  );
+
+  if (blockingFindings.length > 0) {
+    const details = blockingFindings
+      .map(
+        ({ severity, path, message }) =>
+          `${severity}: ${path ? `${path}: ` : ""}${message}`,
+      )
+      .join("\n");
+    throw new Error(
+      `Generated ${theme} DESIGN.md failed validation:\n${details}`,
+    );
+  }
+
+  await mkdir(dirname(outPath), { recursive: true });
+  await writeFile(outPath, output);
+  console.log(`Wrote ${outPath}`);
+}

--- a/packages/core/src/style/design-md.spec.ts
+++ b/packages/core/src/style/design-md.spec.ts
@@ -1,0 +1,140 @@
+import { lint } from "@google/design.md/linter";
+import { parse } from "yaml";
+import { describe, expect, test } from "vitest";
+
+import { generateDesignMd, type DesignTheme } from "./design-md";
+import { semanticTokens } from "./token";
+
+interface DesignFrontmatter {
+  version: string;
+  name: string;
+  omitted: Array<{ section: string; reason: string }>;
+  colors: Record<string, string>;
+  typography: Record<string, { fontFamily: string }>;
+  spacing: Record<string, string>;
+}
+
+const themes = ["light", "dark"] as const satisfies readonly DesignTheme[];
+
+const parseFrontmatter = (document: string): DesignFrontmatter => {
+  const match = document.match(/^---\n([\s\S]*?)\n---\n/);
+  if (!match?.[1]) {
+    throw new Error("DESIGN.md has no YAML frontmatter");
+  }
+  return parse(match[1]) as DesignFrontmatter;
+};
+
+describe("generateDesignMd", () => {
+  test.each(themes)("generates a warning-free %s document", (theme) => {
+    const report = lint(generateDesignMd(theme));
+
+    expect(
+      report.findings.filter(({ severity }) => severity === "error"),
+    ).toEqual([]);
+    expect(
+      report.findings.filter(({ severity }) => severity === "warning"),
+    ).toEqual([]);
+  });
+
+  test.each(themes)("exports every semantic color in %s", (theme) => {
+    const { colors } = parseFrontmatter(generateDesignMd(theme));
+    const semanticColorNames = Object.keys(semanticTokens)
+      .filter((name) => name.startsWith("color-"))
+      .map((name) => name.slice("color-".length))
+      .sort();
+
+    expect(Object.keys(colors).sort()).toEqual(semanticColorNames);
+    expect(Object.keys(colors)).toHaveLength(44);
+    expect(Object.keys(colors)).not.toContainEqual(
+      expect.stringMatching(/^primitive-/),
+    );
+  });
+
+  test("resolves light and dark semantic values independently", () => {
+    const light = parseFrontmatter(generateDesignMd("light")).colors;
+    const dark = parseFrontmatter(generateDesignMd("dark")).colors;
+
+    expect(light).toMatchObject({
+      "box-shadow": "#3e434b40",
+      "surface-base": "#efecea",
+      neutral: "#6c7483",
+      "neutral-strong": "#555b67",
+      primary: "#a68c70",
+      "primary-hover": "#a68c7026",
+      selection: "#a68c7040",
+      "accent-error-surface": "#e9dddd",
+      "display-cyan-surface": "#dde9e7",
+    });
+    expect(dark).toMatchObject({
+      "box-shadow": "#242629",
+      "surface-base": "#393e46",
+      neutral: "#b0b5be",
+      "neutral-strong": "#d7d9e1",
+      primary: "#c6b5a2",
+      "primary-hover": "#c6b5a226",
+      selection: "#c6b5a240",
+      "accent-error-surface": "#291313",
+      "display-cyan-surface": "#203b37",
+    });
+    expect(light["accent-error"]).toBe(dark["accent-error"]);
+    expect(light["display-cyan"]).toBe(dark["display-cyan"]);
+  });
+
+  test.each(themes)(
+    "maps the remaining supported core tokens in %s",
+    (theme) => {
+      const frontmatter = parseFrontmatter(generateDesignMd(theme));
+
+      expect(frontmatter).toMatchObject({
+        version: "alpha",
+        name: `Elmethis ${theme === "light" ? "Light" : "Dark"}`,
+        spacing: { "stack-gap": "2rem" },
+      });
+      expect(frontmatter.typography.sans.fontFamily).toMatch(/^"DM Sans",/);
+      expect(frontmatter.typography.monospace.fontFamily).toMatch(
+        /^"DM Mono",/,
+      );
+      expect(frontmatter.omitted.map(({ section }) => section)).toEqual([
+        "rounded",
+        "components",
+      ]);
+    },
+  );
+
+  test.each(themes)("uses the canonical prose section order in %s", (theme) => {
+    const headings = [...generateDesignMd(theme).matchAll(/^## (.+)$/gm)].map(
+      ([, heading]) => heading,
+    );
+
+    expect(headings).toEqual([
+      "Overview",
+      "Colors",
+      "Typography",
+      "Layout",
+      "Elevation & Depth",
+      "Shapes",
+      "Components",
+      "Do's and Don'ts",
+    ]);
+  });
+
+  test.each(themes)(
+    "materializes unsupported CSS expressions in %s",
+    (theme) => {
+      const document = generateDesignMd(theme);
+
+      expect(document).not.toMatch(/light-dark\(|oklch\(from|var\(/);
+      expect(document).not.toContain("primitive-color");
+    },
+  );
+
+  test.each(themes)(
+    "is deterministic and ends with one newline in %s",
+    (theme) => {
+      const document = generateDesignMd(theme);
+
+      expect(generateDesignMd(theme)).toBe(document);
+      expect(document).toMatch(/[^\n]\n$/);
+    },
+  );
+});

--- a/packages/core/src/style/design-md.ts
+++ b/packages/core/src/style/design-md.ts
@@ -1,0 +1,243 @@
+import { stringify } from "yaml";
+
+import {
+  primitive,
+  semanticTokens,
+  type PrimitiveToken,
+  type SemanticValue,
+} from "./token";
+
+export type DesignTheme = "light" | "dark";
+
+const SEMANTIC_PROPERTY_PREFIX = "--elmethis-";
+const CSS_VAR_PATTERN = /var\((--elmethis-[a-z0-9-]+)\)/g;
+const RELATIVE_ALPHA_PATTERN =
+  /^oklch\(from (#[0-9a-f]{3}|#[0-9a-f]{6}|black|white) l c h \/ (\d+(?:\.\d+)?)(%)?\)$/i;
+
+const primitiveValues = new Map<string, string>();
+
+const isPrimitiveToken = (value: unknown): value is PrimitiveToken =>
+  typeof value === "object" &&
+  value !== null &&
+  "property" in value &&
+  "value" in value &&
+  "ref" in value;
+
+const collectPrimitiveValues = (node: Record<string, unknown>): void => {
+  for (const value of Object.values(node)) {
+    if (isPrimitiveToken(value)) {
+      primitiveValues.set(value.property, value.value);
+    } else {
+      collectPrimitiveValues(value as Record<string, unknown>);
+    }
+  }
+};
+
+collectPrimitiveValues(primitive);
+
+const semanticTokenMap = new Map<string, SemanticValue>(
+  Object.entries(semanticTokens),
+);
+
+const withAlpha = (color: string, percentage: number): string => {
+  const namedColor =
+    color.toLowerCase() === "black"
+      ? "#000000"
+      : color.toLowerCase() === "white"
+        ? "#ffffff"
+        : color;
+  const compact = namedColor.slice(1).toLowerCase();
+  const rgb = compact.length === 3 ? compact.replace(/./g, "$&$&") : compact;
+
+  if (!namedColor.startsWith("#") || rgb.length !== 6) {
+    throw new Error(`Cannot apply alpha to unsupported color: ${color}`);
+  }
+  if (percentage < 0 || percentage > 100) {
+    throw new Error(`Alpha percentage is outside 0-100: ${percentage}`);
+  }
+
+  const alpha = Math.round((percentage / 100) * 255)
+    .toString(16)
+    .padStart(2, "0");
+  return `#${rgb}${alpha}`;
+};
+
+const resolveSemanticToken = (
+  suffix: string,
+  theme: DesignTheme,
+  resolving: ReadonlySet<string> = new Set(),
+): string => {
+  if (resolving.has(suffix)) {
+    throw new Error(`Circular semantic token reference: ${suffix}`);
+  }
+
+  const token = semanticTokenMap.get(suffix);
+  if (!token) {
+    throw new Error(`Unknown semantic token: ${suffix}`);
+  }
+
+  const nextResolving = new Set(resolving).add(suffix);
+  const raw = "common" in token ? token.common : token[theme];
+  const expanded = raw.replace(CSS_VAR_PATTERN, (_match, property: string) => {
+    const primitiveValue = primitiveValues.get(property);
+    if (primitiveValue !== undefined) {
+      return primitiveValue;
+    }
+
+    if (!property.startsWith(SEMANTIC_PROPERTY_PREFIX)) {
+      throw new Error(`Unsupported custom property reference: ${property}`);
+    }
+    return resolveSemanticToken(
+      property.slice(SEMANTIC_PROPERTY_PREFIX.length),
+      theme,
+      nextResolving,
+    );
+  });
+  const relativeAlpha = expanded.match(RELATIVE_ALPHA_PATTERN);
+
+  return relativeAlpha
+    ? withAlpha(
+        relativeAlpha[1],
+        Number(relativeAlpha[2]) * (relativeAlpha[3] === "%" ? 1 : 100),
+      )
+    : expanded;
+};
+
+const assertEverySemanticTokenIsHandled = (): void => {
+  const handled = new Set([
+    "stack-gap",
+    "box-shadow-small",
+    "box-shadow-medium",
+    "box-shadow-large",
+    "font-family-sans",
+    "font-family-monospace",
+    ...[...semanticTokenMap.keys()].filter((name) => name.startsWith("color-")),
+  ]);
+  const unhandled = [...semanticTokenMap.keys()].filter(
+    (name) => !handled.has(name),
+  );
+
+  if (unhandled.length > 0) {
+    throw new Error(
+      `DESIGN.md generator does not classify semantic tokens: ${unhandled.join(", ")}`,
+    );
+  }
+};
+
+const buildBody = (theme: DesignTheme): string => {
+  const label = theme === "light" ? "Light" : "Dark";
+  const shadowSmall = resolveSemanticToken("box-shadow-small", theme);
+  const shadowMedium = resolveSemanticToken("box-shadow-medium", theme);
+  const shadowLarge = resolveSemanticToken("box-shadow-large", theme);
+
+  return `# Elmethis ${label}
+
+## Overview
+
+Elmethis is a small, restrained design system for content-forward interfaces. This document resolves its semantic tokens for the ${theme} color scheme. Let an element's role determine its appearance; do not choose a hue before deciding what the element means.
+
+The frontmatter values are design context, not application CSS. Implementations must use the matching \`--elmethis-*\` custom properties from \`@elmethis/core/tokens.css\` so they continue to follow the published theme.
+
+## Colors
+
+Choose color in this order: semantic role, display preset, then a primitive only when no public role applies. Primitive colors are deliberately absent from this document because appearance-based names are not stable component contracts.
+
+- Use \`neutral\` for body text, \`neutral-weak\` for secondary text, and \`neutral-strong\` for headings and emphasis.
+- Use \`surface-base\` for the page, \`surface-raised\` for containers, \`surface-sunken\` for inset regions, and \`divider\` for borders and separators.
+- Pair each \`accent-{role}\` foreground with its \`accent-{role}-surface\`. Available roles are link, info, success, important, warning, and error.
+- Reserve \`display-{color}\` and its matching surface for charts, legends, swatches, or content where the color itself is meaningful. Never substitute a display color for a semantic status.
+- A frontmatter token such as \`surface-base\` maps to the CSS property \`--elmethis-color-surface-base\`.
+
+## Typography
+
+Use the sans family for interfaces and prose. Use monospace only for code, identifiers, and fixed-width data. Applications must reference \`--elmethis-font-family-sans\` and \`--elmethis-font-family-monospace\` rather than repeating the resolved stacks.
+
+Elmethis core defines font families but not a universal size, weight, or line-height scale. Preserve the hierarchy of the host component or product instead of inventing a core typography scale.
+
+## Layout
+
+Use explicit layout containers and \`gap\` for rhythm between sibling blocks. The \`stack-gap\` token is the standard separation for Elmethis content stacks; do not emulate it with leading margins on leaf components.
+
+Elmethis core does not prescribe a page grid or a complete spacing scale. Keep layouts responsive, preserve readable line lengths, and derive product-level spacing decisions consistently from the surrounding interface.
+
+## Elevation & Depth
+
+Prefer tonal surfaces and the \`divider\` token over shadows. When elevation is necessary, use the smallest shadow that communicates the relationship:
+
+- Small: \`${shadowSmall}\`
+- Medium: \`${shadowMedium}\`
+- Large: \`${shadowLarge}\`
+
+These resolved values correspond to \`--elmethis-box-shadow-small\`, \`--elmethis-box-shadow-medium\`, and \`--elmethis-box-shadow-large\`. Use those properties in CSS rather than copying the values.
+
+## Shapes
+
+Elmethis core intentionally defines no global corner-radius scale. Keep geometry restrained and component-specific. Do not impose pill shapes, excessive rounding, or a new universal radius without a product-level design requirement.
+
+## Components
+
+Build components from semantic roles: base and raised surfaces establish containment, dividers establish separation, neutral roles establish text hierarchy, and accent pairs establish interactive or status meaning.
+
+Keep focus visible with a primary-colored outline. Pair status color with an icon or text label, and test content in both color schemes. Component implementations should consume the public CSS properties rather than the resolved literals in this file.
+
+## Do's and Don'ts
+
+- Do use semantic colors whenever a role fits.
+- Do use matching accent foreground and surface pairs.
+- Do reserve display colors for visualization and intentionally color-named content.
+- Do prefer dividers and tonal surfaces over unnecessary elevation.
+- Do test focus visibility, text contrast, status cues, and both color schemes.
+- Don't copy resolved colors, font stacks, or shadows into application CSS.
+- Don't use primitives where a semantic or display token applies.
+- Don't communicate state through color alone.
+- Don't add component-level light and dark overrides for behavior already provided by Elmethis tokens.
+`;
+};
+
+export const generateDesignMd = (theme: DesignTheme): string => {
+  assertEverySemanticTokenIsHandled();
+
+  const label = theme === "light" ? "Light" : "Dark";
+  const colors = Object.fromEntries(
+    [...semanticTokenMap.keys()]
+      .filter((name) => name.startsWith("color-"))
+      .map((name) => [
+        name.slice("color-".length),
+        resolveSemanticToken(name, theme),
+      ]),
+  );
+  const frontmatter = stringify(
+    {
+      version: "alpha",
+      name: `Elmethis ${label}`,
+      description: `Elmethis semantic design system resolved for the ${theme} color scheme.`,
+      omitted: [
+        {
+          section: "rounded",
+          reason:
+            "@elmethis/core does not define a global corner-radius scale.",
+        },
+        {
+          section: "components",
+          reason:
+            "Framework components consume shared semantic tokens but core defines no component-token map.",
+        },
+      ],
+      colors,
+      typography: {
+        sans: {
+          fontFamily: resolveSemanticToken("font-family-sans", theme),
+        },
+        monospace: {
+          fontFamily: resolveSemanticToken("font-family-monospace", theme),
+        },
+      },
+      spacing: {
+        "stack-gap": resolveSemanticToken("stack-gap", theme),
+      },
+    },
+    { lineWidth: 0 },
+  );
+
+  return `---\n${frontmatter}---\n\n${buildBody(theme)}`;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,6 +164,9 @@ importers:
       '@eslint/js':
         specifier: latest
         version: 10.0.1(eslint@10.8.0(jiti@2.7.0))
+      '@google/design.md':
+        specifier: 0.4.0
+        version: 0.4.0
       '@types/node':
         specifier: 26.1.2
         version: 26.1.2
@@ -218,6 +221,9 @@ importers:
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(terser@5.39.0)(tsx@4.23.1)(yaml@2.8.3))
+      yaml:
+        specifier: 2.8.3
+        version: 2.8.3
       zod:
         specifier: ^3
         version: 3.25.76
@@ -1479,6 +1485,11 @@ packages:
 
   '@formkit/auto-animate@0.10.0':
     resolution: {integrity: sha512-KGomRttjUfORuPUaR/ZGQw+6xfMrTM+sxnILv7JAd9AmabU9rg9i6gF/iC0Ih+QpKCubJpCA/1DX9UHKE8cX+A==}
+
+  '@google/design.md@0.4.0':
+    resolution: {integrity: sha512-7aNIv6hslxIZ9igXq1abbVu+ue/ft/oFMUrAuhzpVFijGr9v+l0CkkCBQsHozucNiZHIBS43XC6l8gYDZRys9Q==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   '@graphql-tools/executor@1.5.7':
     resolution: {integrity: sha512-UcXVClkBml+qyGEsQxfEaAkboqySVGFUd9ivn7pDc9jZSckgF6zL21cNxuRH5ZA2exneV3PTtcc0I0rDOdE0Tg==}
@@ -2811,6 +2822,9 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
@@ -2819,6 +2833,9 @@ packages:
 
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
+
+  '@types/estree-jsx@1.0.5':
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
@@ -2837,6 +2854,9 @@ packages:
 
   '@types/mdx@2.0.14':
     resolution: {integrity: sha512-T48PeuJtvLosNTPVhfnIp3i/n3a4g4Bad7YCq5k64D4u7NwDrAotikQ+5+sjtUvBmxCMlbo3dVL+C2dP0rWHzg==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
   '@types/node@26.1.2':
     resolution: {integrity: sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==}
@@ -2863,6 +2883,9 @@ packages:
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -3545,6 +3568,9 @@ packages:
     resolution: {integrity: sha512-GAwkz0AihzY5bkwIY5QDR+LvsRQgB/B+1foMPvi0FZPMl5fjD7ICiznUiBdLYMH1QYe6vqu4gWYytZOccLouFw==}
     engines: {node: '>= 10.0.0'}
 
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -3678,8 +3704,14 @@ packages:
   character-entities-legacy@3.0.0:
     resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
 
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
   character-parser@2.2.0:
     resolution: {integrity: sha512-+UqJQjFEFaTAs3bNsF2j2kEN1baG/zghZbdqoYEDxGZtJo9LBzl1A+m0D4n3qKx8N2FNv8/Xp6yV9mQmBuptaw==}
+
+  character-reference-invalid@2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
   check-error@2.1.3:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
@@ -3698,6 +3730,9 @@ packages:
 
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
+
+  citty@0.1.6:
+    resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
 
   clarinet@0.12.6:
     resolution: {integrity: sha512-0FR+TrvLbYHLjhzs9oeIbd3yfZmd4u2DzYQEjUTm2dNfh4Y/9RIRWPjsm3aBtrVEpjKI7+lWa4ouqEXoml84mQ==}
@@ -3880,6 +3915,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
 
   decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
@@ -4104,6 +4142,10 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
+
   eslint-plugin-react-hooks@7.1.1:
     resolution: {integrity: sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==}
     engines: {node: '>=18'}
@@ -4167,6 +4209,12 @@ packages:
   estraverse@5.3.0:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
+
+  estree-util-is-identifier-name@3.0.0:
+    resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+
+  estree-util-visit@2.0.0:
+    resolution: {integrity: sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==}
 
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
@@ -4268,6 +4316,9 @@ packages:
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
+  fault@2.0.1:
+    resolution: {integrity: sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -4327,6 +4378,10 @@ packages:
   form-data@4.0.6:
     resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
+
+  format@0.2.2:
+    resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
+    engines: {node: '>=0.4.x'}
 
   formdata-polyfill@4.0.10:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
@@ -4644,12 +4699,21 @@ packages:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
 
+  is-alphabetical@2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+
+  is-alphanumerical@2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
+
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
   is-core-module@2.16.2:
     resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
     engines: {node: '>= 0.4'}
+
+  is-decimal@2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
 
   is-docker@3.0.0:
     resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
@@ -4671,6 +4735,9 @@ packages:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
+  is-hexadecimal@2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
+
   is-html@2.0.0:
     resolution: {integrity: sha512-S+OpgB5i7wzIue/YSE5hg0e5ZYfG3hhpNh9KGl6ayJ38p7ED6wxQLd1TV91xHpcTvw90KMJ9EwN3F/iNflHBVg==}
     engines: {node: '>=8'}
@@ -4690,6 +4757,10 @@ packages:
 
   is-path-inside@4.0.0:
     resolution: {integrity: sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==}
+    engines: {node: '>=12'}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
   is-plain-object@5.0.0:
@@ -5068,6 +5139,9 @@ packages:
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
@@ -5122,8 +5196,35 @@ packages:
   mathml-tag-names@4.0.0:
     resolution: {integrity: sha512-aa6AU2Pcx0VP/XWnh8IGL0SYSgQHDT6Ucror2j2mXeFAlN3ahaNs8EZtG1YiticMkSLj3Gt6VPFfZogt7G5iFQ==}
 
+  mdast-util-from-markdown@2.0.3:
+    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-frontmatter@2.0.1:
+    resolution: {integrity: sha512-LRqI9+wdgC25P0URIJY9vwocIzCcksduHQ9OF2joxQoyTNVduwLAFUzjoopuRJbJAReaKrNQKAZKL3uCMugWJA==}
+
+  mdast-util-mdx-expression@2.0.1:
+    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
+
+  mdast-util-mdx-jsx@3.2.0:
+    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
+
+  mdast-util-mdx@3.0.0:
+    resolution: {integrity: sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w==}
+
+  mdast-util-mdxjs-esm@2.0.1:
+    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
   mdast-util-to-hast@13.2.1:
     resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
 
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
@@ -5165,20 +5266,92 @@ packages:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
     engines: {node: '>= 0.6'}
 
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-frontmatter@2.0.0:
+    resolution: {integrity: sha512-C4AkuM3dA58cgZha7zVnuVxBhDsbttIMiytjgsM2XbHAB2faRVaHRle40558FBN+DJcrLNCoqG5mlrpdU4cRtg==}
+
+  micromark-extension-mdx-expression@3.0.1:
+    resolution: {integrity: sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q==}
+
+  micromark-extension-mdx-jsx@3.0.2:
+    resolution: {integrity: sha512-e5+q1DjMh62LZAJOnDraSSbDMvGJ8x3cbjygy2qFEi7HCeUT4BDKCvMozPozcD6WmOt6sVvYDNBKhFSz3kjOVQ==}
+
+  micromark-extension-mdx-md@2.0.0:
+    resolution: {integrity: sha512-EpAiszsB3blw4Rpba7xTOUptcFeBFi+6PY8VnJ2hhimH+vCQDirWgsMpz7w1XcZE7LVrSAUGb9VJpG9ghlYvYQ==}
+
+  micromark-extension-mdxjs-esm@3.0.0:
+    resolution: {integrity: sha512-DJFl4ZqkErRpq/dAPyeWp15tGrcrrJho1hKK5uBS70BCtfrIFg81sqcTVu3Ta+KD1Tk5vAtBNElWxtAa+m8K9A==}
+
+  micromark-extension-mdxjs@3.0.0:
+    resolution: {integrity: sha512-A873fJfhnJ2siZyUrJ31l34Uqwy4xIFmvPY1oj+Ean5PHcPBYzEsvqvWGaWcfEIr11O5Dlw3p2y0tZWpKHDejQ==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-mdx-expression@2.0.3:
+    resolution: {integrity: sha512-kQnEtA3vzucU2BkrIa8/VaSAsP+EJ3CKOvhMuJgOEGg9KDC6OAY6nSnNDVRiVNRqj7Y4SlSzcStaH/5jge8JdQ==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
   micromark-util-character@2.1.1:
     resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
 
   micromark-util-encode@2.0.1:
     resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
 
+  micromark-util-events-to-acorn@2.0.3:
+    resolution: {integrity: sha512-jmsiEIiZ1n7X1Rr5k8wVExBQCg5jy4UXVADItHmNk1zkwEVhBuIUKRu3fqv+hs4nxLISi2DQGlqIOGiFxgbfHg==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
   micromark-util-sanitize-uri@2.0.1:
     resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
 
   micromark-util-symbol@2.0.1:
     resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
 
   micromark-util-types@2.0.2:
     resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -5428,6 +5601,9 @@ packages:
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
+
+  parse-entities@4.0.2:
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
 
   parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
@@ -5779,6 +5955,18 @@ packages:
 
   regex@6.1.0:
     resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
+
+  remark-frontmatter@5.0.0:
+    resolution: {integrity: sha512-XTFYvNASMe5iPN0719nPrdItC9aU0ssC4v14mH1BCi1u0n1gAocqcujWUrByftZTbLhRtiKRyjYTSIOcr69UVQ==}
+
+  remark-mdx@3.1.1:
+    resolution: {integrity: sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg==}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
@@ -6281,6 +6469,9 @@ packages:
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
 
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
   ts-algebra@2.0.0:
     resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
 
@@ -6432,8 +6623,14 @@ packages:
     resolution: {integrity: sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==}
     engines: {node: '>=20'}
 
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
   unist-util-is@6.0.1:
     resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position-from-estree@2.0.0:
+    resolution: {integrity: sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ==}
 
   unist-util-position@5.0.0:
     resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
@@ -7773,6 +7970,20 @@ snapshots:
 
   '@formkit/auto-animate@0.10.0': {}
 
+  '@google/design.md@0.4.0':
+    dependencies:
+      citty: 0.1.6
+      remark-frontmatter: 5.0.0
+      remark-mdx: 3.1.1
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+      yaml: 2.8.3
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - supports-color
+
   '@graphql-tools/executor@1.5.7(graphql@16.14.2)':
     dependencies:
       '@graphql-tools/utils': 11.2.2(graphql@16.14.2)
@@ -9014,11 +9225,19 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/debug@4.1.13':
+    dependencies:
+      '@types/ms': 2.1.0
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/doctrine@0.0.9': {}
 
   '@types/esrecurse@4.3.1': {}
+
+  '@types/estree-jsx@1.0.5':
+    dependencies:
+      '@types/estree': 1.0.9
 
   '@types/estree@1.0.9': {}
 
@@ -9035,6 +9254,8 @@ snapshots:
       '@types/unist': 3.0.3
 
   '@types/mdx@2.0.14': {}
+
+  '@types/ms@2.1.0': {}
 
   '@types/node@26.1.2':
     dependencies:
@@ -9058,6 +9279,8 @@ snapshots:
 
   '@types/trusted-types@2.0.7':
     optional: true
+
+  '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
 
@@ -9980,6 +10203,8 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
+  bail@2.0.2: {}
+
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
@@ -10135,9 +10360,13 @@ snapshots:
 
   character-entities-legacy@3.0.0: {}
 
+  character-entities@2.0.2: {}
+
   character-parser@2.2.0:
     dependencies:
       is-regex: 1.2.1
+
+  character-reference-invalid@2.0.1: {}
 
   check-error@2.1.3: {}
 
@@ -10171,6 +10400,10 @@ snapshots:
 
   chownr@1.1.4:
     optional: true
+
+  citty@0.1.6:
+    dependencies:
+      consola: 3.4.2
 
   clarinet@0.12.6: {}
 
@@ -10329,6 +10562,10 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
 
   decompress-response@6.0.0:
     dependencies:
@@ -10527,6 +10764,8 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
+  escape-string-regexp@5.0.0: {}
+
   eslint-plugin-react-hooks@7.1.1(eslint@10.8.0(jiti@2.7.0)):
     dependencies:
       '@babel/core': 7.29.7
@@ -10622,6 +10861,13 @@ snapshots:
       estraverse: 5.3.0
 
   estraverse@5.3.0: {}
+
+  estree-util-is-identifier-name@3.0.0: {}
+
+  estree-util-visit@2.0.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/unist': 3.0.3
 
   estree-walker@2.0.2: {}
 
@@ -10766,6 +11012,10 @@ snapshots:
     dependencies:
       reusify: 1.1.0
 
+  fault@2.0.1:
+    dependencies:
+      format: 0.2.2
+
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
       picomatch: 4.0.5
@@ -10844,6 +11094,8 @@ snapshots:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.4
       mime-types: 2.1.35
+
+  format@0.2.2: {}
 
   formdata-polyfill@4.0.10:
     dependencies:
@@ -11183,11 +11435,20 @@ snapshots:
 
   ipaddr.js@1.9.1: {}
 
+  is-alphabetical@2.0.1: {}
+
+  is-alphanumerical@2.0.1:
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
+
   is-arrayish@0.2.1: {}
 
   is-core-module@2.16.2:
     dependencies:
       hasown: 2.0.3
+
+  is-decimal@2.0.1: {}
 
   is-docker@3.0.0: {}
 
@@ -11204,6 +11465,8 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
+  is-hexadecimal@2.0.1: {}
+
   is-html@2.0.0:
     dependencies:
       html-tags: 3.3.1
@@ -11217,6 +11480,8 @@ snapshots:
   is-number@7.0.0: {}
 
   is-path-inside@4.0.0: {}
+
+  is-plain-obj@4.1.0: {}
 
   is-plain-object@5.0.0:
     optional: true
@@ -11554,6 +11819,8 @@ snapshots:
   long@5.3.2:
     optional: true
 
+  longest-streak@3.1.0: {}
+
   loupe@3.2.1: {}
 
   lru-cache@10.4.3: {}
@@ -11608,6 +11875,88 @@ snapshots:
 
   mathml-tag-names@4.0.0: {}
 
+  mdast-util-from-markdown@2.0.3:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-frontmatter@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      escape-string-regexp: 5.0.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-extension-frontmatter: 2.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-expression@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-jsx@3.2.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-stringify-position: 4.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx@3.0.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdxjs-esm@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.1
+
   mdast-util-to-hast@13.2.1:
     dependencies:
       '@types/hast': 3.0.5
@@ -11619,6 +11968,22 @@ snapshots:
       unist-util-position: 5.0.0
       unist-util-visit: 5.1.0
       vfile: 6.0.3
+
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.1.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
 
   mdn-data@2.27.1: {}
 
@@ -11646,12 +12011,179 @@ snapshots:
 
   methods@1.1.2: {}
 
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-frontmatter@2.0.0:
+    dependencies:
+      fault: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-mdx-expression@3.0.1:
+    dependencies:
+      '@types/estree': 1.0.9
+      devlop: 1.1.0
+      micromark-factory-mdx-expression: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-mdx-jsx@3.0.2:
+    dependencies:
+      '@types/estree': 1.0.9
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      micromark-factory-mdx-expression: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      vfile-message: 4.0.3
+
+  micromark-extension-mdx-md@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-mdxjs-esm@3.0.0:
+    dependencies:
+      '@types/estree': 1.0.9
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-position-from-estree: 2.0.0
+      vfile-message: 4.0.3
+
+  micromark-extension-mdxjs@3.0.0:
+    dependencies:
+      acorn: 8.18.0
+      acorn-jsx: 5.3.2(acorn@8.18.0)
+      micromark-extension-mdx-expression: 3.0.1
+      micromark-extension-mdx-jsx: 3.0.2
+      micromark-extension-mdx-md: 2.0.0
+      micromark-extension-mdxjs-esm: 3.0.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-mdx-expression@2.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-position-from-estree: 2.0.0
+      vfile-message: 4.0.3
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
   micromark-util-character@2.1.1:
     dependencies:
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
 
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
   micromark-util-encode@2.0.1: {}
+
+  micromark-util-events-to-acorn@2.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+      '@types/unist': 3.0.3
+      devlop: 1.1.0
+      estree-util-visit: 2.0.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      vfile-message: 4.0.3
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
 
   micromark-util-sanitize-uri@2.0.1:
     dependencies:
@@ -11659,9 +12191,38 @@ snapshots:
       micromark-util-encode: 2.0.1
       micromark-util-symbol: 2.0.1
 
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
   micromark-util-symbol@2.0.1: {}
 
   micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.13
+      debug: 4.4.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   micromatch@4.0.8:
     dependencies:
@@ -11914,6 +12475,16 @@ snapshots:
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
+
+  parse-entities@4.0.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.3.0
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
 
   parse-json@5.2.0:
     dependencies:
@@ -12345,6 +12916,37 @@ snapshots:
   regex@6.1.0:
     dependencies:
       regex-utilities: 2.3.0
+
+  remark-frontmatter@5.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-frontmatter: 2.0.1
+      micromark-extension-frontmatter: 2.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-mdx@3.1.1:
+    dependencies:
+      mdast-util-mdx: 3.0.0
+      micromark-extension-mdxjs: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
 
   require-from-string@2.0.2: {}
 
@@ -13049,6 +13651,8 @@ snapshots:
 
   trim-lines@3.0.1: {}
 
+  trough@2.2.0: {}
+
   ts-algebra@2.0.0: {}
 
   ts-api-utils@2.5.0(typescript@5.9.3):
@@ -13197,7 +13801,21 @@ snapshots:
 
   unicorn-magic@0.4.0: {}
 
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
   unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position-from-estree@2.0.0:
     dependencies:
       '@types/unist': 3.0.3
 
@@ -13530,8 +14148,7 @@ snapshots:
 
   yallist@4.0.0: {}
 
-  yaml@2.8.3:
-    optional: true
+  yaml@2.8.3: {}
 
   yargs-parser@22.0.0: {}
 

--- a/skills/elmethis/SKILL.md
+++ b/skills/elmethis/SKILL.md
@@ -1,21 +1,30 @@
 ---
 name: elmethis
-description: Build and style Elmethis interfaces using its current published design tokens. Use for design AI agents creating or reviewing Elmethis CSS, components, pages, themes, prototypes, or visual states.
+description: Build and style Elmethis interfaces using its current published design system. Use for design AI agents creating or reviewing Elmethis CSS, components, pages, themes, prototypes, or visual states.
 ---
 
 # Elmethis Design System
 
-Use Elmethis as a small, restrained design system. Let semantic roles determine color; do not choose a hue before deciding what an element means.
+## Design Context
 
-## Available Tokens
+Read the generated DESIGN.md for the color scheme being designed:
 
-Check all currently available Elmethis tokens from:
+```text
+https://cdn.jsdelivr.net/npm/@elmethis/core@latest/dist/design/light/DESIGN.md
+https://cdn.jsdelivr.net/npm/@elmethis/core@latest/dist/design/dark/DESIGN.md
+```
+
+Read both documents when the interface adapts to `color-scheme`. They define Elmethis visual intent and expose the same semantic roles with scheme-specific resolved values.
+
+## Implementation Tokens
+
+Check all currently available CSS custom properties from:
 
 ```text
 https://cdn.jsdelivr.net/npm/@elmethis/core@latest/dist/tokens.css
 ```
 
-Treat that stylesheet as the source of truth for available `--elmethis-*` custom properties. Do not rely on a cached token list or copy the resolved values into generated CSS.
+Treat `tokens.css` as the implementation source of truth. DESIGN.md values are design context only; do not copy resolved colors, font stacks, or shadows into application CSS. Use the matching `--elmethis-*` custom properties instead.
 
 ## Stylelint
 
@@ -39,162 +48,8 @@ Run Stylelint against the application's CSS:
 stylelint "src/**/*.css"
 ```
 
-The Elmethis config enforces these design-system boundaries:
+The Elmethis config enforces these implementation boundaries:
 
-- Do not use hex colors, named colors, or direct color functions. Use a token.
-- Use only `--elmethis-box-shadow-small`, `--elmethis-box-shadow-medium`, `--elmethis-box-shadow-large`, or `none` for `box-shadow`.
+- Use tokens instead of literal colors.
+- Use only the supported Elmethis box-shadow tokens or `none`.
 - Name classes in kebab-case, optionally with BEM `__element` and `--modifier` suffixes.
-
-## Typography
-
-Use sans-serif for interfaces and prose. Use monospace only for code, identifiers, and fixed-width data.
-
-```css
-body {
-  font-family: var(--elmethis-font-family-sans);
-}
-
-code,
-kbd,
-pre,
-samp {
-  font-family: var(--elmethis-font-family-monospace);
-}
-```
-
-The semantic font variables reference these primitive stacks:
-
-- `--elmethis-primitive-font-family-sans`: `"DM Sans", "Zen Kaku Gothic New", -apple-system, BlinkMacSystemFont, "Hiragino Kaku Gothic ProN", Meiryo, sans-serif`
-- `--elmethis-primitive-font-family-monospace`: `"DM Mono", "Source Code Pro", Menlo, Consolas, "DejaVu Sans Mono", "Zen Kaku Gothic New", monospace`
-
-Do not repeat either stack in application CSS. Use the semantic font variables unless working inside the token implementation itself.
-
-## Color Priority
-
-Choose colors in this order:
-
-1. Use a semantic role token whenever one fits.
-2. Use a display preset for data visualization or intentionally color-named content.
-3. Use a primitive token only as a last resort when no semantic role or display preset applies.
-
-If the same primitive use appears more than once, add an appropriate semantic token to `packages/core/src/style/token.ts` instead of spreading primitive references through components.
-
-### Neutral Text
-
-| Role                                               | Token                             |
-| -------------------------------------------------- | --------------------------------- |
-| Normal body text                                   | `--elmethis-color-neutral`        |
-| Description, metadata, placeholder, secondary text | `--elmethis-color-neutral-weak`   |
-| Heading, label, emphasized text                    | `--elmethis-color-neutral-strong` |
-
-Do not use weak text merely to reduce visual prominence when doing so makes important content difficult to read.
-
-### Surfaces
-
-| Role                                          | Token                             |
-| --------------------------------------------- | --------------------------------- |
-| Page or body background                       | `--elmethis-color-surface-base`   |
-| Card, panel, menu, dialog, or other container | `--elmethis-color-surface-raised` |
-| Header, inset region, or recessed background  | `--elmethis-color-surface-sunken` |
-| Divider, border, or separator                 | `--elmethis-color-divider`        |
-
-Prefer a divider over a shadow. When elevation is necessary, use the smallest box-shadow token that communicates it.
-
-### Accents
-
-Accent tokens are role pairs:
-
-- Use `--elmethis-color-accent-link` for link text and `--elmethis-color-accent-link-surface` for a link-related background.
-- Use `--elmethis-color-accent-{role}` for foregrounds and `--elmethis-color-accent-{role}-surface` for backgrounds.
-- Available roles are `link`, `info`, `success`, `important`, `warning`, and `error`.
-- Links may use `--elmethis-color-accent-link-visited` and `--elmethis-color-accent-link-surface-visited` for visited states.
-
-Use the matching foreground and surface roles together for callouts, badges, and status regions. Pair status color with an icon or text label; never communicate state through color alone.
-
-### Display Presets
-
-Use `--elmethis-color-display-{color}` only when the color itself is meaningful, such as a chart series, legend, swatch, or user-selected label. Available colors are `red`, `orange`, `yellow`, `green`, `cyan`, `blue`, `purple`, and `magenta`. Each also has a matching `--elmethis-color-display-{color}-surface` token.
-
-Example:
-
-```css
-.chart-series--cyan {
-  color: var(--elmethis-color-display-cyan);
-  background: var(--elmethis-color-display-cyan-surface);
-}
-```
-
-Do not use display tokens as substitutes for semantic statuses. For example, an error uses `--elmethis-color-accent-error`, not `--elmethis-color-display-red`.
-
-### Primitive Colors
-
-Primitive colors follow `--elmethis-primitive-color-{color}-{variant}`, for example `--elmethis-primitive-color-cyan-500`. Primitive names encode appearance rather than meaning, so they are not stable component contracts. Keep any unavoidable primitive use local and explain why no semantic or display token fits.
-
-## Foundation
-
-Start pages and common elements from this baseline:
-
-```css
-:root {
-  color-scheme: light dark;
-  font-family: var(--elmethis-font-family-sans);
-  color: var(--elmethis-color-neutral);
-  background: var(--elmethis-color-surface-base);
-}
-
-body {
-  margin: 0;
-  color: var(--elmethis-color-neutral);
-  background: var(--elmethis-color-surface-base);
-}
-
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-strong {
-  color: var(--elmethis-color-neutral-strong);
-}
-
-a {
-  color: var(--elmethis-color-accent-link);
-}
-
-a:visited {
-  color: var(--elmethis-color-accent-link-visited);
-}
-
-:focus-visible {
-  outline: 2px solid var(--elmethis-color-primary);
-  outline-offset: 2px;
-}
-
-.app-header {
-  background: var(--elmethis-color-surface-sunken);
-  border-block-end: 1px solid var(--elmethis-color-divider);
-}
-
-.card {
-  background: var(--elmethis-color-surface-raised);
-  border: 1px solid var(--elmethis-color-divider);
-  box-shadow: var(--elmethis-box-shadow-small);
-}
-
-.card__description {
-  color: var(--elmethis-color-neutral-weak);
-}
-```
-
-Semantic tokens already adapt to light and dark color schemes. Test both schemes; do not replace them with component-level light/dark color overrides.
-
-## Review Checklist
-
-- Every referenced token exists in the current published stylesheet.
-- Body, containers, headers, borders, and text use their designated semantic roles.
-- Accent foregrounds and surfaces use matching semantic pairs.
-- Display colors are reserved for color-named content and visualization.
-- No primitive color is used where a semantic or display token applies.
-- No literal color or unsupported box shadow bypasses Stylelint.
-- Focus is visible, status is not conveyed by color alone, and both color schemes remain usable.


### PR DESCRIPTION
## Summary
- generate semantic-only light and dark `DESIGN.md` artifacts from the core token source
- materialize theme-dependent and relative-alpha colors, then validate generated documents against pinned `@google/design.md@0.4.0`
- publish both artifacts through core package exports and include generation in the core build
- reduce the Elmethis skill to discovery, CSS token, and Stylelint integration guidance

## Testing
- `pnpm --filter @elmethis/core run check.ci`
- package tarball inspection confirms both `dist/design/*/DESIGN.md` artifacts
- package self-resolution confirms both DESIGN.md export paths